### PR TITLE
Fixes bug #288 - symlinking windows on networked drives

### DIFF
--- a/R/library-support.R
+++ b/R/library-support.R
@@ -70,9 +70,13 @@ ensurePackageSymlink <- function(source, target) {
   # library corresponding to the current running
   # R session.
   if (file.exists(target)) {
-
-    if (isPathToSamePackage(source, target))
-      return(TRUE)
+    fail <- TRUE
+    try({
+      if (suppressWarnings(packrat:::isPathToSamePackage(source, target)))
+        return(TRUE)
+      fail <- FALSE
+    },TRUE)
+    if(fail) return(FALSE)
 
     # Remove the old symlink. Both junction points and symlinks
     # are safely removed with a simple, non-recursive unlink.


### PR DESCRIPTION
https://github.com/rstudio/packrat/issues/288

This is a windows problem.

R/RStudio is on the C drive, and my project folder is on a networked drive. Windows will not allow a symlink/junction between the two drives, so instead of having a bunch of links, such as: packrat/lib-R/base I have a bunch of empty folders named: packrat/lib-R/base. Thus when "isPathToSamePackage" is called, we try to read packrat/lib-R/base/DESCRIPTION (which does not exist) and an error happens. This results in killing packrat, instead of returning a "FALSE" like it should.

Another option would be to edit the function "isPathToSamePackage" and include a "if(!file.exists(lhsPath) | file.exists(rhsPath)){ return(FALSE) }" before the "readChar" commands.