### PR TITLE
Allow for project resources to live in a separate directory

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -268,14 +268,14 @@ bundle_external <- function(project = NULL,
     filesToZip <- c(
       filesToZip,
       file.path(
-        relSrcDir(),
-        list.files(relSrcDir(), recursive = TRUE)
+        "packrat/src",
+        list.files("packrat/src", recursive = TRUE)
       )
     )
   }
 
   if (include.lib) {
-    filesToZip <- c(filesToZip, relLibDir())
+    filesToZip <- c(filesToZip, "packrat/lib")
   }
 
   if (!include.vcs.history) {
@@ -298,7 +298,7 @@ bundle_external <- function(project = NULL,
                           full.names = TRUE,
                           recursive = TRUE)
     srcPkgsRelative <- file.path(
-      relSrcDir(),
+      "packrat/src",
       list.files(recursive = TRUE,
         srcDir(project = file.path(tempdir(), basename(project)))
       )

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -36,7 +36,10 @@ bundle <- function(project = NULL,
                    ...) {
 
   TAR <- Sys.getenv("TAR")
-  if (identical(TAR, "internal") || identical(TAR, "")) {
+  resDir <- opts$project.resources.path()
+  isInternalTar <- identical(TAR, "internal") || identical(TAR, "")
+
+  if (isInternalTar || !is.null(resDir)) {
     bundle_internal(project = project,
                     file = file,
                     include.src = include.src,
@@ -122,6 +125,18 @@ bundle_internal <- function(project = NULL,
     pattern = pattern,
     overwrite = TRUE
   )
+
+  ## If the project resources are in a separate directory, we need to explicitly
+  ## copy that in as well.
+  resDir <- opts$project.resources.path()
+  if (!is.null(resDir)) {
+    dir_copy(
+      from = resDir,
+      to = file.path(to, "packrat"),
+      pattern = pattern,
+      overwrite = TRUE
+    )
+  }
 
   ## Clean up after ourselves
   on.exit(unlink(to, recursive = TRUE), add = TRUE)

--- a/R/options.R
+++ b/R/options.R
@@ -14,7 +14,10 @@ VALID_OPTIONS <- list(
   local.repos = function(x) {
     is.null(x) || is.character(x)
   },
-  load.external.packages.on.startup = list(TRUE, FALSE)
+  load.external.packages.on.startup = list(TRUE, FALSE),
+  project.resources.path = function(x) {
+    is.null(x) || (is.character(x) && length(x) == 1)
+  }
 )
 
 default_opts <- function() {
@@ -26,7 +29,8 @@ default_opts <- function() {
     vcs.ignore.src = FALSE,
     external.packages = Sys.getenv("R_PACKRAT_EXTERNAL_PACKAGES", unset = ""),
     local.repos = "",
-    load.external.packages.on.startup = TRUE
+    load.external.packages.on.startup = TRUE,
+    project.resources.path = NULL
   )
 }
 
@@ -72,6 +76,12 @@ initOptions <- function(project = NULL, options = default_opts()) {
 ##' \item \code{load.external.packages.on.startup}:
 ##'   Load any packages specified within \code{external.packages} on startup?
 ##'   (\code{TRUE} / \code{FALSE}; defaults to \code{TRUE})
+##' \item \code{project.resources.path}:
+##'   Path to store project resources -- specificaly, the \code{lib/}, \code{src/},
+##'   \code{bundles/} directories? Defaults to \code{NULL}, implying that these
+##'   directories are placed within the \code{packrat} sub-directory of the
+##'   package; if set, the project resources will be stored at
+##'   \code{<project.resource.path>/<projectName>/}.
 ##' }
 ##'
 ##' @param options A character vector of valid option names.

--- a/R/packrat-mode.R
+++ b/R/packrat-mode.R
@@ -144,7 +144,9 @@ afterPackratModeOn <- function(project,
 
   # Give the user some visual indication that they're starting a packrat project
   if (interactive() && print.banner) {
-    msg <- paste("Packrat mode on. Using library in directory:\n- \"", prettyLibDir(project), "\"", sep = "")
+    msg <- paste("Packrat mode activated for project: \n- \"",
+                 prettyProjectDir(project),
+                 "\"", sep = "")
     message(msg)
   }
 

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -189,6 +189,9 @@ init <- function(project = '.',
       if (isPackratModeOn())
         off()
 
+      ## Create the 'packrat' directory and write out the options first
+      options <- initOptions(project, opts) ## writes out packrat.opts and returns generated list
+
       ## We always re-packify so that the current version of packrat present can
       ## insert the appropriate auto-loaders
       packify(project = project, quiet = TRUE)
@@ -202,12 +205,11 @@ init <- function(project = '.',
 
       ## Make sure the .Rprofile is up to date
       augmentRprofile(project)
-      options <- initOptions(project, opts) ## writes out packrat.opts and returns generated list
 
       # Take a snapshot
       snapshotImpl(project,
                    available.packages(contrib.url(activeRepos(project))),
-                   lib.loc = NULL,
+                   lib.loc = libDir(project),
                    ignore.stale = TRUE,
                    fallback.ok = TRUE)
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -18,12 +18,12 @@ getProjectDir <- function(project = NULL) {
   )
 }
 
+# Although a project's resources might live in a separate directory,
+# the packrat folder is always a sub-directory of the project (ie --
+# packrat.lock, packrat.opts)
 getPackratDir <- function(project = NULL) {
   project <- getProjectDir(project)
-  file.path(
-    project,
-    .packrat$packratFolderName
-  )
+  file.path(project, "packrat")
 }
 
 ## We differentiate between the 'libDir' -- the actual architecture-specific
@@ -45,86 +45,35 @@ libDir <- function(project = NULL) {
   )
 }
 
-relLibDir <- function() {
-  file.path(
-    .packrat$packratFolderName,
-    relativeLibDir('lib')
-  )
+resourcesDir <- function(..., project = NULL) {
+  project <- getProjectDir(project)
+  optDir <- opts$project.resources.path()
+  if (is.null(optDir))
+    file.path(getPackratDir(project), ...)
+  else
+    file.path(optDir, basename(project), ...)
 }
 
 ## The root library directory for a project, e.g. <proj>/<packrat>/lib
 libraryRootDir <- function(project = NULL) {
-  project <- getProjectDir(project)
-  file.path(
-    project,
-    .packrat$packratFolderName,
-    'lib'
-  )
-}
-
-relLibraryRootDir <- function() {
-  file.path(
-    .packrat$packratFolderName,
-    'lib'
-  )
-}
-
-relativeLibDir <- function(libraryRoot) {
-  file.path(
-    libraryRoot,
-    R.version$platform,
-    getRversion()
-  )
+  resourcesDir("lib", project = project)
 }
 
 # Temporary library directory when modifying an in-use library
 newLibraryDir <- function(project = NULL) {
-  file.path(
-    getPackratDir(project),
-    'library.new'
-  )
-}
-
-relNewLibraryDir <- function() {
-  file.path(
-    .packrat$packratFolderName,
-    'library.new'
-  )
+  resourcesDir("library.new", project = project)
 }
 
 oldLibraryDir <- function(project = NULL) {
-  file.path(
-    getPackratDir(project),
-    'library.old'
-  )
-}
-
-relOldLibraryDir <- function() {
-  file.path(
-    .packrat$packratFolderName,
-    'library.old'
-  )
+  resourcesDir("library.old", project = project)
 }
 
 srcDir <- function(project = NULL) {
-  file.path(
-    getPackratDir(project),
-    'src'
-  )
-}
-
-relSrcDir <- function() {
-  file.path(
-    .packrat$packratFolderName,
-    'src'
-  )
+  resourcesDir("src", project = project)
 }
 
 bundlesDir <- function(project = NULL) {
-  file.path(
-    getPackratDir(project),
-    'bundles'
-  )
+  resourcesDir("bundles", project = project)
 }
 
 lockFilePath <- function(project = NULL) {
@@ -150,33 +99,38 @@ instInitRprofileFilePath <- function() {
   file.path(system.file(package = "packrat"), "resources", "init-rprofile.R")
 }
 
-instMacRUserlibFilePath <- function() {
-  file.path(system.file(package = "packrat"), "resources", "mac_r_userlib.sh")
-}
-
 packratOptionsFilePath <- function(project = NULL) {
   file.path(getPackratDir(project), "packrat.opts")
 }
 
 libRdir <- function(project = NULL) {
-  file.path(getPackratDir(project), "lib-R")
+  resourcesDir("lib-R", project = project)
 }
 
 libExtDir <- function(project = NULL) {
-  file.path(getPackratDir(project), "lib-ext")
+  resourcesDir("lib-ext", project = project)
 }
 
 startsWithBytes <- function(x, y) {
   Encoding(x) <- Encoding(y) <- "bytes"
-  return(substring(x, 1, nchar(y, type = "bytes")) == x)
+  return(substring(x, 1, nchar(y, type = "bytes")) == y)
 }
 
 prettyLibDir <- function(project = NULL) {
   project <- getProjectDir(project)
+  resDir <- resourcesDir(project = project)
+  homeDir <- path.expand("~/")
+  if (startsWithBytes(resDir, homeDir))
+    resDir <- gsub(homeDir, "~/", resDir, fixed = TRUE)
+  file.path(resDir, "lib")
+}
+
+prettyProjectDir <- function(project = NULL) {
+  project <- getProjectDir(project)
   homeDir <- path.expand("~/")
   if (startsWithBytes(project, homeDir))
     project <- gsub(homeDir, "~/", project, fixed = TRUE)
-  file.path(project, .packrat$packratFolderName, "lib")
+  project
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -252,8 +252,8 @@ updateGitIgnore <- function(project = NULL, options) {
   names(git.options) <- swap(
     names(git.options),
     c(
-      "vcs.ignore.lib" = paste0(relLibraryRootDir(), "*/"),
-      "vcs.ignore.src" = paste0(relSrcDir(), "/")
+      "vcs.ignore.lib" = "packrat/lib*/",
+      "vcs.ignore.src" = "packrat/src/"
     )
   )
 
@@ -306,8 +306,8 @@ updateSvnIgnore <- function(project, options) {
   names(svn.options) <- swap(
     names(svn.options),
     c(
-      "vcs.ignore.lib" = relLibraryRootDir(),
-      "vcs.ignore.src" = relSrcDir()
+      "vcs.ignore.lib" = "packrat/lib",
+      "vcs.ignore.src" = "packrat/src"
     )
   )
   add <- names(svn.options)[sapply(svn.options, isTRUE)]
@@ -315,8 +315,8 @@ updateSvnIgnore <- function(project, options) {
 
   ## We need to explicitly exclude library.new, library.old
   add <- unique(c(add,
-                  relNewLibraryDir(),
-                  relOldLibraryDir()
+                  "packrat/library.new",
+                  "packrat/library.old"
   ))
 
   add <- c(add, "packrat/lib-R")

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -1,7 +1,5 @@
 local({
 
-  libDir <- file.path('packrat', 'lib', R.version$platform, getRversion())
-
   ## Escape hatch to allow RStudio to handle initialization
   if (!is.na(Sys.getenv("RSTUDIO", unset = NA)) &&
         is.na(Sys.getenv("RSTUDIO_PACKRAT_BOOTSTRAP", unset = NA))) {
@@ -10,6 +8,19 @@ local({
       source("packrat/init.R")
     })
     return(invisible(NULL))
+  }
+
+  ## Check the packrat.opts file for a custom resources path
+  optFile <- file.path("packrat", "packrat.opts")
+  opts <- readLines(optFile)
+
+  resourcePath <- "packrat"
+  if (any(grepl("^project.resources.path:", opts, perl = TRUE))) {
+    string <- grep("^project.resources.path:", opts, perl = TRUE, value = TRUE)
+    resourcePath <- gsub("^project.resources.path:\\s*", "", string, perl = TRUE)
+    libDir <- file.path(resourcePath, basename(getwd()), "lib", R.version$platform, getRversion())
+  } else {
+    libDir <- file.path("packrat", "lib", R.version$platform, getRversion())
   }
 
   ## Unload packrat in case it's loaded -- this ensures packrat _must_ be

--- a/man/packrat-options.Rd
+++ b/man/packrat-options.Rd
@@ -61,6 +61,12 @@ Get and set options for the current packrat-managed project.
 \item \code{load.external.packages.on.startup}:
   Load any packages specified within \code{external.packages} on startup?
   (\code{TRUE} / \code{FALSE}; defaults to \code{TRUE})
+\item \code{project.resources.path}:
+  Path to store project resources -- specificaly, the \code{lib/}, \code{src/},
+  \code{bundles/} directories? Defaults to \code{NULL}, implying that these
+  directories are placed within the \code{packrat} sub-directory of the
+  package; if set, the project resources will be stored at
+  \code{<project.resource.path>/<projectName>/}.
 }
 }
 \examples{

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -4,9 +4,8 @@
 \alias{snapshot}
 \title{Capture and store the packages and versions in use}
 \usage{
-snapshot(project = NULL, available = available.packages(),
-  lib.loc = libDir(project), ignore.stale = FALSE, dry.run = FALSE,
-  prompt = interactive())
+snapshot(project = NULL, available = NULL, lib.loc = libDir(project),
+  ignore.stale = FALSE, dry.run = FALSE, prompt = interactive())
 }
 \arguments{
 \item{project}{The project directory. Defaults to current working

--- a/man/snapshotImpl.Rd
+++ b/man/snapshotImpl.Rd
@@ -4,10 +4,10 @@
 \alias{.snapshotImpl}
 \title{Internal Snapshot Implementation}
 \usage{
-.snapshotImpl(project, available = available.packages(),
-  lib.loc = libDir(project), dry.run = FALSE, ignore.stale = FALSE,
-  prompt = interactive(), auto.snapshot = FALSE, verbose = TRUE,
-  fallback.ok = FALSE, snapshot.sources = TRUE)
+.snapshotImpl(project, available = NULL, lib.loc = libDir(project),
+  dry.run = FALSE, ignore.stale = FALSE, prompt = interactive(),
+  auto.snapshot = FALSE, verbose = TRUE, fallback.ok = FALSE,
+  snapshot.sources = TRUE)
 }
 \arguments{
 \item{project}{The project directory. Defaults to current working


### PR DESCRIPTION
This is an attempt to allow a Packrat project to keep its project resources (the `lib/` `src/`, `bundles/` directories) in a separate location. The primary startup resources will still live in the `packrat/` subfolder, e.g. `packrat.lock`, `packrat.opts` and so on, but these other parts can be made separate.

This feature is primarily intended to help support e.g. DropBox users, who might want to use Packrat for a project without having to sync the installed libraries / sources.

The trickiest thing to get right in such a scheme is the `bundle`/`unbundle` commands, since we are now trying to tar up resources from multiple paths. Currently, `bundle_internal` does that 'copy everything to one directory, and bundle that', with `unbundle` being able to untar and later move project resources back to the appropriate path.

The main idea is that a project can now use the Packrat option `project.resources.path = <path>`, and then resources will be placed at `<path>/<projectName>`. This might need to change since multiple different projects could have the same name, but I was wondering if it could be possible to have a 'root' resources path that other projects could use, or if instead we should just require all projects to explicitly specify their own directory.