### PR TITLE
Inference of dependencies optional on initialisation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Packrat 0.4.9 (unreleased)
 
+- The infer.dependencies argument can now be used to switch off the scanning of 
+  code for dependencies when using packrat::init and packrat::snapshot.
+
 - Packrat no longer fails to download the current version of a package if
   the binary and source branches of the active repositories are out of sync.
 

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -129,7 +129,8 @@ NULL
 init <- function(project = '.',
                  options = NULL,
                  enter = TRUE,
-                 restart = enter)
+                 restart = enter,
+                 infer.dependencies = TRUE)
 {
   ## Get the initial directory structure, so we can rewind if necessary
   project <- normalizePath(project, winslash = '/', mustWork = TRUE)
@@ -154,7 +155,7 @@ init <- function(project = '.',
   )
 
   withCallingHandlers(
-    initImpl(project, options, enter, restart),
+    initImpl(project, options, enter, restart, infer.dependencies),
     error = function(e) {
       # Undo any changes to the directory that did not exist previously
       for (i in seq_along(priorStructure)) {
@@ -173,7 +174,8 @@ init <- function(project = '.',
 initImpl <- function(project = getwd(),
                      options = NULL,
                      enter = TRUE,
-                     restart = enter)
+                     restart = enter,
+                     infer.dependencies = TRUE)
 {
   opts <- get_opts(project = project)
   if (is.null(opts))
@@ -218,7 +220,8 @@ initImpl <- function(project = getwd(),
   snapshotImpl(project,
                lib.loc = NULL,
                ignore.stale = TRUE,
-               fallback.ok = TRUE)
+               fallback.ok = TRUE,
+               infer.dependencies = infer.dependencies)
 
   # Use the lockfile to copy sources and install packages to the library
   restore(project, overwrite.dirty = TRUE, restart = FALSE)
@@ -393,7 +396,7 @@ restore <- function(project = NULL,
   options(repos = repos)
   on.exit({
     options(repos = externalRepos)
-    }, add = TRUE)
+  }, add = TRUE)
 
   # Install each package from CRAN or github, from binaries when available and
   # then from sources.
@@ -589,4 +592,3 @@ lockInfo <- function(project, property='packages', fatal=TRUE) {
   }
   readLockFile(lockFilePath)[[property]]
 }
-

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -82,7 +82,8 @@ NULL
 #' \enumerate{
 #'
 #' \item Application dependencies are computed by examining the \R code
-#' throughout the project for \code{library} and \code{require} calls.
+#' throughout the project for \code{library} and \code{require} calls (note this step can be
+#' switched off by setting infer.dependencies = FALSE).
 #'
 #' \item A snapshot is taken of the version of each package currently used by
 #' the project as described in \code{\link{snapshot}}, and each package's
@@ -110,6 +111,8 @@ NULL
 #'   \code{\link{packrat-options}}.
 #' @param enter Boolean, enter packrat mode for this project after finishing a init?
 #' @param restart If \code{TRUE}, restart the R session after init.
+#' @param infer.dependencies If \code{TRUE}, infer package dependencies by
+#'   examining the \R code.
 #'
 #' @note
 #'

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -52,7 +52,8 @@ snapshot <- function(project = NULL,
                      ignore.stale = FALSE,
                      dry.run = FALSE,
                      prompt = interactive(),
-                     snapshot.sources = TRUE)
+                     snapshot.sources = TRUE,
+                     infer.dependencies = TRUE)
 {
 
   if (is.null(available))
@@ -83,7 +84,8 @@ snapshot <- function(project = NULL,
                                  dry.run,
                                  ignore.stale = ignore.stale,
                                  prompt = prompt && !dry.run,
-                                 snapshot.sources = snapshot.sources)
+                                 snapshot.sources = snapshot.sources,
+                                 infer.dependencies = infer.dependencies)
 
   if (dry.run)
     return(invisible(snapshotResult))
@@ -162,6 +164,7 @@ snapshot <- function(project = NULL,
   ignore <- c(ignore, c("manipulate", "rstudio"))
 
   libPkgs <- setdiff(list.files(libDir(project)), ignore)
+
   if (infer.dependencies) {
     inferredPkgs <- sort_c(appDependencies(project,
                                            available.packages = available,

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -25,6 +25,8 @@
 #'   being present in the last snapshot.
 #' @param snapshot.sources Boolean; should package sources be downloaded during
 #'   snapshot?
+#' @param infer.dependencies If \code{TRUE}, infer package dependencies by
+#'   examining the \R code.
 #'
 #' @note \code{snapshot} modifies the project's \code{packrat.lock} file, and
 #' the sources stored in the project's \code{packrat/src} directory. If you
@@ -109,6 +111,8 @@ snapshot <- function(project = NULL,
 #'   dependency of this project, if not otherwise discovered? This should be
 #'   \code{FALSE} only if you can guarantee that \code{packrat} will be available
 #'   via other means when attempting to load this project.
+#' @param infer.dependencies If \code{TRUE}, infer package dependencies by
+#'   examining the \R code.
 #' @keywords internal
 #' @rdname snapshotImpl
 #' @export

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -120,7 +120,8 @@ snapshot <- function(project = NULL,
                           verbose = TRUE,
                           fallback.ok = FALSE,
                           snapshot.sources = TRUE,
-                          implicit.packrat.dependency = TRUE) {
+                          implicit.packrat.dependency = TRUE,
+                          infer.dependencies = TRUE) {
 
   if (is.null(available))
   {
@@ -161,9 +162,14 @@ snapshot <- function(project = NULL,
   ignore <- c(ignore, c("manipulate", "rstudio"))
 
   libPkgs <- setdiff(list.files(libDir(project)), ignore)
-  inferredPkgs <- sort_c(appDependencies(project,
-                                         available.packages = available,
-                                         implicit.packrat.dependency = implicit.packrat.dependency))
+  if (infer.dependencies) {
+    inferredPkgs <- sort_c(appDependencies(project,
+                                           available.packages = available,
+                                           implicit.packrat.dependency = implicit.packrat.dependency))
+  } else {
+    # packrat is always a dependency
+    inferredPkgs <- 'packrat'
+  }
 
   inferredPkgsNotInLib <- setdiff(inferredPkgs, libPkgs)
 

--- a/man/init.Rd
+++ b/man/init.Rd
@@ -4,7 +4,8 @@
 \alias{init}
 \title{Initialize Packrat on a new or existing \R project}
 \usage{
-init(project = ".", options = NULL, enter = TRUE, restart = enter)
+init(project = ".", options = NULL, enter = TRUE, restart = enter,
+  infer.dependencies = TRUE)
 }
 \arguments{
 \item{project}{The directory that contains the \R project.}
@@ -15,6 +16,9 @@ init(project = ".", options = NULL, enter = TRUE, restart = enter)
 \item{enter}{Boolean, enter packrat mode for this project after finishing a init?}
 
 \item{restart}{If \code{TRUE}, restart the R session after init.}
+
+\item{infer.dependencies}{If \code{TRUE}, infer package dependencies by
+examining the \R code.}
 }
 \description{
 Given a project directory, makes a new packrat project in the directory.
@@ -25,7 +29,8 @@ Given a project directory, makes a new packrat project in the directory.
 \enumerate{
 
 \item Application dependencies are computed by examining the \R code
-throughout the project for \code{library} and \code{require} calls.
+throughout the project for \code{library} and \code{require} calls (note this step can be
+switched off by setting infer.dependencies = FALSE).
 
 \item A snapshot is taken of the version of each package currently used by
 the project as described in \code{\link{snapshot}}, and each package's

--- a/man/snapshot.Rd
+++ b/man/snapshot.Rd
@@ -6,7 +6,7 @@
 \usage{
 snapshot(project = NULL, available = NULL, lib.loc = libDir(project),
   ignore.stale = FALSE, dry.run = FALSE, prompt = interactive(),
-  snapshot.sources = TRUE)
+  snapshot.sources = TRUE, infer.dependencies = TRUE)
 }
 \arguments{
 \item{project}{The project directory. Defaults to current working
@@ -37,6 +37,9 @@ being present in the last snapshot.}
 
 \item{snapshot.sources}{Boolean; should package sources be downloaded during
 snapshot?}
+
+\item{infer.dependencies}{If \code{TRUE}, infer package dependencies by
+examining the \R code.}
 }
 \description{
 Finds the packages in use in the project, and stores a list

--- a/man/snapshotImpl.Rd
+++ b/man/snapshotImpl.Rd
@@ -7,7 +7,8 @@
 .snapshotImpl(project, available = NULL, lib.loc = libDir(project),
   dry.run = FALSE, ignore.stale = FALSE, prompt = interactive(),
   auto.snapshot = FALSE, verbose = TRUE, fallback.ok = FALSE,
-  snapshot.sources = TRUE, implicit.packrat.dependency = TRUE)
+  snapshot.sources = TRUE, implicit.packrat.dependency = TRUE,
+  infer.dependencies = TRUE)
 }
 \arguments{
 \item{project}{The project directory. Defaults to current working
@@ -51,6 +52,9 @@ package?}
 dependency of this project, if not otherwise discovered? This should be
 \code{FALSE} only if you can guarantee that \code{packrat} will be available
 via other means when attempting to load this project.}
+
+\item{infer.dependencies}{If \code{TRUE}, infer package dependencies by
+examining the \R code.}
 }
 \description{
 This is the internal implementation for \code{\link{snapshot}}. Most users

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -28,6 +28,22 @@ withTestContext({
     expect_true(file.exists(file.path(lib, "toast")))
   })
 
+  test_that("init does not install dependencies when infer.dependencies is false", {
+    skip_on_cran()
+    projRoot <- cloneTestProject("sated")
+    init(enter = FALSE, projRoot, options = list(local.repos = "packages"),
+         infer.dependencies=FALSE)
+    lib <- libDir(projRoot)
+    expect_true(file.exists(lockFilePath(projRoot)))
+    expect_true(file.exists(srcDir(projRoot)))
+    expect_true(file.exists(libDir(projRoot)))
+    expect_false(file.exists(file.path(lib, "breakfast")))
+    expect_false(file.exists(file.path(lib, "bread")))
+    expect_false(file.exists(file.path(lib, "oatmeal")))
+    expect_true(file.exists(file.path(lib, "packrat")))
+    expect_false(file.exists(file.path(lib, "toast")))
+  })
+
   test_that("restore ignores dirty packages", {
     skip_on_cran()
     projRoot <- cloneTestProject("carbs")
@@ -80,6 +96,31 @@ withTestContext({
     expect_true("bread" %in% pkgs)
     expect_true("toast" %in% pkgs)
   })
+
+  test_that("snapshot captures new installed dependecies but not
+            inferred dependencies when infer.dependencies is FALSE", {
+              skip_on_cran()
+              projRoot <- cloneTestProject("healthy")
+              lib <- libDir(projRoot)
+              init(enter = FALSE, projRoot, options = list(local.repos = "packages"))
+
+              # Simulate the addition of a dependency
+              expect_false(file.exists(file.path(lib, "bread")))
+              expect_false(file.exists(file.path(lib, "toast")))
+              installTestPkg("bread", "1.0.0", lib)
+              addTestDependency(projRoot, "toast")  # toast depends on bread
+              expect_true(file.exists(file.path(lib, "bread")))
+
+              # Snapshot the new state and make sure we picked up both toast and its
+              # dependency, bread
+              pkgs <- pkgNames(lockInfo(projRoot))
+              expect_false("bread" %in% pkgs)
+              expect_false("toast" %in% pkgs)
+              snapshot(projRoot, infer.dependencies = FALSE)
+              pkgs <- pkgNames(lockInfo(projRoot))
+              expect_true("bread" %in% pkgs)
+              expect_false("toast" %in% pkgs)
+})
 
   test_that("dependencies in library directories are ignored", {
     skip_on_cran()

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -81,9 +81,7 @@ withTestContext({
     expect_false(file.exists(file.path(lib, "bread")))
     expect_false(file.exists(file.path(lib, "toast")))
     installTestPkg("bread", "1.0.0", lib)
-    installTestPkg("toast", "1.0.0", lib)
     addTestDependency(projRoot, "toast")  # toast depends on bread
-    expect_true(file.exists(file.path(lib, "toast")))
     expect_true(file.exists(file.path(lib, "bread")))
 
     # Snapshot the new state and make sure we picked up both toast and its


### PR DESCRIPTION
Hello,

This is to allow a packrat project to be initialised without searching the code for dependencies. It is useful to have more control of what package versions etc are installed when initialising packrat for a work in progress project.

I think this would close https://github.com/rstudio/packrat/issues/258.

To do this an `infer.dependencies` argument has been added to the `init` function (and also `snapshot` as this could be useful as well).

Tests all pass and an additional test has been added.

I've sanity checked by initialising a new project with the new argument and without it.

(Also, thanks for creating and maintaining packrat!)
