### PR TITLE
ensure downloader respects HTTP error codes

### DIFF
--- a/R/downloader.R
+++ b/R/downloader.R
@@ -34,75 +34,76 @@
 # }
 #
 download <- function(url, ...) {
-  # First, check protocol. If http or https, check platform:
-  if (grepl('^https?://', url)) {
 
-    # Check whether we are running R 3.2 and whether we have libcurl
-    isR32 <- getRversion() >= "3.2"
+  method <- inferAppropriateDownloadMethod(url)
 
-    # Windows
-    if (.Platform$OS.type == "windows") {
+  # When on Windows using an 'internal' method, we need to call
+  # 'setInternet2' to set some appropriate state.
+  if (is.windows() && method == "internal") {
 
-      if (isR32) {
-        method <- "wininet"
-      } else {
+    # If we directly use setInternet2, R CMD CHECK gives a Note on Mac/Linux
+    seti2 <- `::`(utils, 'setInternet2')
 
-        # If we directly use setInternet2, R CMD CHECK gives a Note on Mac/Linux
-        seti2 <- `::`(utils, 'setInternet2')
+    # Check whether we are already using internet2 for internal
+    internet2_start <- seti2(NA)
 
-        # Check whether we are already using internet2 for internal
-        internet2_start <- seti2(NA)
+    # If not then temporarily set it
+    if (!internet2_start) {
+      # Store initial settings, and restore on exit
+      on.exit(suppressWarnings(seti2(internet2_start)), add = TRUE)
 
-        # If not then temporarily set it
-        if (!internet2_start) {
-          # Store initial settings, and restore on exit
-          on.exit(suppressWarnings(seti2(internet2_start)))
-
-          # Needed for https. Will get warning if setInternet2(FALSE) already run
-          # and internet routines are used. But the warnings don't seem to matter.
-          suppressWarnings(seti2(TRUE))
-        }
-
-        method <- "internal"
-      }
-
-      # download.file will complain about file size with something like:
-      #       Warning message:
-      #         In download.file(url, ...) : downloaded length 19457 != reported length 200
-      # because apparently it compares the length with the status code returned (?)
-      # so we supress that
-      suppressWarnings(download.file(url, method = method, ...))
-
-    } else {
-      # If non-Windows, check for libcurl/curl/wget/lynx, then call download.file with
-      # appropriate method.
-
-      if (isR32 && capabilities("libcurl")) {
-        method <- "libcurl"
-      } else if (nzchar(Sys.which("wget")[1])) {
-        method <- "wget"
-      } else if (nzchar(Sys.which("curl")[1])) {
-        method <- "curl"
-
-        # curl needs to add a -L option to follow redirects.
-        # Save the original options and restore when we exit.
-        orig_extra_options <- getOption("download.file.extra")
-        on.exit(options(download.file.extra = orig_extra_options))
-
-        options(download.file.extra = paste("-L", orig_extra_options))
-
-      } else if (nzchar(Sys.which("lynx")[1])) {
-        method <- "lynx"
-      } else {
-        stop("no download method found")
-      }
-
-      download.file(url, method = method, ...)
+      # Needed for https. Will get warning if setInternet2(FALSE) already run
+      # and internet routines are used. But the warnings don't seem to matter.
+      suppressWarnings(seti2(TRUE))
     }
-
-  } else {
-    download.file(url, ...)
   }
+
+  downloadFile(url, method, ...)
+}
+
+downloadFile <- function(url,
+                         method = inferAppropriateDownloadMethod(url),
+                         extra = getOption("download.file.extra"),
+                         ...)
+{
+  # If we're using 'curl', we need to set '-L' to follow
+  # redirects, and '-f' to ensure HTTP error codes are treated
+  # as errors.
+  if (method == "curl") {
+    extra <- paste(extra, "-L -f")
+  }
+
+  # Catch warnings in the call.
+  caughtWarning <- NULL
+  result <- withCallingHandlers(
+    download.file(url = url, method = method, extra = extra, ...),
+    warning = function(w) {
+      caughtWarning <<- w
+      invokeRestart("muffleWarning")
+    }
+  )
+
+  # If we're using 'wget' or 'curl', upgrade the warning to an error.
+  if (method %in% c("curl", "wget") && length(caughtWarning)) {
+    msg <- sprintf("Failed to download '%s' ('%s' had status code '%s')",
+                   url,
+                   method,
+                   result)
+    stop(msg)
+  }
+
+  return(result)
+
+}
+
+# libcurl is broken in older versions of R as it does not
+# respect HTTP error codes (and instead just downloads the 404
+# page and returns a zero status code)
+canUseLibCurlDownloadMethod <- function() {
+  svnRev <- R.version$`svn rev`
+  goodVersion <- length(svnRev) && as.numeric(svnRev) >= 69197
+  hasLibCurl <- "libcurl" %in% names(capabilities()) && capabilities("libcurl")
+  goodVersion && hasLibCurl
 }
 
 
@@ -134,59 +135,52 @@ downloadWithRetries <- function(url, ..., maxTries = 5L) {
   success
 }
 
-# Attempt to determine a secure download method for the current platform/configuration
-# (returns NULL if none can be ascertaine, this will yield default behavior by R)
+inferAppropriateDownloadMethod <- function(url) {
+  isSecureWebProtocol <- grepl("^(?:ht|f)tps://", url, perl = TRUE)
+  if (isSecureWebProtocol)
+    return(secureDownloadMethod())
+  else
+    return("internal")
+}
+
+# Attempt to determine a secure download method for the current
+# platform/configuration. Returns NULL if no such method can
+# be ascertained.
 secureDownloadMethod <- function() {
 
   # Check whether we are running R 3.2 and whether we have libcurl
   isR32 <- getRversion() >= "3.2"
-  haveLibcurl <- isR32 && capabilities("libcurl")
 
-  # Utility function to bind to libcurl or a fallback utility (e.g. wget)
-  posixMethod <- function(utility) {
-    if (haveLibcurl)
-      "libcurl"
-    else if (nzchar(Sys.which(utility)[1]))
-      utility
+  if (is.windows()) {
+
+    # For windows we prefer binding directly to wininet if we can (since
+    # that doesn't rely on the value of setInternet2). If it's R <= 3.1
+    # then we can use "internal" for https so long as internet2 is enabled
+    # (we don't use libcurl on Windows because it doesn't check certs).
+    if (isR32)
+        return("wininet")
+
+    # Otherwise, make a call to 'setInternet2' and use the 'internal' method
+    # if that call succeeds.
+    seti2 <- `::`(utils, 'setInternet2')
+    if (seti2(NA))
+      return("internal")
     else
-      NULL
-  }
-
-  # Determine the right secure download method per-system
-  sysName <- Sys.info()[['sysname']]
-
-  # For windows we prefer binding directly to wininet if we can (since
-  # that doesn't rely on the value of setInternet2). If it's R <= 3.1
-  # then we can use "internal" for https so long as internet2 is enabled
-  # (we don't use libcurl on Windows because it doesn't check certs).
-  if (identical(sysName, "Windows")) {
-    if (isR32) {
-      "wininet"
-    }
-    else {
-      seti2 <- `::`(utils, 'setInternet2')
-      if (seti2(NA))
-        "internal"
-      else
-        NULL
-    }
+      return(NULL)
   }
 
   # For Darwin and Linux we use libcurl if we can and then fall back
   # to curl or wget as appropriate. We prefer libcurl because it honors
   # the same proxy configuration that "internal" does so it less likely
   # to break downloads for users behind proxy servers.
+  if (canUseLibCurlDownloadMethod())
+    return("libcurl")
 
-  # OS X
-  else if (identical(sysName, "Darwin")) {
-    posixMethod("curl")
-  }
+  # Otherwise, fall back to 'wget' or 'curl' (preferring 'wget')
+  candidates <- c("wget", "curl")
+  for (candidate in candidates)
+    if (isProgramOnPath(candidate))
+      return(candidate)
 
-  # Other UNIX
-  else {
-    method <- posixMethod("wget")
-    if (!nzchar(method))
-      method <- posixMethod("curl")
-    method
-  }
+  stop("Failed to discover a secure download method.")
 }

--- a/R/packrat-mode.R
+++ b/R/packrat-mode.R
@@ -183,8 +183,16 @@ afterPackratModeOn <- function(project,
   }
 
   # Set a secure download method if any of the repos URLs use https
-  if (any(grepl("^https", repos)))
-    options(download.file.method = secureDownloadMethod())
+  if (any(grepl("^https", repos))) {
+    method <- secureDownloadMethod()
+    if (is.null(method)) {
+      secureRepos <- grep("^https", repos, value = TRUE)
+      pasted <- paste("-", shQuote(secureRepos), collapse = "\n")
+      warning("The following repositories require a secure download method but ",
+              "none could be found:\n", pasted)
+    }
+    options(download.file.method = method)
+  }
 
   # Update settings
   updateSettings(project = project)

--- a/R/utils.R
+++ b/R/utils.R
@@ -518,3 +518,7 @@ filePrefix <- function() {
 reFilePrefix <- function() {
   paste("^", filePrefix(), sep = "")
 }
+
+isProgramOnPath <- function(program) {
+  nzchar(Sys.which(program)[[1]])
+}

--- a/tests/testthat/test-downloader.R
+++ b/tests/testthat/test-downloader.R
@@ -2,14 +2,18 @@ context("Downloader")
 
 getAvailableDownloadMethods <- function() {
 
+  if (is.windows()) {
+    methods <- "internal"
+    if (getRversion() >= "3.2")
+      methods <- c(methods, "wininet")
+    return(methods)
+  }
+
   has <- function(program) {
     nzchar(Sys.which(program)[[1]])
   }
 
   methods <- "internal"
-
-  if (is.windows() && getRversion() >= "3.2")
-    methods <- c(methods, "wininet")
 
   if (has("wget"))
     methods <- c(methods, "wget")

--- a/tests/testthat/test-downloader.R
+++ b/tests/testthat/test-downloader.R
@@ -17,8 +17,7 @@ getAvailableDownloadMethods <- function() {
   if (has("curl"))
     methods <- c(methods, "curl")
 
-  svnRevision <- R.version$`svn rev`
-  if (length(svnRevision) && as.numeric(svnRevision) >= 69197)
+  if (canUseLibCurlDownloadMethod())
     methods <- c(methods, "libcurl")
 
   methods

--- a/tests/testthat/test-downloader.R
+++ b/tests/testthat/test-downloader.R
@@ -1,0 +1,65 @@
+context("Downloader")
+
+getAvailableDownloadMethods <- function() {
+
+  has <- function(program) {
+    nzchar(Sys.which(program)[[1]])
+  }
+
+  methods <- "internal"
+
+  if (is.windows() && getRversion() >= "3.2")
+    methods <- c(methods, "wininet")
+
+  if (has("wget"))
+    methods <- c(methods, "wget")
+
+  if (has("curl"))
+    methods <- c(methods, "curl")
+
+  svnRevision <- R.version$`svn rev`
+  if (length(svnRevision) && as.numeric(svnRevision) >= 69197)
+    methods <- c(methods, "libcurl")
+
+  methods
+}
+
+test_that("404s are errors", {
+
+  URL <- "https://cran.rstudio.com/no/such/file/here.txt"
+  methods <- getAvailableDownloadMethods()
+
+  destfile <- tempfile()
+  on.exit(try(unlink(file), silent = TRUE), add = TRUE)
+
+  for (method in methods) {
+    expect_error(
+      downloadFile(URL, destfile = destfile, method = method, quiet = TRUE),
+      info = sprintf("(method = '%s')", method)
+    )
+  }
+
+})
+
+test_that("The same content is returned regardless of download method", {
+
+  URL <- "https://cran.rstudio.org/src/base/AUTHORS"
+  methods <- getAvailableDownloadMethods()
+  methods <- setdiff(methods, "internal")
+
+  contents <- lapply(methods, function(method) {
+
+    path <- tempfile()
+    on.exit(try(unlink(path), silent = TRUE), add = TRUE)
+
+    downloadFile(URL, destfile = path, method = method, quiet = TRUE)
+    readChar(path, file.info(path)$size, TRUE)
+
+  })
+
+  expect_true(
+    length(Reduce(unique, contents)) == 1,
+    info = "various download methods retrieve exact same content"
+  )
+
+})


### PR DESCRIPTION
NOTE: This PR will need some pretty thoughtful review to ensure it's correct...

There are two overarching issues that this PR attempts to resolve:

1) When an external program (e.g. `wget`, `curl`) fails to download a file, the status code from running the program is logged as a warning when non-zero, but no error is emitted. This is in contrast to the behaviour of `method = "internal"`, which _does_ err in such a case.

2) With R (SVN revision < 69197), `libcurl` also does not respect HTTP error codes; even worse, it downloads the 404 page and returns a 0 (success) status code. This is only fixed in recent R SVN revisions.

For 1), we catch warnings from `download.file()` when using methods `curl` and `wget`, and err if a non-zero status code is returned.

For 2), we only enable `libcurl` on versions of R with SVN revision >= 69197.

In the end, this fixes a very ugly problem where `snapshot()` could silently download a 404 page and pretend that the 404 page was the source package it intended to download.