### PR TITLE
set parent directory name for package to package name (#194)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.3-4
+Version: 0.4.3-5
 Date: 2014-09-02
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # Packrat 0.4.4 (Unreleased)
 
-- Packrat issues a warning if it was unable to infer the source of a particular
-  package on initialization and instead uses the latest CRAN version.
+- Packrat issues a warning on `packrat::init()` if it was unable to infer the
+  source of a particular package on initialization and instead uses the latest
+  CRAN version.
 
 - Packrat now infers whether a project implicitly depends on Shiny.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Packrat 0.4.4 (Unreleased)
 
+- The cache directory layout has been modified to ensure help (`?`) calls
+  succeed. This is a breaking change with older versions of Packrat, and so
+  newer versions of Packrat will use a new cache folder. (#194)
+  
 - Packrat issues a warning on `packrat::init()` if it was unable to infer the
   source of a particular package on initialization and instead uses the latest
   CRAN version.

--- a/R/library-support.R
+++ b/R/library-support.R
@@ -57,9 +57,11 @@ symlinkSystemPackages <- function(project = NULL) {
 
   ## Clean up recursive symlinks if necessary -- it is possible that, e.g.
   ## within a base package directory:
+  ##
   ##     /Library/Frameworks/R.framework/Versions/3.2/library/MASS
+  ##
   ## there will be a link to MASS within MASS; we try to be friendly and
-  ## remove those
+  ## remove those.
   recursiveSymlinks <- file.path(.Library, sysPkgNames, sysPkgNames)
   invisible(lapply(recursiveSymlinks, function(file) {
     if (is.symlink(file)) {

--- a/R/paths.R
+++ b/R/paths.R
@@ -231,7 +231,7 @@ defaultAppDataDir <- function() {
 }
 
 packratCacheVersion <- function() {
-  "v1"
+  "v2"
 }
 
 cacheLibDir <- function(...) {

--- a/R/restore.R
+++ b/R/restore.R
@@ -357,7 +357,7 @@ installPkg <- function(pkgRecord,
     # This package has already been installed in the cache; just symlink
     # to that if possible, or copy otherwise
     success <- suppressWarnings(symlink(
-      file.path(cacheLibDir(pkgRecord$name, pkgRecord$hash)),
+      file.path(cacheLibDir(pkgRecord$name, pkgRecord$hash, pkgRecord$name)),
       file.path(libDir(project), pkgRecord$name)
     ))
 

--- a/inst/resources/init-rprofile.R
+++ b/inst/resources/init-rprofile.R
@@ -1,3 +1,3 @@
-#### -- Packrat Autoloader (version 0.4.3-4) -- ####
+#### -- Packrat Autoloader (version 0.4.3-5) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -151,7 +151,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- 'InstallAgent: packrat 0.4.3-4'
+    installAgent <- 'InstallAgent: packrat 0.4.3-5'
 
     ## -- InstallSource -- ##
     installSource <- 'InstallSource: source'


### PR DESCRIPTION
This PR fixes a bug in packrat where help calls, e.g. `?stringr::str_c`, would fail if the project was using the packrat cache.

In essence, this PR changes the cache directory structure from:

    <cachePath>/<pkgName>/<hash>

to

    <cachePath>/<pkgName>/<hash>/<pkgName>

Because this PR changes the directory structure for packages within the cache, the cache directory is updated from `v1` to `v2` -- so all versions of packrat from here-on would use a new cache directory, to be safe.
