### PR TITLE
github flavored markdown requires 8 spaces for code blocks within lists

### DIFF
--- a/announce/packrat-0.2.0.md
+++ b/announce/packrat-0.2.0.md
@@ -61,8 +61,9 @@ the following:
 3. Start an R session in this folder,
 4. Run the following script:
 
-    if (!require("devtools")) install.packages("devtools")
-    devtools::install_github("rstudio/packrat") packrat::migrate()
+        if (!require("devtools")) install.packages("devtools")
+        devtools::install_github("rstudio/packrat")
+        packrat::migrate()
 
 After this, you can restart your R session, and you should be good to go!
 


### PR DESCRIPTION
Should be self explanatory...  look at the [announcement on github](https://github.com/rstudio/packrat/blob/master/announce/packrat-0.2.0.md) to see what's wrong with the current script.
