### PR TITLE
set the repos option during restore so it is available downstream

### DIFF
--- a/R/packrat.R
+++ b/R/packrat.R
@@ -390,9 +390,17 @@ restore <- function(project = NULL,
     pkgsToIgnore <- dirtyPackageNames[!dirtyPackageNames %in% pkgNames(packages)]
   }
 
+  # Configure repos globally to avoid explicitly passing the repos list to all
+  # downstream function calls.
+  repos <- lockInfo(project, 'repos')
+  externalRepos <- getOption('repos')
+  options(repos = repos)
+  on.exit({
+    options(repos = externalRepos)
+    }, add = TRUE)
+
   # Install each package from CRAN or github, from binaries when available and
   # then from sources.
-  repos <- lockInfo(project, 'repos')
   restoreImpl(project, repos, packages, libDir,
               pkgsToIgnore = pkgsToIgnore, prompt = prompt,
               dry.run = dry.run,


### PR DESCRIPTION
This allows successful, repeated `packrat::restore` when using a private repository.

Builds on #315 

The one thing I dislike about this approach is that we have a mixture of `repos` passed as a function argument and `repos` available via `getOption("repos")`. This inconsistency can be confusing when reading through the code. It would be nice to shift to one model or the other.