### PR TITLE
Fix invalid getwd() while retrieving quiet.package.installation()

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -61,13 +61,13 @@ bundles_dir <- function(project = NULL) {
 
 getProjectDir <- function(project = NULL) {
 
-  if (!is.null(project))
+  if (!is.null(project) && length(project) > 0)
     return(normalizePath(project, winslash = "/", mustWork = TRUE))
 
   packratOption(
     "R_PACKRAT_PROJECT_DIR",
     "packrat.project.dir",
-    normalizePath(getwd(), winslash = "/", mustWork = TRUE)
+    if (length(getwd()) > 0) normalizePath(getwd(), winslash = "/", mustWork = TRUE) else ""
   )
 }
 


### PR DESCRIPTION
Hit invalid `getwd()` under `packrat::opts$quiet.package.installation()` while troubleshooting `cloudml`:

<img width="1040" alt="screen shot 2017-11-20 at 12 25 23 pm" src="https://user-images.githubusercontent.com/3478847/33041999-265a998e-cdf5-11e7-945f-07f12ac6fa06.png">
