### PR TITLE
roll back non-recursive dependency search

### DIFF
--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -174,7 +174,7 @@ snapshot <- function(project = NULL,
                                      project = project,
                                      available = available,
                                      lib.loc = lib.loc,
-                                     recursive = FALSE)
+                                     recursive = TRUE)
 
   # For inferred packages (ie. packages within the code), we try to construct
   # records first from the lockfile, and then from other sources if possible


### PR DESCRIPTION
This PR fixes some issues noted by users where dependent packages did not have their associated `Requires:` field written out during `snapshot()`.

Fixes #391.