### PR TITLE
Change to dir after checking name length.

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -180,10 +180,10 @@ unbundle <- function(bundle, where, ..., restore = TRUE) {
   dirName <- normalizePath(setdiff(list.files(), whereFiles), winslash = "/", mustWork = TRUE)
 
   if (restore) {
-    setwd(dirName)
     if (length(dirName) != 1) {
       stop("Couldn't infer top-level directory name; cannot perform automatic restore")
     }
+    setwd(dirName)
     ## Ensure the (empty) library directory is present before restoring
     dir.create(libDir(getwd()), recursive = TRUE, showWarnings = FALSE)
     message("- Restoring project library...")


### PR DESCRIPTION
If we try to change the working directory before checking the length of `dirName`, we don't get the right protection from problems working out the `dirName`. The call to `setwd` will fail with an argument of `character(0)`. We will get the following
```
Error in setwd(dirName) : character argument expected
```
rather than the error message "Couldn't infer top-level directory name..." as intended.