### PR TITLE
Add implicit.packrat.dependency parameter to snapshotImpl

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -11,6 +11,7 @@
 #'   directory.
 #' @return Returns a list of the names of the packages on which R code in the
 #'   application depends.
+#' @param implicit.packrat.dependency is packrat an implicit dependency?
 #' @details Dependencies are determined by parsing application source code and
 #'   looking for calls to \code{library}, \code{require}, \code{::}, and
 #'   \code{:::}.
@@ -29,7 +30,8 @@
 #' @keywords internal
 appDependencies <- function(project = NULL,
                             available.packages = NULL,
-                            fields = c("Imports", "Depends", "LinkingTo")) {
+                            fields = c("Imports", "Depends", "LinkingTo"),
+                            implicit.packrat.dependency = TRUE) {
 
   if (is.null(available.packages)) available.packages <- available.packages()
 
@@ -72,7 +74,12 @@ appDependencies <- function(project = NULL,
                                               fields)
   }
 
-  result <- unique(c(parentDeps, childDeps, "packrat"))
+  result <- unique(c(parentDeps, childDeps))
+
+  # should packrat be included as automatic dependency?
+  if (implicit.packrat.dependency) {
+    result <- unique(c(result, "packrat"))
+  }
 
   # If this project is implicitly a shiny application, then
   # add that in as the previously run expression dependency lookup

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -98,6 +98,8 @@ snapshot <- function(project = NULL,
 #'   locally installed version is unavailable?
 #' @param snapshot.sources Download the tarball associated with a particular
 #'   package?
+#' @param implicit.packrat.dependency should packrat itself be included in the
+#'   snapshot as an implicit dependency?
 #' @keywords internal
 #' @rdname snapshotImpl
 #' @export
@@ -110,7 +112,8 @@ snapshot <- function(project = NULL,
                           auto.snapshot = FALSE,
                           verbose = TRUE,
                           fallback.ok = FALSE,
-                          snapshot.sources = TRUE) {
+                          snapshot.sources = TRUE,
+                          implicit.packrat.dependency = TRUE) {
 
   if (is.null(available))
   {
@@ -146,7 +149,8 @@ snapshot <- function(project = NULL,
 
   libPkgs <- setdiff(list.files(libDir(project)), ignore)
   inferredPkgs <- sort_c(appDependencies(project,
-                                         available.packages = available))
+                                         available.packages = available,
+                                         implicit.packrat.dependency = implicit.packrat.dependency))
 
   inferredPkgsNotInLib <- setdiff(inferredPkgs, libPkgs)
 


### PR DESCRIPTION
By default packrat itself is included as an implicit dependency by `snapshotImpl`, there are use cases (`rsconnect`) where this is not desirable. This PR adds a parameter to disable this dependency by passing `implicit.packrat.dependency = FALSE` to `snapshotImpl`