### PR TITLE
Don't change position of existing autoloader when overwriting .Rprofile

### DIFF
--- a/R/packrat.R
+++ b/R/packrat.R
@@ -565,14 +565,17 @@ packify <- function(project = NULL, quiet = FALSE) {
       end <- NULL
     }
 
-    if (length(start) && length(end) && end > start)
-      content <- content[-c(start:end)]
-
-    if (length(content)) {
-      content <- c(content, "", autoloader)
+    if (length(start) && length(end) && end > start) {
+      before <- seq_len(start)
+      after <- seq(from = end + 1, length.out = length(content) - end)
     } else {
-      content <- autoloader
+      before <- seq_along(content)
+      after <- integer()
+      if (length(content))
+        autoloader <- c("", autoloader)
     }
+
+    content <- c(content[before], autoloader, content[after])
     cat(content, file = .Rprofile, sep = "\n")
 
   }


### PR DESCRIPTION
In `packify()`:
- Memoize "before" and "after" part which is copied from the existing content
  - If no autoloader, "before" is the entire sequence, and "after" is empty
- Remove early return which could avoid creating `init.R` in some cases
- Always overwrite `init.R`

Fixes #164.
