### PR TITLE
use full set of .libPaths to resolve package dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.3-12
+Version: 0.4.3-13
 Date: 2014-09-02
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -35,6 +35,16 @@ appDependencies <- function(project = NULL,
 
   project <- getProjectDir(project)
 
+  ## We want to search both local and global library paths for DESCRIPTION files
+  ## in the recursive dependency lookup; hence we take a large (ordered) union
+  ## of library paths. The ordering ensures that we search the private library first,
+  ## and fall back to the local / global library (necessary for `packrat::init`)
+  libPaths <- c(
+    libDir(project),
+    .libPaths(),
+    .packrat_mutables$origLibPaths
+  )
+
   ## For R packages, we only use the DESCRIPTION file
   if (isRPackage(project)) {
 
@@ -47,13 +57,13 @@ appDependencies <- function(project = NULL,
     ## do not need suggests -- for the package itself, we should make sure
     ## we grab suggests, however
     childDeps <- recursivePackageDependencies(parentDeps,
-                                              libDir(project),
+                                              libPaths,
                                               available.packages,
                                               fields)
   } else {
     parentDeps <- setdiff(unique(c(dirDependencies(project))), "packrat")
     childDeps <- recursivePackageDependencies(parentDeps,
-                                              libDir(project),
+                                              libPaths,
                                               available.packages,
                                               fields)
   }

--- a/inst/resources/init-rprofile.R
+++ b/inst/resources/init-rprofile.R
@@ -1,3 +1,3 @@
-#### -- Packrat Autoloader (version 0.4.3-12) -- ####
+#### -- Packrat Autoloader (version 0.4.3-13) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -151,7 +151,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- 'InstallAgent: packrat 0.4.3-12'
+    installAgent <- 'InstallAgent: packrat 0.4.3-13'
 
     ## -- InstallSource -- ##
     installSource <- 'InstallSource: source'


### PR DESCRIPTION
This PR ensures that we crawl through all library paths when attempting to resolve (recursive) package dependencies on the system.