### PR TITLE
bugfix: need to pass records to searchPackages, not names

### DIFF
--- a/R/packrat_status.R
+++ b/R/packrat_status.R
@@ -65,7 +65,7 @@ status <- function(projDir = '.', lib.loc = libdir(projDir), quiet = FALSE) {
   installedPkgVersions <- getPackageElement(installedPkgRecords, "version")
 
   # Packages inferred from the code
-  inferredPkgNames <- appDependencies(projDir)
+  inferredPkgNames <- pkgNames(flattenPackageRecords(getPackageRecords(appDependencies(projDir))))
 
   # All packages mentioned in one of the three above
   allPkgNames <- sort(unique(c(


### PR DESCRIPTION
`status()` errs without this. No test for that, sorry.

Applies cleanly to both `master` and `feature/packrat-mode`.
