### PR TITLE
Tell packrat not to look for dependencies in certain directories

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -122,6 +122,27 @@ dirDependencies <- function(dir) {
   packratDirRegex <- "(?:^|/)packrat"
   R_files <- grep(packratDirRegex, R_files, invert = TRUE, value = TRUE)
 
+  ## Avoid anything on the list of ignored directories
+  ignoredDir <- get_opts("ignored.directories")
+  if (length(ignoredDir) > 0) {
+    # Make sure all the directories end with a slash...
+    ignoredDir <- ifelse(
+      substr(ignoredDir, nchar(ignoredDir), nchar(ignoredDir)) != "/",
+      paste0(ignoredDir, "/"),
+      ignoredDir
+    )
+
+    # Make a regex to match any of them.
+    ignoredDirRegex <- paste0(
+      "(?:^",
+      paste0(
+        ignoredDir,
+        collapse=")|(?:^"
+      ),
+      ")"
+    )
+    R_files <- grep(ignoredDirRegex, R_files, invert = TRUE, value = TRUE)
+  }
 
   sapply(R_files, function(file) {
     filePath <- file.path(dir, file)

--- a/R/options.R
+++ b/R/options.R
@@ -18,6 +18,9 @@ VALID_OPTIONS <- list(
   ignored.packages = function(x) {
     is.null(x) || is.character(x)
   },
+  ignored.directories = function(x) {
+    is.null(x) || is.character(x)
+  },
   quiet.package.installation = list(TRUE, FALSE),
   snapshot.recommended.packages = list(TRUE, FALSE),
   snapshot.fields = function(x) {
@@ -36,6 +39,7 @@ default_opts <- function() {
     local.repos = NULL,
     load.external.packages.on.startup = TRUE,
     ignored.packages = NULL,
+    ignored.directories = c("data", "inst"),
     quiet.package.installation = TRUE,
     snapshot.recommended.packages = FALSE,
     snapshot.fields = c("Imports", "Depends", "LinkingTo")
@@ -90,6 +94,14 @@ initOptions <- function(project = NULL, options = default_opts()) {
 ##'   Prevent packrat from tracking certain packages. Dependencies of these packages
 ##'   will also not be tracked (unless these packages are encountered as dependencies
 ##'   in a separate context from the ignored package).
+##'   (character; empty by default)
+##' \item \code{ignored.directories}:
+##'   Prevent packrat from looking for dependencies inside certain directories of your
+##'   workspace. For example, if you have set your "local.repos" to be inside your local
+##'   workspace so that you can track custom packages as git submodules.
+##'   Each item should be the relative path to a directory in the workspace, e.g. "data",
+##'   "lib/gitsubmodule". Note that packrat already ignores any "invisible" files and
+##'   directories, such as those whose names start with a "." character.
 ##'   (character; empty by default)
 ##' \item \code{quiet.package.installation}:
 ##'   Emit output during package installation?

--- a/tests/testthat/projects/partlyignored/ignoreme/ignorethis.R
+++ b/tests/testthat/projects/partlyignored/ignoreme/ignorethis.R
@@ -1,0 +1,1 @@
+library(toast)

--- a/tests/testthat/projects/partlyignored/notignored.R
+++ b/tests/testthat/projects/partlyignored/notignored.R
@@ -1,0 +1,1 @@
+library(bread)

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -134,6 +134,18 @@ withTestContext({
     expect_false(file.exists(file.path(lib, "oatmeal")))
   })
 
+  test_that("dependencies in \"ignored.directories\" are ignored", {
+    skip_on_cran()
+    projRoot <- cloneTestProject("partlyignored")
+    lib <- libDir(projRoot)
+    init(enter = FALSE, projRoot, options = list(ignored.directories="ignoreme"))
+
+    # This test project has a file called notignored.R that depends on bread, and
+    # another file called ignoreme/ignorethis.R that depends on toast.
+    expect_true(file.exists(file.path(lib, "bread")))
+    expect_false(file.exists(file.path(lib, "toast")))
+  })
+
   test_that("clean removes libraries and sources", {
     skip_on_cran()
     projRoot <- cloneTestProject("smallbreakfast")


### PR DESCRIPTION
This pull request adds a new option `ignore.directories`, that will tell packrat not to scan for dependencies in the R code in those directories.

My personal use-case for this, is that I have copies of some older reports in my project's git repository. They're useful for reference purposes, but I don't want their dependencies installed, and I don't want to see the warning about them being untracked every time I do `packrat::status()`.

When I was searching the Internet to see if there was an existing solution for this, I found that a second use-case is if a project has a very large amount of files in the `./data` directory, in which case it takes packrat a long time to scan them.