### PR TITLE
infer whether project implicitly depends on Shiny

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.3-2
+Version: 0.4.3-3
 Date: 2014-09-02
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Packrat 0.4.4 (Unreleased)
 
+- Packrat now infers whether a project implicitly depends on Shiny.
+
 - Packrat now properly infers whether a package is from a CRAN-like repository,
   by checking if the `source` field maps to one of the repository names in
   `getOption('repos')`. (#185)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -63,7 +63,7 @@ appDependencies <- function(project = NULL,
   # If this project is implicitly a shiny application, then
   # add that in as the previously run expression dependency lookup
   # won't have found it.
-  if (isShinyApp(project))
+  if (!("shiny" %in% result) && isShinyApp(project))
     result <- c(result, "shiny")
 
   sort_c(result)

--- a/inst/resources/init-rprofile.R
+++ b/inst/resources/init-rprofile.R
@@ -1,3 +1,3 @@
-#### -- Packrat Autoloader (version 0.4.3-2) -- ####
+#### -- Packrat Autoloader (version 0.4.3-3) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -151,7 +151,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- 'InstallAgent: packrat 0.4.3-2'
+    installAgent <- 'InstallAgent: packrat 0.4.3-3'
 
     ## -- InstallSource -- ##
     installSource <- 'InstallSource: source'

--- a/tests/testthat/resources/interactive-doc-example.Rmd
+++ b/tests/testthat/resources/interactive-doc-example.Rmd
@@ -1,0 +1,53 @@
+---
+title: "Untitled"
+runtime: shiny
+output: html_document
+---
+
+This R Markdown document is made interactive using Shiny. Unlike the more traditional workflow of creating static reports, you can now create documents that allow your readers to change the assumptions underlying your analysis and see the results immediately. 
+
+To learn more, see [Interactive Documents](http://rmarkdown.rstudio.com/authoring_shiny.html).
+
+## Inputs and Outputs
+
+You can embed Shiny inputs and outputs in your document. Outputs are automatically updated whenever inputs change.  This demonstrates how a standard R plot can be made interactive by wrapping it in the Shiny `renderPlot` function. The `selectInput` and `sliderInput` functions create the input widgets used to drive the plot.
+
+```{r, echo=FALSE}
+inputPanel(
+  selectInput("n_breaks", label = "Number of bins:",
+              choices = c(10, 20, 35, 50), selected = 20),
+  
+  sliderInput("bw_adjust", label = "Bandwidth adjustment:",
+              min = 0.2, max = 2, value = 1, step = 0.2)
+)
+
+renderPlot({
+  hist(faithful$eruptions, probability = TRUE, breaks = as.numeric(input$n_breaks),
+       xlab = "Duration (minutes)", main = "Geyser eruption duration")
+  
+  dens <- density(faithful$eruptions, adjust = input$bw_adjust)
+  lines(dens, col = "blue")
+})
+```
+
+## Embedded Application
+
+It's also possible to embed an entire Shiny application within an R Markdown document using the `shinyAppDir` function. This example embeds a Shiny application located in another directory:
+
+```{r, echo=FALSE}
+shinyAppDir(
+  system.file("examples/06_tabsets", package="shiny"),
+  options=list(
+    width="100%", height=550
+  )
+)
+```
+
+Note the use of the `height` parameter to determine how much vertical space the embedded application should occupy.
+
+You can also use the `shinyApp` function to define an application inline rather then in an external directory.
+
+In all of R code chunks above the `echo = FALSE` attribute is used. This is to prevent the R code within the chunk from rendering in the document alongside the Shiny components.
+
+
+

--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -1,0 +1,21 @@
+context("Shiny")
+
+test_that("projects which use shiny implicitly are detected", {
+
+  # Try checking to see if packrat believes all example shiny apps
+  # are, in fact, shiny apps
+  options(repos = c(CRAN = "http://cran.rstudio.org"))
+  if ("shiny" %in% rownames(installed.packages())) {
+    examplesPath <- system.file("examples", package = "shiny")
+    apps <- list.files(examplesPath, full.names = TRUE)
+    for (app in apps) {
+      expect_true("shiny" %in% packrat:::appDependencies(app))
+    }
+  }
+
+  # Check that 'shiny' is listed as a dependency for an
+  # R Markdown document with 'runtime: shiny'
+  interactiveDocPath <- file.path("resources", "interactive-doc-example.Rmd")
+  expect_true("shiny" %in% packrat:::fileDependencies(interactiveDocPath))
+
+})


### PR DESCRIPTION
This PR checks whether a project (implicitly) depends on Shiny. It does so by checking:

1. For a `shinyServer` call in `server.R`, or
2. A `shinyApp` call in `app.R`.

Note that `shiny` dependencies within R Markdown documents with `runtime: shiny` in the YAML header are already properly detected by us.

@jjallaire, can you merge if you think everything looks okay?