### PR TITLE
initial work on untrusted cache

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -265,3 +265,7 @@ packratCacheVersion <- function() {
 cacheLibDir <- function(...) {
   file.path(appDataDir(), packratCacheVersion(), "library", ...)
 }
+
+untrustedCacheLibDir <- function(...) {
+  file.path(appDataDir(), packratCacheVersion(), "library-client", ...)
+}

--- a/R/restore-routines.R
+++ b/R/restore-routines.R
@@ -91,7 +91,7 @@ restoreWithCopyFromUntrustedCache <- function(project,
   suppressWarnings(symlink(source, target))
   success <- file.exists(target)
   if (success) {
-    cacheCopyStatus$type <- "symlinked cache"
+    cacheCopyStatus$type <- "symlinked user cache"
     return(TRUE)
   }
 
@@ -102,11 +102,11 @@ restoreWithCopyFromUntrustedCache <- function(project,
   ))
 
   if (success) {
-    cacheCopyStatus$type <- "copied cache"
+    cacheCopyStatus$type <- "copied user cache"
     return(TRUE)
   }
 
   # failed to copy or symlink from cache; report warning and return false
-  warning("failed to symlink or copy package '", pkgRecord$name, "' from cache")
+  warning("failed to symlink or copy package '", pkgRecord$name, "' from user cache")
   return(FALSE)
 }

--- a/R/restore-routines.R
+++ b/R/restore-routines.R
@@ -1,3 +1,14 @@
+isTrustedPackage <- function(package) {
+  untrusted <- getOption("packrat.untrusted.packages", default = character())
+  !package %in% untrusted
+}
+
+hashTarball <- function(path) {
+  # TODO: unpack, recursively hash, and combine? for now
+  # we just hash the tarball as-is
+  tools::md5sum(files = normalizePath(path, mustWork = TRUE))
+}
+
 restoreWithCopyFromCache <- function(project,
                                      pkgRecord,
                                      cacheCopyStatus)
