### PR TITLE
Bugfix in getSourceForPkgRecord.

### DIFF
--- a/R/restore.R
+++ b/R/restore.R
@@ -112,12 +112,13 @@ getSourceForPkgRecord <- function(pkgRecord,
       }
     })
     type <- "local"
-  } else if (isFromCranlikeRepo(pkgRecord) &&
-               pkgRecord$name %in% rownames(availablePkgs)) {
-    currentVersion <- availablePkgs[pkgRecord$name,"Version"]
+  } else if (isFromCranlikeRepo(pkgRecord)){
+    currentVersion <- if (pkgRecord$name %in% rownames(availablePkgs)) availablePkgs[pkgRecord$name,"Version"] else "not available"
     # Is the source for this version of the package on CRAN and/or a
     # Bioconductor repo?
-    if (identical(pkgRecord$version, currentVersion)) {
+    if (pkgRecord$name %in% rownames(availablePkgs) && identical(pkgRecord$version, currentVersion)) {
+
+
       # Get the source package
       # NOTE: we cannot use 'availablePkgs' as it might have been used to
       # generate an available package listing for _binary_ packages,


### PR DESCRIPTION
Try downloading archive versions when package is not available (older versions of package could be available).

Details:
When the current version of a package depends on some version of R, it is not returned by the function available.packages if you are running an older R version. However, an archive version of the package could be just fine. This is why I suggest that we should try downloading archive versions of unavailable packages.
Any thoughts about this ?