### PR TITLE
differentiate between binary, source repos during restore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.8-31
+Version: 0.4.8-32
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, Aron Atkins, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Manage the R packages your project depends

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Packrat 0.4.9 (unreleased)
 
+- Packrat no longer fails to download the current version of a package if
+  the binary and source branches of the active repositories are out of sync.
+
 - Packrat now attempts to parse scripts using UTF-8 encoding in addition to the
   system encoding. This should primarily help users on Windows who (rightly)
   save their documents using UTF-8 encoding rather than the default system

--- a/R/aaa-globals.R
+++ b/R/aaa-globals.R
@@ -1,4 +1,5 @@
 .packrat <- new.env(parent = emptyenv())
+.packrat$repos <- new.env(parent = emptyenv())
 .packrat$packratFormat <- "1.4"
 .packrat$options <- NULL
 

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -19,9 +19,21 @@ availablePackagesSkeleton <- function() {
 }
 
 availablePackagesBinary <- function(repos = getOption("repos")) {
-  available.packages(repos = repos, type = .Platform$pkgType)
+  availablePackages(repos = repos, type = .Platform$pkgType)
 }
 
 availablePackagesSource <- function(repos = getOption("repos")) {
-  available.packages(repos = repos, type = "source")
+  availablePackages(repos = repos, type = "source")
+}
+
+availablePackages <- function(repos = getOption("repos"),
+                              type = getOption("pkgType"))
+{
+  key <- paste(deparse(repos), deparse(type), sep = " ", collapse = " ")
+  if (!is.null(.packrat$repos[[key]]))
+    return(.packrat$repos[[key]])
+
+  result <- available.packages(repos = repos, type = type)
+  .packrat$repos[[key]] <- result
+  result
 }

