### PR TITLE
restart R when bootstrapping or restoring

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -136,7 +136,7 @@ unbundle <- function(bundle, where, ..., restore = TRUE) {
     ## Ensure the (empty) library directory is present before restoring
     dir.create(libDir(getwd()), recursive = TRUE, showWarnings = FALSE)
     message("- Restoring project library...")
-    restore(project = getwd())
+    restore(project = getwd(), restart = FALSE)
     message("Done! The project has been unbundled and restored at:\n- \"", dirName, "\"")
   } else {
     message("Done! The packrat project has been unbundled at:\n- \"", dirName, "\"")

--- a/R/utils.R
+++ b/R/utils.R
@@ -345,3 +345,14 @@ swap <- function(vec, from, to = NULL) {
   tmp[is.na(tmp)] <- vec[is.na(tmp)]
   return(tmp)
 }
+
+
+attemptRestart <- function() {
+  restart <- getOption("restart")
+  if (!is.null(restart)) {
+    restart()
+    TRUE
+  } else {
+    FALSE
+  }
+}

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -71,7 +71,7 @@ local({
   library("packrat", character.only = TRUE, lib.loc = lib)
 
   message("> Restoring library")
-  restore()
+  restore(restart = FALSE)
 
   message("> Packrat bootstrap successfully completed. Entering packrat mode...")
   packrat_mode()

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -41,7 +41,7 @@ test_that("restore ignores dirty packages", {
 
   installTestPkg("oatmeal", "1.0.0", lib)
   expect_true(file.exists(file.path(lib, "oatmeal")))
-  restore(projRoot, prompt = FALSE)
+  restore(projRoot, prompt = FALSE, restart = FALSE)
   expect_true(file.exists(file.path(lib, "oatmeal")))
 })
 
@@ -54,7 +54,7 @@ test_that("restore installs missing packages", {
   # Remove a used package and restore
   remove.packages("bread", lib = lib)
   expect_false(file.exists(file.path(lib, "bread")))
-  restore(projRoot, prompt = FALSE)
+  restore(projRoot, prompt = FALSE, restart = FALSE)
   expect_true(file.exists(file.path(lib, "bread")))
 })
 


### PR DESCRIPTION
This adds a restart flag to the restore function which defaults to !dry.run. It's a big ugly as internal uses of restore now need to remember to pass restart = FALSE but I couldn't clearly see another way to get this done. Let me know what you think.