@@ -17,6 +28,61 @@ restoreWithCopyFromCache <- function(project,
 
   # ensure that the cache package path exists
   source <- cacheLibDir(pkgRecord$name, pkgRecord$hash, pkgRecord$name)
+  if (!file.exists(source))
+    return(FALSE)
+
+  # attempt to form a symlink to the packrat library
+  target <- file.path(libDir(project), pkgRecord$name)
+  suppressWarnings(symlink(source, target))
+  success <- file.exists(target)
+  if (success) {
+    cacheCopyStatus$type <- "symlinked cache"
+    return(TRUE)
+  }
+
+  # symlinking failed; attempt a copy from the cache to the target directory
+  success <- all(dir_copy(
+    cacheLibDir(pkgRecord$name, pkgRecord$hash),
+    file.path(libDir(project), pkgRecord$name)
+  ))
+
+  if (success) {
+    cacheCopyStatus$type <- "copied cache"
+    return(TRUE)
+  }
+
+  # failed to copy or symlink from cache; report warning and return false
+  warning("failed to symlink or copy package '", pkgRecord$name, "' from cache")
+  return(FALSE)
+}
+
+restoreWithCopyFromUntrustedCache <- function(project,
+                                              pkgRecord,
+                                              cacheCopyStatus)
+{
+  # don't copy from cache if disabled for this project
+  if (!isUsingCache(project))
+    return(FALSE)
+
+  # don't try to cache uncacheable packages (ie, packages that
+  # need to be reinstalled each time for whatever reason)
+  if (!isCacheable(pkgRecord$name))
+    return(FALSE)
+
+  # attempt to find source tarball associated with passed-in
+  # package record
+  tarballName <- sprintf("%s_%s.tar.gz", pkgRecord$name, pkgRecord$version)
+  tarballPath <- file.path(srcDir(project), tarballName)
+  if (!file.exists(tarballPath))
+    return(FALSE)
+
+  # attempt to hash tarball
+  hash <- hashTarball(tarballPath)
+  if (!is.character(hash))
+    return(FALSE)
+
+  # attempt to discover cached package in untrusted cache
+  source <- untrustedCacheLibDir(pkgRecord$name, hash, pkgRecord$name)
   if (!file.exists(source))
     return(FALSE)
 

--- a/R/restore-routines.R
+++ b/R/restore-routines.R
@@ -72,7 +72,7 @@ restoreWithCopyFromUntrustedCache <- function(project,
   # attempt to find source tarball associated with passed-in
   # package record
   tarballName <- sprintf("%s_%s.tar.gz", pkgRecord$name, pkgRecord$version)
-  tarballPath <- file.path(srcDir(project), tarballName)
+  tarballPath <- file.path(srcDir(project), pkgRecord$name, tarballName)
   if (!file.exists(tarballPath))
     return(FALSE)
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -526,7 +526,7 @@ installPkg <- function(pkgRecord,
     } else {
       pkgPath <- file.path(lib, pkgRecord$name)
       tarballName <- sprintf("%s_%s.tar.gz", pkgRecord$name, pkgRecord$version)
-      tarballPath <- file.path(srcDir(project), tarballName)
+      tarballPath <- file.path(srcDir(project), pkgRecord$name, tarballName)
       if (!file.exists(tarballPath)) {
         warning("cannot cache untrusted package: source tarball not available")
       } else {

--- a/R/restore.R
+++ b/R/restore.R
@@ -601,6 +601,8 @@ restoreImpl <- function(project,
   # optionally overlay the 'src' directory from a custom location
   overlaySourcePackages(srcDir(project))
 
+  discoverUntrustedPackages(srcDir(project))
+
   # We also ignore restores for packages specified in external.packages
   pkgsToIgnore <- c(
     pkgsToIgnore,
@@ -729,6 +731,12 @@ detachPackageForInstallationIfNecessary <- function(pkg) {
   defer(library(pkg, lib.loc = libPaths, character.only = TRUE), parent.frame())
 
   TRUE
+}
+
+discoverUntrustedPackages <- function(srcDir) {
+  if (is.na(Sys.getenv("RSTUDIO_CONNECT", unset = NA)))
+    return()
+  options(packrat.untrusted.packages = list.files(srcDir))
 }
 
 overlaySourcePackages <- function(srcDir, overlayDir = NULL) {

--- a/R/restore.R
+++ b/R/restore.R
@@ -405,6 +405,7 @@ installPkg <- function(pkgRecord,
     }
   }
 
+  # Try restoring the package from the global cache.
   cacheCopyStatus <- new.env(parent = emptyenv())
   copiedFromCache <- restoreWithCopyFromCache(project, pkgRecord, cacheCopyStatus)
   if (copiedFromCache) {
@@ -412,7 +413,14 @@ installPkg <- function(pkgRecord,
     needsInstall <- FALSE
   }
 
-  if (!(copiedFromCache) &&
+  # Try restoring the package from the 'unsafe' cache, if applicable.
+  copiedFromUntrustedCache <- restoreWithCopyFromUntrustedCache(project, pkgRecord, cacheCopyStatus)
+  if (copiedFromUntrustedCache) {
+    type <- cacheCopyStatus$type
+    needsInstall <- FALSE
+  }
+
+  if (!(copiedFromCache || copiedFromUntrustedCache) &&
         isFromCranlikeRepo(pkgRecord, repos) &&
         pkgRecord$name %in% rownames(availablePkgs) &&
         versionMatchesDb(pkgRecord, availablePkgs) &&
@@ -501,7 +509,35 @@ installPkg <- function(pkgRecord,
   # copy package into cache if enabled
   if (isUsingCache(project)) {
     pkgPath <- file.path(lib, pkgRecord$name)
-    moveInstalledPackageToCache(packagePath = pkgPath)
+
+    # copy into global cache if this is a trusted package
+    if (isTrustedPackage(pkgRecord$name)) {
+      descPath <- file.path(pkgPath, "DESCRIPTION")
+      if (!file.exists(descPath)) {
+        warning("cannot cache package: no DESCRIPTION file at path '", descPath, "'")
+      } else {
+        hash <- hash(descPath)
+        moveInstalledPackageToCache(
+          packagePath = pkgPath,
+          hash = hash,
+          cacheDir = cacheLibDir()
+        )
+      }
+    } else {
+      pkgPath <- file.path(lib, pkgRecord$name)
+      tarballName <- sprintf("%s_%s.tar.gz", pkgRecord$name, pkgRecord$version)
+      tarballPath <- file.path(srcDir(project), tarballName)
+      if (!file.exists(tarballPath)) {
+        warning("cannot cache untrusted package: source tarball not available")
+      } else {
+        hash <- hashTarball(tarballPath)
+        moveInstalledPackageToCache(
+          packagePath = pkgPath,
+          hash = hash,
+          cacheDir = untrustedCacheLibDir()
+        )
+      }
+    }
   }
 
   return(type)

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -305,8 +305,6 @@ snapshot <- function(project = NULL,
       }
     }
 
-    moveInstalledPackagesToCache(project)
-
     if (verbose) {
       message('Snapshot written to ',
               shQuote(normalizePath(lockFilePath(project), winslash = '/'))

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -10,18 +10,19 @@ test_that("package installation when configured with a a cache uses the cache", 
   projRoot <- cloneTestProject("healthy")
   libRoot <- file.path(projRoot, "packrat", "lib")
   srcRoot <- file.path(projRoot, "packrat", "src")
-  theCache <- tempdir()
+
+  theCache <- tempfile("packrat-cache-")
+  ensureDirectory(theCache)
+  Sys.setenv(R_PACKRAT_CACHE_DIR = theCache)
+  on.exit(Sys.unsetenv("R_PACKRAT_CACHE_DIR"), add = TRUE)
 
   init(projRoot, options = list(local.repos = "packages"), enter = FALSE)
 
   rv <- R.Version()
-  package_dir <- file.path(libDir(projRoot), "oatmeal")
+  packageDir <- file.path(libDir(projRoot), "oatmeal")
 
-  expect_true(file.exists(package_dir), package_dir)
-  expect_false(is.symlink(package_dir), package_dir)
-
-  Sys.setenv(R_PACKRAT_CACHE_DIR = theCache)
-  on.exit(Sys.unsetenv("R_PACKRAT_CACHE_DIR"), add = TRUE)
+  expect_true(file.exists(packageDir), packageDir)
+  expect_false(is.symlink(packageDir), packageDir)
 
   set_opts(project = projRoot, use.cache = TRUE)
   on.exit(set_opts(use.cache = FALSE, project = projRoot), add = TRUE)
@@ -37,8 +38,8 @@ test_that("package installation when configured with a a cache uses the cache", 
           prompt = FALSE,
           restart = FALSE)
 
-  expect_true(file.exists(package_dir), package_dir)
-  expect_true(is.symlink(package_dir), package_dir)
+  expect_true(file.exists(packageDir), packageDir)
+  expect_true(is.symlink(packageDir), packageDir)
 
   # Subsequent restore. Uses the cache.
   unlink(libRoot, recursive = TRUE)
@@ -48,6 +49,59 @@ test_that("package installation when configured with a a cache uses the cache", 
           prompt = FALSE,
           restart = FALSE)
 
-  expect_true(file.exists(package_dir), package_dir)
-  expect_true(is.symlink(package_dir), package_dir)
+  expect_true(file.exists(packageDir), packageDir)
+  expect_true(is.symlink(packageDir), packageDir)
+})
+
+test_that("packrat uses the untrusted cache when instructed", {
+  skip_on_cran()
+  skip_on_os("windows")
+
+  scopeTestContext()
+
+  projRoot <- cloneTestProject("healthy")
+  libRoot <- file.path(projRoot, "packrat", "lib")
+  srcRoot <- file.path(projRoot, "packrat", "src")
+
+  theCache <- tempfile("packrat-cache-")
+  ensureDirectory(theCache)
+  Sys.setenv(R_PACKRAT_CACHE_DIR = theCache)
+  on.exit(Sys.unsetenv("R_PACKRAT_CACHE_DIR"), add = TRUE)
+
+  options(packrat.untrusted.packages = "oatmeal")
+  on.exit(options(packrat.untrusted.packages = NULL), add = TRUE)
+
+  init(projRoot, options = list(local.repos = "packages"), enter = FALSE)
+
+  rv <- R.Version()
+  packageDir <- file.path(libDir(projRoot), "oatmeal")
+
+  expect_true(file.exists(packageDir), packageDir)
+  expect_false(is.symlink(packageDir), packageDir)
+
+  set_opts(project = projRoot, use.cache = TRUE)
+  on.exit(set_opts(use.cache = FALSE, project = projRoot), add = TRUE)
+
+  options(packrat.verbose.cache = TRUE)
+  on.exit(options(packrat.verbose.cache = FALSE), add = TRUE)
+
+  # Initial restore. Populates the cache and creates a symlink into it.
+  unlink(libRoot, recursive = TRUE)
+  restore(projRoot,
+          overwrite.dirty = TRUE,
+          prompt = FALSE,
+          restart = FALSE)
+
+  expect_true(file.exists(packageDir), packageDir)
+  expect_true(is.symlink(packageDir), packageDir)
+
+  # Subsequent restore. Uses the cache.
+  unlink(libRoot, recursive = TRUE)
+  restore(projRoot,
+          overwrite.dirty = TRUE,
+          prompt = FALSE,
+          restart = FALSE)
+
+  expect_true(file.exists(packageDir), packageDir)
+  expect_true(is.symlink(packageDir), packageDir)
 })

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -59,6 +59,10 @@ test_that("packrat uses the untrusted cache when instructed", {
 
   scopeTestContext()
 
+  # pretend that we're RStudio Connect
+  Sys.setenv(RSTUDIO_CONNECT = 1)
+  on.exit(Sys.unsetenv("RSTUDIO_CONNECT"), add = TRUE)
+
   projRoot <- cloneTestProject("healthy")
   libRoot <- file.path(projRoot, "packrat", "lib")
   srcRoot <- file.path(projRoot, "packrat", "src")
@@ -67,9 +71,6 @@ test_that("packrat uses the untrusted cache when instructed", {
   ensureDirectory(theCache)
   Sys.setenv(R_PACKRAT_CACHE_DIR = theCache)
   on.exit(Sys.unsetenv("R_PACKRAT_CACHE_DIR"), add = TRUE)
-
-  options(packrat.untrusted.packages = "oatmeal")
-  on.exit(options(packrat.untrusted.packages = NULL), add = TRUE)
 
   init(projRoot, options = list(local.repos = "packages"), enter = FALSE)
 


### PR DESCRIPTION
This PR implements an alternative cache source for untrusted client packages. The goal here is to allow users to deploy applications bundling their own package sources, but ensure that these package sources live in a separate cache from the 'global' cache (to avoid malicious users poisoning the cache).

The main way this works:

- The 'untrusted' cache lives as a separate directory inside the global cache directory,
- Hashes are produced from the source tarballs uploaded by the user,
- Otherwise, the same cache machinery stays in play.

Users of the untrusted cache will need to explicitly set the `packrat.untrusted.packages` R option, to signal to Packrat which packages that are about to be restored truly are untrusted.

cc: @trestletech. Main TODO here -- add some unit tests + confirm the 'untrusted' cache directory.