### PR TITLE
Consider the GitHub SHA as just another hash input.

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -19,14 +19,10 @@ hash <- function(path) {
 
   DESCRIPTION <- as.data.frame(readDcf(path), stringsAsFactors = FALSE)
 
-  # If we already have a GitHub SHA1, just use that
-  if ("GithubSHA1" %in% names(DESCRIPTION))
-    return(DESCRIPTION$GithubSHA1)
-
   # TODO: Do we want the 'Built' field used for hashing? The main problem with using that is
   # it essentially makes packages installed from source un-recoverable, since they will get
   # built transiently and installed (and so that field could never be replicated).
-  fields <- c("Package", "Version", "Depends", "Imports", "Suggests", "LinkingTo")
+  fields <- c("Package", "Version", "GithubSHA1", "Depends", "Imports", "Suggests", "LinkingTo")
   sub <- DESCRIPTION[names(DESCRIPTION) %in% fields]
 
   # Handle LinkingTo specially -- we need to discover what version of packages in LinkingTo


### PR DESCRIPTION
Fixes the first and second parts of #202.

The GitHub SHA is never taken verbatim as the hash but included in the content we use to compute the hash for an installed package. This also lets us distinguish between CRAN and GitHub installed packages due to the presence of `GithubSHA1` (perhaps there are more attributes?).