### PR TITLE
use GitHub tarball API when downloading packages

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -13,7 +13,10 @@ githubDownload <- function(url, destfile, ...) {
   content         <- yoink("httr", "content")
 
   token <- github_pat(quiet = TRUE)
-  auth <- authenticate(token, "x-oauth-basic", "basic")
+  auth <- if (!is.null(token))
+    authenticate(token, "x-oauth-basic", "basic")
+  else
+    list()
   request <- GET(url, auth)
   writeBin(content(request, "raw"), destfile)
   if (file.exists(destfile)) 0 else 1

--- a/R/restore.R
+++ b/R/restore.R
@@ -195,7 +195,6 @@ getSourceForPkgRecord <- function(pkgRecord,
     else
       "https"
 
-    # TODO: construct paths using api.github.com as appropriate
     fmt <- "%s://api.github.com/repos/%s/%s/tarball/%s"
     archiveUrl <- sprintf(fmt, protocol, pkgRecord$gh_username, pkgRecord$gh_repo, pkgRecord$gh_sha1)
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -196,13 +196,8 @@ getSourceForPkgRecord <- function(pkgRecord,
       "https"
 
     # TODO: construct paths using api.github.com as appropriate
-    hostname <- "www.github.com"
-    path <- file.path(pkgRecord$gh_username,
-                      pkgRecord$gh_repo,
-                      "archive",
-                      join(pkgRecord$gh_sha1, ".tar.gz"))
-
-    archiveUrl <- join(protocol, "://", hostname, "/", path)
+    fmt <- "%s://api.github.com/repos/%s/%s/zipball/%s"
+    archiveUrl <- sprintf(fmt, protocol, pkgRecord$gh_username, pkgRecord$gh_repo, pkgRecord$gh_sha1)
 
     srczip <- tempfile(fileext = '.tar.gz')
     on.exit({

--- a/R/restore.R
+++ b/R/restore.R
@@ -196,7 +196,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       "https"
 
     # TODO: construct paths using api.github.com as appropriate
-    fmt <- "%s://api.github.com/repos/%s/%s/zipball/%s"
+    fmt <- "%s://api.github.com/repos/%s/%s/tarball/%s"
     archiveUrl <- sprintf(fmt, protocol, pkgRecord$gh_username, pkgRecord$gh_repo, pkgRecord$gh_sha1)
 
     srczip <- tempfile(fileext = '.tar.gz')

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -7,8 +7,8 @@ test_that("we can use devtools:::download to retrieve GitHub archives", {
   if (!canUseGitHubDownloader())
     skip("requires devtools")
 
-  url <- "https://github.com/rstudio/packrat/archive/cd0f9a4dae7ea0c79966b6784b44d7e4e4edadad.zip"
-  destination <- tempfile("packrat-test-gh-", fileext = ".zip")
+  url <- "https://api.github.com/repos/rstudio/packrat/tarball/cd0f9a4dae7ea0c79966b6784b44d7e4e4edadad"
+  destination <- tempfile("packrat-test-gh-", fileext = ".tar.gz")
   result <- githubDownload(url, destination)
   expect_true(result == 0)
   expect_true(file.exists(destination))


### PR DESCRIPTION
This PR modifies packrat to use GitHub API URLs when downloading packages, and tweaks some of the authentication code (to handle the case with no `GITHUB_PAT` set)