### PR TITLE
print error message during package installation into stderr in case message is too long (#189)

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -576,6 +576,10 @@ system_check <- function(cmd, args = character(), env = character(),
     stopMsg <- paste0("Command failed (", status, ")",
       "\n\nThe command failed with output:\n",
       paste(result, collapse = "\n"))
+    # issue #186
+    if (nchar(stopMsg) > getOption("warning.length")) {
+      print(stopMsg, file=stderr())
+    }
     stop(stopMsg, call. = FALSE)
   }
 


### PR DESCRIPTION
fixing #189 