### PR TITLE
record a manifest (collection of DESCRIPTION files) with packrat projects

### DIFF
--- a/R/manifest.R
+++ b/R/manifest.R
@@ -4,7 +4,7 @@ readManifest <- function(project = NULL) {
     return(list())
 
   content <- read(path)
-  splat <- strsplit(content, "\n{2,}", perl = TRUE)
+  splat <- strsplit(content, "\n{2,}", perl = TRUE)[[1]]
   lapply(splat, readManifestEntry)
 }
 

--- a/R/manifest.R
+++ b/R/manifest.R
@@ -1,0 +1,38 @@
+readManifest <- function(project = NULL) {
+  path <- manifestFilePath(project)
+  if (!file.exists(path))
+    return(list())
+
+  content <- read(path)
+  splat <- strsplit(content, "\n{2,}", perl = TRUE)
+  lapply(splat, readManifestEntry)
+}
+
+# Manifest entries are just DESCRIPTION files
+readManifestEntry <- function(entry) {
+  read.dcf(textConnection(entry))
+}
+
+writeManifest <- function(manifestPath, pkgRecords) {
+
+  ip <- installed.packages()
+  missingPkgs <- c()
+
+  content <- vapply(pkgRecords, FUN.VALUE = character(1), USE.NAMES = FALSE, function(record) {
+    name <- record$name
+
+    if (!(name %in% rownames(ip))) {
+      missingPkgs <- c(missingPkgs, name)
+      next
+    }
+
+    libPath <- ip[name, "LibPath"]
+    descPath <- file.path(libPath, name, "DESCRIPTION")
+    if (!file.exists(descPath))
+      stop("No DESCRIPTION file for package '", name, "'")
+
+    read(descPath)
+  })
+
+  cat(content, file = manifestPath, sep = "\n")
+}

--- a/R/manifest.R
+++ b/R/manifest.R
@@ -10,14 +10,15 @@ readManifest <- function(project = NULL) {
 
 # Manifest entries are just DESCRIPTION files
 readManifestEntry <- function(entry) {
-  read.dcf(textConnection(entry))
+  readDcf(textConnection(entry), all = TRUE)
 }
 
-writeManifest <- function(manifestPath, pkgRecords) {
+writeManifest <- function(project, pkgRecords) {
+  project <- getProjectDir(NULL)
+  manifestPath <- manifestFilePath(project)
+  ip <- installed.packages(lib.loc = libDir(project))
 
-  ip <- installed.packages()
   missingPkgs <- c()
-
   content <- vapply(pkgRecords, FUN.VALUE = character(1), USE.NAMES = FALSE, function(record) {
     name <- record$name
 
@@ -33,6 +34,12 @@ writeManifest <- function(manifestPath, pkgRecords) {
 
     read(descPath)
   })
+
+  if (length(missingPkgs)) {
+    stop("The DESCRIPTION files associated with the following packages ",
+         "could not be found:\n- ",
+         paste(surround(missingPkgs, with = '"'), collapse = ", "))
+  }
 
   cat(content, file = manifestPath, sep = "\n")
 }

--- a/R/paths.R
+++ b/R/paths.R
@@ -131,6 +131,10 @@ lockFilePath <- function(project = NULL) {
   file.path(getPackratDir(project), "packrat.lock")
 }
 
+manifestFilePath <- function(project = NULL) {
+  file.path(getPackratDir(project), "packrat.manifest")
+}
+
 snapshotLockFilePath <- function(project = NULL) {
   file.path(getPackratDir(project), "snapshot.lock")
 }

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -264,6 +264,11 @@ snapshot <- function(project = NULL,
       allRecords
     )
 
+    writeManifest(
+      manifestFilePath(project),
+      allRecords
+    )
+
     for (record in allRecordsFlat) {
       name <- record$name
       path <- file.path(libDir(project), name, "DESCRIPTION")

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -264,10 +264,7 @@ snapshot <- function(project = NULL,
       allRecords
     )
 
-    writeManifest(
-      manifestFilePath(project),
-      allRecords
-    )
+    writeManifest(project, allRecords)
 
     for (record in allRecordsFlat) {
       name <- record$name

--- a/R/utils.R
+++ b/R/utils.R
@@ -518,3 +518,15 @@ filePrefix <- function() {
 reFilePrefix <- function() {
   paste("^", filePrefix(), sep = "")
 }
+
+read <- function(path) {
+
+  if (!file.exists(path))
+    stop("No file at path '", path, "'")
+
+  info <- as.list(file.info(path))
+  if (identical(info$isdir, TRUE))
+    stop("'", path, "' refers to a directory, not a file")
+
+  readChar(path, info$size)
+}


### PR DESCRIPTION
This PR ensures that `packrat::snapshot()` calls will also record the `DESCRIPTION` file of all packages discovered and used at the time of snapshot.