### PR TITLE
messaging about enrolling packages in the package cache.

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -94,6 +94,10 @@ normalizeForHash <- function(item) {
   gsub("[[:space:]]", "", paste(unlist(item), collapse = ""))
 }
 
+isVerboseCache <- function() {
+  return(isTRUE(getOption("packrat.verbose.cache")))
+}
+
 moveInstalledPackageToCache <- function(packagePath, overwrite = TRUE) {
 
   # ensure cache directory
@@ -123,7 +127,9 @@ moveInstalledPackageToCache <- function(packagePath, overwrite = TRUE) {
     on.exit(unlink(backupPackagePath, recursive = TRUE), add = TRUE)
   }
 
-  message("Caching ", packageName, ".")
+  if (isVerboseCache()) {
+    message("Caching ", packageName, ".")
+  }
   
   # attempt to rename to cache
   if (suppressWarnings(file.rename(packagePath, cachedPackagePath)))
@@ -159,7 +165,9 @@ moveInstalledPackagesToCache <- function(project = NULL) {
 
   needsMove <- installedPkgPaths[sapply(installedPkgPaths, Negate(is.symlink))]
 
-  message("Promoting newly installed packages to the package cache.")
+  if (isVerboseCache()) {
+    message("Promoting newly installed packages to the package cache.")
+  }
 
   # for each package installed that is not a symlink, we migrate it to the cache
   for (package in needsMove) {

--- a/R/cache.R
+++ b/R/cache.R
@@ -123,6 +123,8 @@ moveInstalledPackageToCache <- function(packagePath, overwrite = TRUE) {
     on.exit(unlink(backupPackagePath, recursive = TRUE), add = TRUE)
   }
 
+  message("Caching ", packageName, ".")
+  
   # attempt to rename to cache
   if (suppressWarnings(file.rename(packagePath, cachedPackagePath)))
     return(cachedPackagePath)
@@ -157,9 +159,10 @@ moveInstalledPackagesToCache <- function(project = NULL) {
 
   needsMove <- installedPkgPaths[sapply(installedPkgPaths, Negate(is.symlink))]
 
+  message("Promoting newly installed packages to the package cache.")
+
   # for each package installed that is not a symlink, we migrate it to the cache
   for (package in needsMove) {
-
     # copy package into cache
     cachedPackagePath <- moveInstalledPackageToCache(package)
     symlink(normalizePath(cachedPackagePath, winslash = "/", mustWork = TRUE), package)


### PR DESCRIPTION
When there are lots of newly installed packages and they need to be added to
the package cache, promoting these packages to the cache can take lots of time
(due to #325). Add some messaging for transparency into this process.

Related to #325 (but does not address it)