### PR TITLE
Fall back to UTF-8 encoding on failure to determine format

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -161,9 +161,19 @@ fileDependencies.Rmd <- function(file) {
 
   deps <- "rmarkdown"
 
+  # we don't know this file's encoding, so presume the default encoding
+  encoding <- getOption("encoding")
+  format <- NULL
+
   # check whether the default output format references a package
   if (requireNamespace("rmarkdown", quietly = TRUE)) {
-    format <- rmarkdown::default_output_format(file)
+    tryCatch({
+      format <- rmarkdown::default_output_format(file)
+    }, error = function(e) {
+      # if we can't parse the YAML header with the default encoding, try UTF-8
+      encoding <<- "UTF-8"
+      format <<- rmarkdown::default_output_format(file, encoding)
+    })
     components <- strsplit(format$name, "::")[[1]]
     if (length(components) == 2) {
       deps <- c(deps, components[[1]])
@@ -172,7 +182,7 @@ fileDependencies.Rmd <- function(file) {
 
   # We need to check for and parse YAML frontmatter if necessary
   yamlDeps <- NULL
-  content <- readLines(file)
+  content <- readLines(file, encoding = encoding, warn = FALSE)
   if (hasYamlFrontMatter(content)) {
 
     # Extract the YAML frontmatter.
@@ -216,7 +226,6 @@ fileDependencies.Rmd <- function(file) {
     }
   }
 
-
   # Escape hatch for empty .Rmd files
   if (!length(content) || identical(unique(gsub("[[:space:]]", "", content, perl = TRUE)), "")) {
     return(deps)
@@ -237,7 +246,7 @@ fileDependencies.Rmd <- function(file) {
     tempfile <- tempfile()
     on.exit(unlink(tempfile))
     tryCatch(silent(
-      knitr::knit(file, output = tempfile, tangle = TRUE)
+      knitr::knit(file, output = tempfile, tangle = TRUE, encoding = encoding)
     ), error = function(e) {
       message("Unable to tangle file '", file, "'; cannot parse dependencies")
       character()


### PR DESCRIPTION
This fixes an issue on Windows with UTF-8 encoded R Markdown documents. Previously, we'd fail when attempting to determine their dependencies because `rmarkdown::default_output_format` requires the correct encoding, and cannot infer UTF-8. 

Now, we try the native encoding first, but when we can't parse the output format with the native encoding, we try UTF-8. 

NB: this is meant to address the most common failure mode; for a fully robust solution we could for instance laboriously try every encoding in `iconvlist()`, perhaps sorted by likelihood, until we got one that worked.