### PR TITLE
Checking for failed symlinks

### DIFF
--- a/R/library-support.R
+++ b/R/library-support.R
@@ -105,7 +105,7 @@ ensurePackageSymlink <- function(source, target) {
   symlink(source, target)
 
   # Success if the file now exists
-  file.exists(target)
+  file.exists(file.path(target, "DESCRIPTION"))
 }
 
 symlinkExternalPackages <- function(project = NULL) {


### PR DESCRIPTION
In Windows, if the symlink fails (e.g. on a networked drive), an empty folder will be created. So by just checking if the folder exists, we aren't actually checking if the symlink was successful. We need to go inside the folder and see if the files actually exist like we expect them to.