### PR TITLE
Strip code executed by alternate engines before parsing

### DIFF
--- a/tests/testthat/resources/alternate-engines.Rmd
+++ b/tests/testthat/resources/alternate-engines.Rmd
@@ -1,0 +1,18 @@
+---
+title: "Untitled"
+output: html_document
+---
+
+```{bash}
+echo "Shell we play a game?"
+```
+
+```{r}
+library(testthat)
+print("This code relies on testthat.")
+```
+
+```{bash}
+echo "I shell return."
+```
+

--- a/tests/testthat/resources/no-chunks.Rmd
+++ b/tests/testthat/resources/no-chunks.Rmd
@@ -1,0 +1,7 @@
+---
+title: "No Chunks"
+output: html_document
+---
+
+This R Markdown document does not have any chunks in it. It might as well be an
+ordinary Markdown document.

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -22,3 +22,10 @@ test_that("dependencies are properly resolved in expressions", {
   ))
 
 })
+
+
+test_that("dependencies are discovered in R Markdown documents using alternate engines", {
+  altEngineRmd <- file.path("resources", "alternate-engines.Rmd")
+  expect_true("testthat" %in% packrat:::fileDependencies(altEngineRmd))
+})
+

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -29,3 +29,13 @@ test_that("dependencies are discovered in R Markdown documents using alternate e
   expect_true("testthat" %in% packrat:::fileDependencies(altEngineRmd))
 })
 
+test_that("dependencies are discovered in R Markdown documents with R chunks", {
+  ordinaryRmd <- file.path("resources", "params-example.Rmd")
+  expect_true("rmarkdown" %in% packrat:::fileDependencies(ordinaryRmd))
+})
+
+test_that("dependencies are discovered in R Markdown documents with no chunks", {
+  chunklessRmd <- file.path("resources", "no-chunks.Rmd")
+  expect_true("rmarkdown" %in% packrat:::fileDependencies(chunklessRmd))
+})
+


### PR DESCRIPTION
This small change maintains compatibility with releases of knitr which do not have the very recent change https://github.com/yihui/knitr/commit/70986820cb5bec57b1d421ba8a74d5db8fcd410e. 

Prior to that change, knitr would emit non-R engine code verbatim into the tangled R file. This file would then become unparseable, which would in turn prevent Packrat from discovering dependencies in it. The fix here is elide the non-R code from the tangled R file prior to parsing it.