### PR TITLE
Add newline when installing package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.4-4
+Version: 0.4.4-5
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Manage the R packages your project depends

--- a/R/restore.R
+++ b/R/restore.R
@@ -529,8 +529,9 @@ playActions <- function(pkgRecords, actions, repos, project, lib) {
               pkgRecord$version, ") ... ", appendLF = FALSE)
       removePkgs(project, pkgRecord$name, lib)
     } else if (identical(action, "add")) {
+      # Insert newline to show progress on consoles that buffer to newlines.
       message("Installing ", pkgRecord$name, " (", pkgRecord$version, ") ... ",
-              appendLF = FALSE)
+              appendLF = TRUE)
     } else if (identical(action, "remove")) {
       if (is.null(pkgRecord)) {
         message("Removing ", names(actions[i]), " ... ", appendLF = FALSE)
@@ -544,7 +545,7 @@ playActions <- function(pkgRecords, actions, repos, project, lib) {
       next
     }
     type <- installPkg(pkgRecord, project, availablePkgs, repos, lib, cache)
-    message("OK (", type, ")")
+    message("\tOK (", type, ")")
   }
   invisible()
 }


### PR DESCRIPTION
We have a couple of instances where we build packages during deployment and feed the progress out to the user as the packrat library restores.

Unfortunately, we (among others) buffer to newline, meaning we get no information about what's going on until the end of the "Installing" line. Currently, that means we can see when a package is done installing but we get no update until that point.

This PR breaks the line showing that the installation has begun from the one showing it has completed.