### PR TITLE
fix expressionDependencies on expression

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -89,7 +89,7 @@ expressionDependencies <- function(e) {
   
   # recursive case: expression (= list of calls)
   if (is.expression(e)) {
-    unlist(lapply(e, expressionDependencies))
+    return(unlist(lapply(e, expressionDependencies)))
   }
   
   # base case: a call


### PR DESCRIPTION
- The value from recursive calls should be returned
- `fileDependencies` always call `expressionDependencies` with language or symbols instead of            expression, so this chunk is never used and can be safely removed for now.
