### PR TITLE
use environment variables to track packrat state

### DIFF
--- a/R/env.R
+++ b/R/env.R
@@ -3,11 +3,25 @@ getenv <- function(x) {
   strsplit(Sys.getenv(x, unset = ""), .Platform$path.sep, fixed = TRUE)[[1]]
 }
 
-setenv <- function(name, value) {
-  value <- paste(value, collapse = .Platform$path.sep)
-  call <- list(value)
-  names(call) <- name
-  do.call(Sys.setenv, call)
+setenv <- function(...) {
+  dots <- list(...)
+
+  # validate argument length
+  n <- length(dots)
+  if (n %% 2 != 0)
+    stop("expected even number of arguments to 'setenv'")
+
+  # extract keys, values from '...'
+  indices <- seq(1, length(dots), by = 2)
+  keys <- dots[indices]
+  vals <- dots[indices + 1]
+
+  # construct call to Sys.setenv
+  names(vals) <- keys
+  vals <- lapply(vals, function(val) {
+    paste(val, collapse = .Platform$path.sep)
+  })
+  do.call(Sys.setenv, vals)
 }
 
 unsetenv <- function(name) {
@@ -16,6 +30,7 @@ unsetenv <- function(name) {
 
 # for autocompletion
 .packrat.env <- list(
+  "R_PACKRAT_PROJECT_DIR",
   "R_PACKRAT_DEFAULT_LIBPATHS",
   "R_PACKRAT_SYSTEM_LIBRARY",
   "R_PACKRAT_SITE_LIBRARY"

--- a/R/env.R
+++ b/R/env.R
@@ -31,6 +31,9 @@ unsetenv <- function(name) {
 # for autocompletion
 .packrat.env <- list(
   "R_PACKRAT_PROJECT_DIR",
+  "R_PACKRAT_SRC_DIR",
+  "R_PACKRAT_LIB_DIR",
+  "R_PACKRAT_CACHE_DIR",
   "R_PACKRAT_DEFAULT_LIBPATHS",
   "R_PACKRAT_SYSTEM_LIBRARY",
   "R_PACKRAT_SITE_LIBRARY"

--- a/R/packrat-mode.R
+++ b/R/packrat-mode.R
@@ -181,6 +181,9 @@ afterPackratModeOn <- function(project,
   mutables <- get(".packrat_mutables", envir = asNamespace("packrat"))
   mutables$set(state)
 
+  # Record the active project.
+  setenv(.packrat.env$R_PACKRAT_PROJECT_DIR, project)
+
   # Set the repositories
   repos <- lockInfo(project = project, property = "repos", fatal = FALSE)
   if (length(repos)) {
@@ -264,10 +267,9 @@ setPackratModeOff <- function(project = NULL,
 
   # Default back to the current working directory for packrat function calls
   .packrat_mutables$set(project = NULL)
-  .packrat_mutables$set(origLibPaths = NULL)
+  unsetenv(.packrat.env$R_PACKRAT_PROJECT_DIR)
 
   invisible(getLibPaths())
-
 }
 
 checkPackified <- function(project = NULL, quiet = FALSE) {

--- a/R/paths.R
+++ b/R/paths.R
@@ -29,16 +29,10 @@ getPackratDir <- function(project = NULL) {
 # -- unlikely since we encourage people to build from snapshots, but we leave it
 # possible)
 libDir <- function(project = NULL) {
-
-  envLibDir <- Sys.getenv("R_PACKRAT_LIB_DIR", unset = NA)
-  if (!is.na(envLibDir))
-    return(envLibDir)
-
-  project <- getProjectDir(project)
-  file.path(
-    libraryRootDir(project),
-    R.version$platform,
-    getRversion()
+  packratOption(
+    .packrat.env$R_PACKRAT_LIB_DIR,
+    "packrat.lib.dir",
+    file.path(libraryRootDir(project), R.version$platform, getRversion())
   )
 }
 
@@ -78,9 +72,10 @@ relOldLibraryDir <- function() {
 }
 
 srcDir <- function(project = NULL) {
-  Sys.getenv(
-    "R_PACKRAT_SRC_DIR",
-    unset = file.path(getPackratDir(project), "src")
+  packratOption(
+    .packrat.env$R_PACKRAT_SRC_DIR,
+    "packrat.src.dir",
+    file.path(getPackratDir(project), "src")
   )
 }
 
@@ -172,8 +167,11 @@ packrat_lib <- function() {
 
 ## A location where "global" packrat data is stored, e.g. the library cache
 appDataDir <- function() {
-  Sys.getenv("R_PACKRAT_CACHE_DIR",
-             unset = defaultAppDataDir())
+  packratOption(
+    .packrat.env$R_PACKRAT_CACHE_DIR,
+    "packrat.cache.dir",
+    defaultAppDataDir()
+  )
 }
 
 defaultAppDataDir <- function() {

--- a/R/paths.R
+++ b/R/paths.R
@@ -2,19 +2,13 @@
 
 getProjectDir <- function(project = NULL) {
 
-  ## If project is NULL, and .packrat$project is NULL, then we should look
-  ## in the current working directory
-  cachedDir <- .packrat_mutables$get("project")
-  if (is.null(project)) {
-    if (is.null(cachedDir)) {
-      project <- getwd()
-    } else {
-      project <- cachedDir
-    }
-  }
+  if (!is.null(project))
+    return(normalizePath(project, winslash = "/", mustWork = TRUE))
 
-  file.path(
-    normalizePath(project, winslash = "/", mustWork = TRUE)
+  packratOption(
+    .packrat.env$R_PACKRAT_PROJECT_DIR,
+    "packrat.project.dir",
+    normalizePath(project %||% getwd(), winslash = "/", mustWork = TRUE)
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -636,3 +636,16 @@ packageVersionInstalled <- function(...) {
     !inherits(result, "try-error") && result >= version
   })
 }
+
+packratOption <- function(envName, optionName, defaultValue) {
+
+  envValue <- Sys.getenv(envName, unset = NA)
+  if (!is.na(envValue))
+    return(envValue)
+
+  optionValue <- getOption(optionName)
+  if (!is.null(optionValue))
+    return(optionValue)
+
+  defaultValue
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,10 @@
 .onLoad <- function(libname, pkgname) {
-  setenv(.packrat.env$R_PACKRAT_DEFAULT_LIBPATHS, .libPaths())
-  setenv(.packrat.env$R_PACKRAT_SYSTEM_LIBRARY, .Library)
-  setenv(.packrat.env$R_PACKRAT_SITE_LIBRARY, .Library.site)
+  if (!length(getenv(.packrat.env$R_PACKRAT_DEFAULT_LIBPATHS)))
+    setenv(.packrat.env$R_PACKRAT_DEFAULT_LIBPATHS, .libPaths())
+
+  if (!length(getenv(.packrat.env$R_PACKRAT_SYSTEM_LIBRARY)))
+    setenv(.packrat.env$R_PACKRAT_SYSTEM_LIBRARY, .Library)
+
+  if (!length(getenv(.packrat.env$R_PACKRAT_SITE_LIBRARY)))
+    setenv(.packrat.env$R_PACKRAT_SITE_LIBRARY, .Library.site)
 }


### PR DESCRIPTION
This PR should help ensure that R processes launched while within packrat mode inherit the current packrat state (project paths, and so on).