### PR TITLE
use secure download method for interactions with CRAN when required

### DIFF
--- a/R/packrat-mode.R
+++ b/R/packrat-mode.R
@@ -182,6 +182,10 @@ afterPackratModeOn <- function(project,
     options(repos = repos)
   }
 
+  # Set a secure download method if any of the repos URLs use https
+  if (any(grepl("^https", repos)))
+    options(download.file.method = secureDownloadMethod())
+
   # Update settings
   updateSettings(project = project)
 


### PR DESCRIPTION
Two changes here:

1) Update the `download` method to take advantage of the new secure R 3.2 download methods ("wininet" and "libcurl") when available.

2) Add a new `secureDownloadMethod` function which sets the default R download method to a secure one (if possible) when one of the repositories in `getOption("repos")` uses https. This allows `available.packages` and `install.packages` to work correctly in the presence of https repository URLs.

@jcheng5 @trestletech @wch

Winston, I'll put in a similar PR into downloader soon (packrat includes a copy of the the downloader::download function so as not to take a dependency on any other packages).
