### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Packrat functions:
 Share a Packrat project with `bundle` and `unbundle`:
 - `packrat::bundle()`: Bundle a packrat project, for easy sharing.
 - `packrat::unbundle()`: Unbundle a packrat project, generating a project
-  directory with libraries restored.
+  directory with libraries restored from the most recent snapshot.
 
 Navigate projects and set/get options with:
 - `packrat::on()`, `packrat::off()`: Toggle packrat mode on and off, for


### PR DESCRIPTION
made it clear that unbundling restores from a snapshot. Just bundling then unbundling doesn't seem to do anything across OSs.