### PR TITLE
retry download.packages and stop if nothing is downloaded

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.8-47
+Version: 0.4.8-48
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, Aron Atkins, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Manage the R packages your project depends

--- a/R/downloader.R
+++ b/R/downloader.R
@@ -159,6 +159,29 @@ canUseLibCurlDownloadMethod <- function() {
 }
 
 
+# Attempt download.packages multiple times.
+#
+# Assumes we are downloading a single package.
+downloadPackagesWithRetries <- function(name, destdir, repos, type, maxTries = 5L) {
+  maxTries <- as.integer(maxTries)
+  stopifnot(maxTries > 0L)
+  stopifnot(length(name) > 0L)
+
+  fileLoc <- matrix(character(), 0L, 2L)
+  for (i in 1:maxTries) {
+    fileLoc <- download.packages(name,
+                                 destdir = destdir,
+                                 repos = repos,
+                                 type = type,
+                                 quiet = TRUE)
+    if (nrow(fileLoc)) {
+      break
+    }
+  }
+  fileLoc
+}
+
+
 # Download from a URL with a certain number of retries -- returns TRUE
 # if the download succeeded, and FALSE otherwise
 downloadWithRetries <- function(url, ..., maxTries = 5L) {
@@ -207,11 +230,11 @@ inferAppropriateDownloadMethod <- function(url) {
   if (is.linux() || is.mac() || isSecureWebProtocol)
     return(secureDownloadMethod())
 
-  
+
   # Use "wininet" as default for R >= 3.2
   if (is.windows() && getRversion() >= "3.2")
     return("wininet")
-  
+
   # default
   return("internal")
 }

--- a/R/restore.R
+++ b/R/restore.R
@@ -145,14 +145,14 @@ getSourceForPkgRecord <- function(pkgRecord,
       # generate an available package listing for _binary_ packages,
       # rather than source packages. Leave it NULL and let R do the
       # right thing
-      fileLoc <- download.packages(pkgRecord$name,
-                                   destdir = pkgSrcDir,
-                                   repos = repos,
-                                   type = "source",
-                                   quiet = TRUE)
-      if (!nrow(fileLoc))
-        warning("Failed to download current version of ", pkgRecord$name,
-                "(", pkgRecord$version, ")")
+      fileLoc <- downloadPackagesWithRetries(pkgRecord$name,
+                                             destdir = pkgSrcDir,
+                                             repos = repos,
+                                             type = "source")
+      if (!nrow(fileLoc)) {
+        stop("Failed to download current version of ", pkgRecord$name,
+             "(", pkgRecord$version, ")")
+        }
 
       # If the file wasn't saved to the destination directory (which can happen
       # if the repo is local--see documentation in download.packages), copy it


### PR DESCRIPTION
The `fileLoc` error was caused by a failed package download. We trapped for that failed download but only triggered a `warning` instead of `stop`. This change retries `download.packages` (modeled after `downloadWithRetries`) and stops if the retried download results in no `fileLoc` rows.

fixes #404
