### PR TITLE
restoreWithCopyFromCache to check for dir not file

### DIFF
--- a/R/restore-routines.R
+++ b/R/restore-routines.R
@@ -28,7 +28,7 @@ restoreWithCopyFromCache <- function(project,
 
   # ensure that the cache package path exists
   source <- cacheLibDir(pkgRecord$name, pkgRecord$hash, pkgRecord$name)
-  if (!dir.exists(source))
+  if (!file_test("-d", source))
     return(FALSE)
 
   # attempt to form a symlink to the packrat library

--- a/R/restore-routines.R
+++ b/R/restore-routines.R
@@ -28,7 +28,7 @@ restoreWithCopyFromCache <- function(project,
 
   # ensure that the cache package path exists
   source <- cacheLibDir(pkgRecord$name, pkgRecord$hash, pkgRecord$name)
-  if (!file.exists(source))
+  if (!dir.exists(source))
     return(FALSE)
 
   # attempt to form a symlink to the packrat library


### PR DESCRIPTION
cloudml is blocked from using packrat restore since I'm hitting this bug in `restoreWithCopyFromCache()` where we test for a file instead of a dir.