### PR TITLE
Properly record packages installed from subdirectories of a GitHub repo

### DIFF
--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -237,6 +237,7 @@ aliases <- c(
   GithubUsername = "gh_username",
   GithubRef = "gh_ref",
   GithubSha1 = "gh_sha1",
+  GithubSubdir = "gh_subdir",
   SourcePath = "source_path"
 )
 r_aliases <- structure(names(aliases), names = aliases)

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -14,6 +14,8 @@
 #   gh_username = 'hadley',
 #   gh_ref = 'master',
 #   gh_sha1 = '66b81e9307793029f6083fc6108592786a564b09'
+# # Optional:
+#   , gh_subdir = 'pkg'
 # )
 
 # Returns a package records for the given packages
@@ -101,14 +103,15 @@ inferPackageRecord <- function(df) {
     ), class=c('packageRecord', 'CRAN')))
   } else if (!is.null(df$GithubRepo)) {
     # It's GitHub!
-    return(structure(list(
+    return(structure(c(list(
       name = name,
       source = 'github',
       version = ver,
       gh_repo = as.character(df$GithubRepo),
       gh_username = as.character(df$GithubUsername),
       gh_ref = as.character(df$GithubRef),
-      gh_sha1 = as.character(df$GithubSHA1)
+      gh_sha1 = as.character(df$GithubSHA1)),
+      c(gh_subdir = as.character(df$GithubSubdir))
     ), class=c('packageRecord', 'github')))
   } else if (identical(as.character(df$Priority), 'base')) {
     # It's a base package!

--- a/R/restore.R
+++ b/R/restore.R
@@ -152,15 +152,19 @@ getSourceForPkgRecord <- function(pkgRecord, sourceDir, availablePkgs, repos,
       else
         scratchDir
 
+      if (!is.null(pkgRecord$gh_subdir))
+        basedir <- file.path(basedir, pkgRecord$gh_subdir)
+
       if (!file.exists(file.path(basedir, 'DESCRIPTION'))) {
         stop('No DESCRIPTION file was found in the archive for ', pkgRecord$name)
       }
 
-      ghinfo <- data.frame(
+      ghinfo <- as.data.frame(c(list(
         GithubRepo = pkgRecord$gh_repo,
         GithubUsername = pkgRecord$gh_username,
         GithubRef = pkgRecord$gh_ref,
-        GithubSHA1 = pkgRecord$gh_sha1
+        GithubSHA1 = pkgRecord$gh_sha1)),
+        c(GithubSubdir = pkgRecord$gh_subdir)
       )
       appendToDcf(file.path(basedir, 'DESCRIPTION'), ghinfo)
 


### PR DESCRIPTION
Example: `install_github("krlmlr/memisc/pkg/mtable")`

Applies to current `master`.
