### PR TITLE
use an evaluate hook to discover rmd deps

### DIFF
--- a/tests/testthat/resources/evaluate-deps.Rmd
+++ b/tests/testthat/resources/evaluate-deps.Rmd
@@ -1,0 +1,15 @@
+
+```{r}
+library(abc)
+library(def)
+```
+
+```{r eval=FALSE}
+x + {}}
+```
+
+```{r}
+library(ghi)
+library(jkl)
+```
+

--- a/tests/testthat/test-rmarkdown.R
+++ b/tests/testthat/test-rmarkdown.R
@@ -12,3 +12,11 @@ test_that("Rmd documents with parameters are analyzed", {
   expect_true("shiny" %in% deps, "Rmd docs with parameters have a shiny dependency for the customization app")
   expect_true("stringr" %in% deps, "dependencies in parameter expressions are extracted")
 })
+
+test_that("We can discover dependencies with an evaluate hook", {
+
+  path <- "resources/evaluate-deps.Rmd"
+  deps <- fileDependencies.Rmd.evaluate(path)
+  expect_equal(deps, c("abc", "def", "ghi", "jkl"))
+
+})


### PR DESCRIPTION
This allows us to extract dependencies from R Markdown files that contain parse errors in some of their chunks.