### PR TITLE
use host provided build tools when available

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -165,7 +165,25 @@ install_local_single <- function(path, subdir = NULL, before_install = NULL, ...
     before_install(bundle, pkg_path)
 
   # Finally, run install
-  install(pkg_path, quiet = quiet, ...)
+  with_build_tools({
+    install(pkg_path, quiet = quiet, ...)
+  })
+}
+
+with_build_tools <- function(code) {
+  check <- getOption("buildtools.check", NULL)
+  if (!is.null(check)) {
+    if (check("Installing R packages from source")) {
+      with <- getOption("buildtools.with", NULL)
+      if (!is.null(with))
+        with(code)
+      else
+        force(code)
+    }
+  }
+  else {
+    force(code)
+  }
 }
 
 decompress <- function(src, target = tempdir()) {


### PR DESCRIPTION
The host of an R process (e.g. RStudio) may provide buildtools.check and buildtools.with options that can be used for automatic prompted installation of required build tools and execution of arbitrary code with the build tools on the PATH. This PR calls those optional functions whenever they are available.
