### PR TITLE
ensure working directory set to project directory on restart

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.2-9
+Version: 0.4.2-10
 Date: 2014-09-02
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>

--- a/inst/resources/init-rprofile.R
+++ b/inst/resources/init-rprofile.R
@@ -1,3 +1,3 @@
-#### -- Packrat Autoloader (version 0.4.2-9) -- ####
+#### -- Packrat Autoloader (version 0.4.2-10) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -7,6 +7,13 @@ local({
         is.na(Sys.getenv("RSTUDIO_PACKRAT_BOOTSTRAP", unset = NA))) {
     Sys.setenv("RSTUDIO_PACKRAT_BOOTSTRAP" = "1")
     setHook("rstudio.sessionInit", function(...) {
+      # Ensure that, on sourcing 'packrat/init.R', we are
+      # within the project root directory
+      if (exists(".rs.getProjectDirectory")) {
+        owd <- getwd()
+        setwd(.rs.getProjectDirectory())
+        on.exit(setwd(owd), add = TRUE)
+      }
       source("packrat/init.R")
     })
     return(invisible(NULL))
@@ -144,7 +151,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- 'InstallAgent: packrat 0.4.2-9'
+    installAgent <- 'InstallAgent: packrat 0.4.2-10'
 
     ## -- InstallSource -- ##
     installSource <- 'InstallSource: source'


### PR DESCRIPTION
This fixes #183 by ensuring that the working directory is set to the project directory when sourcing the `packrat/init.R` file, and then restoring it after completing initialization.