### PR TITLE
Print a shorter & prettier (via use of ~) packrat lib at startup

### DIFF
--- a/R/packrat-mode.R
+++ b/R/packrat-mode.R
@@ -138,7 +138,7 @@ afterPackratModeOn <- function(project,
 
   # Give the user some visual indication that they're starting a packrat project
   if (interactive()) {
-    msg <- paste("Packrat mode on. Using library in directory:\n- \"", libDir(project), "\"", sep = "")
+    msg <- paste("Packrat mode on. Using library in directory:\n- \"", prettyLibDir(project), "\"", sep = "")
     message(msg)
   }
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -156,3 +156,10 @@ packratOptionsFilePath <- function(project = NULL) {
 libRdir <- function(project = NULL) {
   file.path(getPackratDir(project), "lib-R")
 }
+
+prettyLibDir <- function(project) {
+  homeDir <- path.expand("~")
+  if (substring(project, 1, nchar(homeDir)) == homeDir)
+    project <- gsub(homeDir, "~", project, fixed = TRUE)
+  file.path(project, .packrat$packratFolderName, "lib")
+}


### PR DESCRIPTION
This is also excludes the printing of the architecture and R version parts of the library path.
