### PR TITLE
Don't write "ignore-file" unless the content actually changes

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -237,7 +237,7 @@ updateIgnoreFile <- function(project = NULL, file, add = NULL, remove = NULL) {
   ## If it already exists, add and remove as necessary, otherwise do nothing
   content <- readLines(path)
   newContent <- union(content, add)
-  newContent <- setdiff(content, remove)
+  newContent <- setdiff(newContent, remove)
   if (!setequal(content, newContent)) {
     cat(newContent, file = path, sep = "\n")
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -239,7 +239,7 @@ updateIgnoreFile <- function(project = NULL, file, add = NULL, remove = NULL) {
   newContent <- union(content, add)
   newContent <- setdiff(content, remove)
   if (!setequal(content, newContent)) {
-    cat(content, file = path, sep = "\n")
+    cat(newContent, file = path, sep = "\n")
   }
   return(invisible())
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -234,11 +234,13 @@ updateIgnoreFile <- function(project = NULL, file, add = NULL, remove = NULL) {
     return(invisible())
   }
 
-  ## If it already exists, add and remove as necessary
+  ## If it already exists, add and remove as necessary, otherwise do nothing
   content <- readLines(path)
-  content <- union(content, add)
-  content <- setdiff(content, remove)
-  cat(content, file = path, sep = "\n")
+  newContent <- union(content, add)
+  newContent <- setdiff(content, remove)
+  if (!setequal(content, newContent)) {
+    cat(content, file = path, sep = "\n")
+  }
   return(invisible())
 
 }


### PR DESCRIPTION
I'm using packrat to distribute an R script in a shared environment where users only need read access to the script and packrat library. This works well, but when the `.gitignore` file is only user-writeable things break:

```
$ chmod 755 .gitignore
$ su testuser
$ ##run R script##
Error in file(file, ifelse(append, "a", "w")) :
  cannot open the connection
  Calls: source ... updateSettings -> updateGitIgnore -> updateIgnoreFile -> cat -> file
  In addition: Warning message:
  In file(file, ifelse(append, "a", "w")) :
    cannot open file '.gitignore': Permission denied
    Execution halted
```
The content of the `.gitignore` file does not actually need to be updated:
```
$ cat .gitignore
packrat/lib*/
$ md5sum .gitignore
b8b019322d9d464c11f220816db44a76 .gitignore
$ chmod 766 .gitignore
$ su testuser
$ ##run R script##
$ cat .gitignore
packrat/lib*/
$ md5sum .gitignore
b8b019322d9d464c11f220816db44a76 .gitignore
```
This PR adds simple logic to determine if the ignoreFile needs to be updated at all, before opening the file as writeable.