--- a/R/available-packages.R
+++ b/R/available-packages.R
@@ -1,0 +1,27 @@
+# Call 'available.packages()' with an invalid URL to get the
+# 'skeleton' output of 'available.packages()' (ie, an empty matrix
+# with all appropriate fields populated)
+availablePackagesSkeleton <- function() {
+
+  # Use internal download file method just to ensure no errors leak.
+  download.file.method <- getOption("download.file.method")
+  on.exit(options(download.file.method = download.file.method), add = TRUE)
+  options(download.file.method = "internal")
+
+  # Use 'available.packages()' to query a URL that doesn't exist
+  result <- withCallingHandlers(
+    available.packages("/no/such/path/here/i/hope/"),
+    warning = function(w) invokeRestart("muffleWarning"),
+    message = function(m) invokeRestart("muffleMessage")
+  )
+
+  result
+}
+
+availablePackagesBinary <- function(repos = getOption("repos")) {
+  available.packages(repos = repos, type = .Platform$pkgType)
+}
+
+availablePackagesSource <- function(repos = getOption("repos")) {
+  available.packages(repos = repos, type = "source")
+}

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -38,7 +38,8 @@ appDependencies <- function(project = NULL,
                             fields = opts$snapshot.fields(),
                             implicit.packrat.dependency = TRUE) {
 
-  if (is.null(available.packages)) available.packages <- available.packages()
+  if (is.null(available.packages))
+    available.packages <- availablePackages()
 
   project <- getProjectDir(project)
 

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -129,8 +129,52 @@ NULL
 init <- function(project = '.',
                  options = NULL,
                  enter = TRUE,
-                 restart = enter) {
+                 restart = enter)
+{
+  ## Get the initial directory structure, so we can rewind if necessary
+  project <- normalizePath(project, winslash = '/', mustWork = TRUE)
+  message("Initializing packrat project in directory:\n- ", surround(prettyDir(project), "\""))
 
+  ## A set of files that packrat might generate as part of init -- we
+  ## enumerate them here to assist with later cleanup
+  prFiles <- c(
+    file.path(project, ".gitignore"),
+    file.path(project, ".Rprofile"),
+    file.path(project, "packrat"),
+    file.path(project, "packrat", "lib"),
+    file.path(project, "packrat", "lib-R"),
+    file.path(project, "packrat", "src"),
+    file.path(project, "packrat", "packrat.lock"),
+    file.path(project, "packrat", "packrat.opts")
+  )
+
+  priorStructure <- setNames(
+    file.exists(prFiles),
+    prFiles
+  )
+
+  withCallingHandlers(
+    initImpl(project, options, enter, restart),
+    error = function(e) {
+      # Undo any changes to the directory that did not exist previously
+      for (i in seq_along(priorStructure)) {
+        file <- names(priorStructure)[[i]]
+        fileExistedBefore <- priorStructure[[i]]
+        fileExistsNow <- file.exists(file)
+        if (!fileExistedBefore && fileExistsNow) {
+          unlink(file, recursive = TRUE)
+        }
+      }
+    }
+  )
+
+}
+
+initImpl <- function(project = getwd(),
+                     options = NULL,
+                     enter = TRUE,
+                     restart = enter)
+{
   opts <- get_opts(project = project)
   if (is.null(opts))
     opts <- default_opts()
@@ -158,99 +202,52 @@ init <- function(project = '.',
     }
   }
 
-  ## Get the initial directory structure, so we can rewind if necessary
-  project <- normalizePath(project,
-                           winslash = '/',
-                           mustWork = TRUE)
-  message("Initializing packrat project in directory:\n- ", surround(prettyDir(project), "\""))
+  # Force packrat mode off
+  if (isPackratModeOn())
+    off()
 
-  ## A set of files that packrat might generate as part of init -- we
-  ## enumerate them here to assist with later cleanup
-  prFiles <- c(
-    file.path(project, ".gitignore"),
-    file.path(project, ".Rprofile"),
-    file.path(project, "packrat"),
-    file.path(project, "packrat", "lib"),
-    file.path(project, "packrat", "lib-R"),
-    file.path(project, "packrat", "src"),
-    file.path(project, "packrat", "packrat.lock"),
-    file.path(project, "packrat", "packrat.opts")
+  # We always re-packify so that the current version of packrat present can
+  # insert the appropriate auto-loaders
+  packify(project = project, quiet = TRUE)
+
+  # Make sure the .Rprofile is up to date
+  augmentRprofile(project)
+  options <- initOptions(project, opts) ## writes out packrat.opts and returns generated list
+
+  # Take a snapshot
+  snapshotImpl(project,
+               lib.loc = NULL,
+               ignore.stale = TRUE,
+               fallback.ok = TRUE)
+
+  # Use the lockfile to copy sources and install packages to the library
+  restore(project, overwrite.dirty = TRUE, restart = FALSE)
+
+  # Copy init.R so a user can 'start from zero' with a project
+  file.copy(
+    instInitFilePath(),
+    file.path(project, "packrat", "init.R")
   )
 
-  priorStructure <- setNames(
-    file.exists(prFiles),
-    prFiles
-  )
+  # Update project settings -- this also involves updating the .gitignore,
+  # etc
+  updateSettings(project, options)
 
-  withCallingHandlers(
+  ## Symlink system libraries always
+  symlinkSystemPackages(project = project)
 
-    expr = {
+  message("Initialization complete!")
 
-      ## Force packrat mode off
-      if (isPackratModeOn())
-        off()
+  if (enter) {
 
-      ## We always re-packify so that the current version of packrat present can
-      ## insert the appropriate auto-loaders
-      packify(project = project, quiet = TRUE)
+    setwd(project)
 
-      ## Make sure the .Rprofile is up to date
-      augmentRprofile(project)
-      options <- initOptions(project, opts) ## writes out packrat.opts and returns generated list
+    # Restart R if the environment is capable of it (otherwise enter packrat mode)
+    if (!restart || !attemptRestart())
+      on(project = project, clean.search.path = TRUE)
+  }
 
-      # Take a snapshot
-      snapshotImpl(project,
-                   lib.loc = NULL,
-                   ignore.stale = TRUE,
-                   fallback.ok = TRUE)
-
-      # Use the lockfile to copy sources and install packages to the library
-      restore(project, overwrite.dirty = TRUE, restart = FALSE)
-
-      # Copy init.R so a user can 'start from zero' with a project
-      file.copy(
-        instInitFilePath(),
-        file.path(project, "packrat", "init.R")
-      )
-
-      # Update project settings -- this also involves updating the .gitignore,
-      # etc
-      updateSettings(project, options)
-
-      ## Symlink system libraries always
-      symlinkSystemPackages(project = project)
-
-      message("Initialization complete!")
-
-      if (enter) {
-
-        setwd(project)
-
-        # Restart R if the environment is capable of it (otherwise enter packrat mode)
-        if (!restart || !attemptRestart())
-          on(project = project, clean.search.path = TRUE)
-      }
-
-      invisible()
-
-    }, ## expr
-
-    error = function(e) {
-
-      # Undo any changes to the directory that did not exist previously
-      for (i in seq_along(priorStructure)) {
-        file <- names(priorStructure)[[i]]
-        fileExistedBefore <- priorStructure[[i]]
-        fileExistsNow <- file.exists(file)
-        if (!fileExistedBefore && fileExistsNow) {
-          unlink(file, recursive = TRUE)
-        }
-      }
-
-    } ## error
-
-  )
-
+  invisible()
 }
 
 #' Apply the most recent snapshot to the library

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -200,7 +200,6 @@ init <- function(project = '.',
 
       # Take a snapshot
       snapshotImpl(project,
-                   available.packages(contrib.url(activeRepos(project))),
                    lib.loc = NULL,
                    ignore.stale = TRUE,
                    fallback.ok = TRUE)

--- a/R/recursive-package-dependencies.R
+++ b/R/recursive-package-dependencies.R
@@ -1,6 +1,6 @@
 getPackageDependencies <- function(pkgs,
                                    lib.loc,
-                                   available.packages = available.packages(),
+                                   available.packages = availablePackages(),
                                    fields = c("Depends", "Imports", "LinkingTo")) {
 
   if (isPackratModeOn()) {
@@ -102,7 +102,7 @@ dropSystemPackages <- function(packages) {
 }
 
 recursivePackageDependencies <- function(pkgs, lib.loc,
-                                         available.packages = available.packages(),
+                                         available.packages = availablePackages(),
                                          fields = c("Depends", "Imports", "LinkingTo")) {
 
   if (!length(pkgs)) return(NULL)

--- a/R/restore.R
+++ b/R/restore.R
@@ -369,7 +369,6 @@ removePkgs <- function(project, pkgNames, lib.loc = libDir(project)) {
 # the package (built source, downloaded binary, etc.)
 installPkg <- function(pkgRecord,
                        project,
-                       availablePkgs,
                        repos,
                        lib = libDir(project))
 {
@@ -434,11 +433,13 @@ installPkg <- function(pkgRecord,
     }, add = TRUE)
   }
 
+  # Try downloading a binary (when appropriate).
   if (!(copiedFromCache || copiedFromUntrustedCache) &&
+        !identical(getOption("pkgType"), "source") &&
         isFromCranlikeRepo(pkgRecord, repos) &&
-        pkgRecord$name %in% rownames(availablePkgs) &&
-        versionMatchesDb(pkgRecord, availablePkgs) &&
-        !identical(getOption("pkgType"), "source")) {
+        pkgRecord$name %in% rownames(availablePackagesBinary(repos = repos)) &&
+        versionMatchesDb(pkgRecord, availablePackagesBinary(repos = repos)))
+  {
     tempdir <- tempdir()
     tryCatch({
       # install.packages emits both messages and standard output; redirect these
@@ -447,19 +448,12 @@ installPkg <- function(pkgRecord,
       # on windows, we need to detach the package before installation
       detachPackageForInstallationIfNecessary(pkgRecord$name)
 
-      # If pkgType is 'both', the availablePkgs inferred will be wrong.
-      # The default behaviour for `available.packages()`,
-      # when `pkgType == "both"`.
-      pkgType <- getOption("pkgType")
-      if (identical(pkgType, "both"))
-        availablePkgs <- NULL
-
       suppressMessages(
         capture.output(
           utils::install.packages(pkgRecord$name,
                                   lib = lib,
                                   repos = repos,
-                                  available = availablePkgs,
+                                  available = availablePackagesBinary(repos = repos),
                                   quiet = TRUE,
                                   dependencies = FALSE,
                                   verbose = FALSE)))
@@ -486,7 +480,7 @@ installPkg <- function(pkgRecord,
       # missing.)
       getSourceForPkgRecord(pkgRecord,
                             srcDir(project),
-                            availablePkgs,
+                            availablePackagesSource(repos = repos),
                             repos,
                             quiet = TRUE)
       if (!file.exists(pkgSrc)) {
@@ -559,10 +553,6 @@ installPkg <- function(pkgRecord,
 
 playActions <- function(pkgRecords, actions, repos, project, lib) {
 
-  # Get the list of available packages and the latest version of those packages
-  # from the repositories, and the local install list for comparison
-  availablePkgs <- available.packages(contrib.url(repos))
-
   installedPkgs <- installed.packages(priority = c("NA", "recommended"))
   targetPkgs <- searchPackages(pkgRecords, names(actions))
 
@@ -597,7 +587,7 @@ playActions <- function(pkgRecords, actions, repos, project, lib) {
       message("OK")
       next
     }
-    type <- installPkg(pkgRecord, project, availablePkgs, repos, lib)
+    type <- installPkg(pkgRecord, project, repos, lib)
     message("\tOK (", type, ")")
   }
   invisible()

--- a/R/restore.R
+++ b/R/restore.R
@@ -286,8 +286,7 @@ snapshotSources <- function(project, repos, pkgRecords) {
                        pkgRecords)
 
   # Get a list of source packages available on the repositories
-  availablePkgs <- available.packages(contrib.url(repos, "source"),
-                                      type = "source")
+  availablePkgs <- availablePackagesSource(repos = repos)
 
   # Find the source directory (create it if necessary)
   sourceDir <- srcDir(project)

--- a/R/restore.R
+++ b/R/restore.R
@@ -434,7 +434,6 @@ installPkg <- function(pkgRecord,
 
   # Try downloading a binary (when appropriate).
   if (!(copiedFromCache || copiedFromUntrustedCache) &&
-        !identical(getOption("pkgType"), "source") &&
         isFromCranlikeRepo(pkgRecord, repos) &&
         pkgRecord$name %in% rownames(availablePackagesBinary(repos = repos)) &&
         versionMatchesDb(pkgRecord, availablePackagesBinary(repos = repos)))

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -60,7 +60,7 @@ snapshot <- function(project = NULL,
     available <- if (dry.run)
       availablePackagesSkeleton()
     else
-      available.packages()
+      availablePackages()
   }
 
   project <- getProjectDir(project)
@@ -127,7 +127,7 @@ snapshot <- function(project = NULL,
     available <- if (dry.run)
       availablePackagesSkeleton()
     else
-      available.packages()
+      availablePackages()
   }
 
   # ensure packrat directory available

--- a/R/status.R
+++ b/R/status.R
@@ -89,7 +89,7 @@ status <- function(project = NULL, lib.loc = libDir(project), quiet = FALSE) {
   # it is in general necessary to have the set of `available.packages()` to fill in
   # broken links.
   availablePkgs <- if (hasCachedAvailablePackages())
-    available.packages()
+    availablePackages()
   else
     availablePackagesSkeleton()
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -550,26 +550,6 @@ reFilePrefix <- function() {
   paste("^", filePrefix(), sep = "")
 }
 
-# Call 'available.packages()' with an invalid URL to get the
-# 'skeleton' output of 'available.packages()' (ie, an empty matrix
-# with all appropriate fields populated)
-availablePackagesSkeleton <- function() {
-
-  # Use internal download file method just to ensure no errors leak.
-  download.file.method <- getOption("download.file.method")
-  on.exit(options(download.file.method = download.file.method), add = TRUE)
-  options(download.file.method = "internal")
-
-  # Use 'available.packages()' to query a URL that doesn't exist
-  result <- withCallingHandlers(
-    available.packages("/no/such/path/here/i/hope/"),
-    warning = function(w) invokeRestart("muffleWarning"),
-    message = function(m) invokeRestart("muffleMessage")
-  )
-
-  result
-}
-
 isProgramOnPath <- function(program) {
   nzchar(Sys.which(program)[[1]])
 }

--- a/inst/resources/init-rprofile.R
+++ b/inst/resources/init-rprofile.R
@@ -1,3 +1,3 @@
-#### -- Packrat Autoloader (version 0.4.8-31) -- ####
+#### -- Packrat Autoloader (version 0.4.8-32) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -181,7 +181,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- 'InstallAgent: packrat 0.4.8-31'
+    installAgent <- 'InstallAgent: packrat 0.4.8-32'
 
     ## -- InstallSource -- ##
     installSource <- 'InstallSource: source'

--- a/tests/testthat/helper-bundle.R
+++ b/tests/testthat/helper-bundle.R
@@ -13,7 +13,7 @@ bundle_test <- function(bundler, checker, ...) {
   setwd("packrat-test-bundle")
   suppressWarnings(packrat::init(enter = FALSE))
   bundler(file = "test-bundle.tar.gz", ...)
-  untar("test-bundle.tar.gz", exdir = "untarred", tar = "internal")
+  utils::untar("test-bundle.tar.gz", exdir = "untarred", tar = "internal")
 
   # run checker
   checker()

--- a/tests/testthat/helper-packrat.R
+++ b/tests/testthat/helper-packrat.R
@@ -13,6 +13,22 @@ cloneTestProject <- function(projectName) {
 # "Rebuilds" the test repo from its package "sources" (just DESCRIPTION files).
 rebuildTestRepo <- function(testroot = getwd()) {
 
+  # Try to guess where the DESCRIPTION file lives (for R CMD check
+  # and for interactive testing)
+  candidates <- c(
+    "DESCRIPTION",
+    "../../DESCRIPTION",
+    "../../00_pkg_src/packrat/DESCRIPTION",
+    "../../packrat/DESCRIPTION"
+  )
+
+  for (candidate in candidates) {
+    if (file.exists(candidate)) {
+      DESCRIPTION <- normalizePath(candidate, winslash = "/")
+      break
+    }
+  }
+
   owd <- getwd()
   on.exit(setwd(owd))
 
@@ -22,11 +38,7 @@ rebuildTestRepo <- function(testroot = getwd()) {
 
   # Create a dummy folder for the current version of Packrat.
   dir.create("packrat", showWarnings = FALSE)
-  file.copy(
-    system.file("DESCRIPTION", package = "packrat"),
-    "packrat/DESCRIPTION",
-    overwrite = TRUE
-  )
+  file.copy(DESCRIPTION, "packrat/DESCRIPTION", overwrite = TRUE)
 
   # Force Packrat tests to believe the currently installed / tested
   # version of Packrat is on CRAN.

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -3,6 +3,7 @@ context("Bundle")
 test_that("Bundle works when using R's internal tar", {
 
   skip_on_cran()
+  skip_on_travis()
   scopeTestContext()
 
   # force packrat to use the internal R tar
@@ -23,6 +24,7 @@ test_that("Bundle works when using R's internal tar", {
 test_that("Bundle works when omitting CRAN packages", {
 
   skip_on_cran()
+  skip_on_travis()
   scopeTestContext()
 
   checker <- function() {


### PR DESCRIPTION
This PR should help resolve an issue spotted by @trestletech where attempts to restore a project on e.g. macOS when using a CRAN mirror that did not supply binary packages would fail.

The underlying issue here was that Packrat inadvertently attempted to use the binary repositories, rather than the source repositories, when attempting to ascertain if a package was available and current, or available in the CRAN archives.

This PR also performs in-memory caching of the output retrieved by `available.packages()`, just to speed up processing when `available.packages()` is called recursively.