### PR TITLE
detect Rmd dependencies based on custom output formats

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Suggests:
     testthat (>= 0.7),
     devtools,
     httr,
-    knitr
+    knitr,
+    rmarkdown
 Enhances: BiocInstaller
 URL: https://github.com/rstudio/packrat/
 BugReports: https://github.com/rstudio/packrat/issues

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -160,6 +160,15 @@ fileDependencies.Rmd <- function(file) {
 
   deps <- "rmarkdown"
 
+  # check whether the default output format references a package
+  if (requireNamespace("rmarkdown", quietly = TRUE)) {
+    format <- rmarkdown::default_output_format(file)
+    components <- strsplit(format$name, "::")[[1]]
+    if (length(components) == 2) {
+      deps <- c(deps, components[[1]])
+    }
+  }
+
   # We need to check for and parse YAML frontmatter if necessary
   yamlDeps <- NULL
   content <- readLines(file)


### PR DESCRIPTION
Currently if a custom output format from another package is used in an Rmd it is not detected as a dependency, e.g. for

```yaml
output: mypackage::myformat
```

`mypackage` is not detected as a dependency.

This PR calls into the `rmarkdown::default_output_format` function to determine if there is a custom format implemented within a package and adds that package to the dependencies.

Note that there is already some processing of the yaml within Rmd files however this is all based regular expressions and determining the default format would involve both much more complex parsing (using the yaml package) as well as doing a bunch of other resolution (e.g. looking for an `_output.yml` file in the Rmd file's directory) so it's much better to call into the rmarkdown package for this.

Note that 3 tests failed for me locally after applying this change but I'm not sure if I'm well equipped to diagnose whether this change caused the failures or not.

