### PR TITLE
use devtools downloader when available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.6-15
+Version: 0.4.6-19
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, Aron Atkins, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Manage the R packages your project depends

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ Suggests:
 Enhances: BiocInstaller
 URL: https://github.com/rstudio/packrat/
 BugReports: https://github.com/rstudio/packrat/issues
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/R/downloader.R
+++ b/R/downloader.R
@@ -35,6 +35,14 @@
 #
 download <- function(url, method = inferAppropriateDownloadMethod(url), ...) {
 
+  # If this is a path to a GitHub URL, attempt to download with authentication,
+  # so that private GitHub repositories can be handled.
+  if (isGitHubURL(url) && canUseGitHubDownloader()) {
+    result <- try(githubDownload(url, ...), silent = TRUE)
+    if (!inherits(result, "try-error"))
+      return(result)
+  }
+
   # When on Windows using an 'internal' method, we need to call
   # 'setInternet2' to set some appropriate state.
   if (is.windows() && method == "internal") {

--- a/R/github.R
+++ b/R/github.R
@@ -1,0 +1,21 @@
+isGitHubURL <- function(url) {
+  is.string(url) && grepl("^http(?:s)?://www.github.com", url, perl = TRUE)
+}
+
+canUseGitHubDownloader <- function() {
+  result <- try(packageVersion("devtools"), silent = TRUE)
+  !inherits(result, "try-error") && result >= "1.9.1"
+}
+
+githubDownload <- function(url, destfile, ...) {
+  github_pat      <- yoink("devtools", "github_pat")
+  github_auth     <- yoink("devtools", "github_auth")
+  GET             <- yoink("httr", "GET")
+  content         <- yoink("httr", "content")
+
+  pat <- github_pat(quiet = TRUE)
+  auth <- github_auth(pat)
+  request <- GET(url, auth)
+  writeBin(content(request, "raw"), destfile)
+  if (file.exists(destfile)) 0 else 1
+}

--- a/R/github.R
+++ b/R/github.R
@@ -3,8 +3,7 @@ isGitHubURL <- function(url) {
 }
 
 canUseGitHubDownloader <- function() {
-  result <- try(packageVersion("devtools"), silent = TRUE)
-  !inherits(result, "try-error") && result >= "1.9.1"
+  all(packageVersionInstalled(devtools = "1.9.1", httr = "1.0.0"))
 }
 
 githubDownload <- function(url, destfile, ...) {

--- a/R/restore.R
+++ b/R/restore.R
@@ -176,7 +176,7 @@ getSourceForPkgRecord <- function(pkgRecord,
     on.exit({
       if (file.exists(srczip))
         unlink(srczip, recursive = TRUE)
-    })
+    }, add = TRUE)
 
     if (!downloadWithRetries(archiveUrl, destfile = srczip, quiet = TRUE, mode = "wb")) {
       message("FAILED")

--- a/R/utils.R
+++ b/R/utils.R
@@ -627,3 +627,18 @@ isUsingExternalTar <- function() {
 yoink <- function(package, symbol) {
   eval(call(":::", package, symbol))
 }
+
+enumerate <- function(list, fn) {
+  keys <- names(list)
+  values <- list
+  sapply(seq_along(keys), function(i) {
+    fn(keys[[i]], values[[i]])
+  })
+}
+
+packageVersionInstalled <- function(...) {
+  enumerate(list(...), function(package, version) {
+    result <- try(packageVersion(package), silent = TRUE)
+    !inherits(result, "try-error") && result >= version
+  })
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -622,3 +622,8 @@ isUsingExternalTar <- function() {
 
   TRUE
 }
+
+# sneakily get a function
+yoink <- function(package, symbol) {
+  eval(call(":::", package, symbol))
+}

--- a/inst/resources/init-rprofile.R
+++ b/inst/resources/init-rprofile.R
@@ -1,3 +1,3 @@
-#### -- Packrat Autoloader (version 0.4.6-15) -- ####
+#### -- Packrat Autoloader (version 0.4.6-19) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -178,7 +178,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- 'InstallAgent: packrat 0.4.6-15'
+    installAgent <- 'InstallAgent: packrat 0.4.6-19'
 
     ## -- InstallSource -- ##
     installSource <- 'InstallSource: source'

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -1,0 +1,17 @@
+context("GitHub")
+
+test_that("we can use devtools:::download to retrieve GitHub archives", {
+
+  skip("run manually for now")
+
+  if (!canUseDevtoolsDownloader())
+    skip("requires devtools")
+
+  url <- "https://github.com/rstudio/packrat/archive/cd0f9a4dae7ea0c79966b6784b44d7e4e4edadad.zip"
+  destination <- tempfile("packrat-test-gh-", fileext = ".zip")
+  result <- githubDownload(url, destination)
+  expect_true(result == 0)
+  expect_true(file.exists(destination))
+  unlink(destination)
+
+})


### PR DESCRIPTION
This PR modifies the packrat downloader to use `devtools::download()` when available.