### PR TITLE
Bugfix/snapshot private GitHub packages

### DIFF
--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -279,6 +279,7 @@ aliases <- c(
   GithubRef = "gh_ref",
   GithubSha1 = "gh_sha1",
   GithubSubdir = "gh_subdir",
+  RemoteHost = "remote_host",
   SourcePath = "source_path",
   Hash = "hash"
 )

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -278,10 +278,6 @@ inferPackageRecord <- function(df) {
       gh_sha1 = as.character(df$GithubSHA1)),
       #remote_ variables contains URLs for correct retrieval of git src
       remote_host = as.character(df$RemoteHost),
-      remote_repo = as.character(df$RemoteRepo),
-      remote_username = as.character(df$RemoteUsername),
-      remote_ref = as.character(df$RemoteRef),
-      remove_sha1 = as.character(df$RemoteSha),
       c(gh_subdir = as.character(df$GithubSubdir))
     ), class = c('packageRecord', 'github')))
   } else if (identical(as.character(df$Priority), 'base')) {

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -276,6 +276,12 @@ inferPackageRecord <- function(df) {
       gh_username = as.character(df$GithubUsername),
       gh_ref = as.character(df$GithubRef),
       gh_sha1 = as.character(df$GithubSHA1)),
+      #remote_ variables contains URLs for correct retrieval of git src
+      remote_host = as.character(df$RemoteHost),
+      remote_repo = as.character(df$RemoteRepo),
+      remote_username = as.character(df$RemoteUsername),
+      remote_ref = as.character(df$RemoteRef),
+      remove_sha1 = as.character(df$RemoteSha),
       c(gh_subdir = as.character(df$GithubSubdir))
     ), class = c('packageRecord', 'github')))
   } else if (identical(as.character(df$Priority), 'base')) {

--- a/R/restore.R
+++ b/R/restore.R
@@ -202,10 +202,20 @@ getSourceForPkgRecord <- function(pkgRecord,
       error = function(e) "internal"
     )
 
-    fmt <- "%s/repos/%s/%s/tarball/%s"
-
-    archiveUrl <- sprintf(fmt, pkgRecord$remote_host, pkgRecord$gh_username, pkgRecord$gh_repo, pkgRecord$gh_sha1)
-
+    if(!exists('pkgRecord$remote_host') || is.null(pkgRecord$remote_host) || pkgRecord$remote_host == ''){
+      message('devtools version < 1.13.5, downloading from api.github.com')
+      protocol <- if (identical(method, "internal"))
+        "http"
+      else
+        "https"
+      fmt <- paste(protocol,'://api.github.com/repos/%s/%s/tarball/%s',sep='')
+      archiveUrl <- sprintf(fmt, pkgRecord$gh_username, pkgRecord$gh_repo, pkgRecord$gh_sha1)
+    }
+    else {
+      fmt <- "%s/repos/%s/%s/tarball/%s"
+      archiveUrl <- sprintf(fmt, pkgRecord$remote_host, pkgRecord$gh_username, pkgRecord$gh_repo, pkgRecord$gh_sha1)
+    }
+    
     srczip <- tempfile(fileext = '.tar.gz')
     on.exit({
       if (file.exists(srczip))

--- a/R/restore.R
+++ b/R/restore.R
@@ -202,13 +202,9 @@ getSourceForPkgRecord <- function(pkgRecord,
       error = function(e) "internal"
     )
 
-    protocol <- if (identical(method, "internal"))
-      "http"
-    else
-      "https"
+    fmt <- "%s/repos/%s/%s/tarball/%s"
 
-    fmt <- "%s://api.github.com/repos/%s/%s/tarball/%s"
-    archiveUrl <- sprintf(fmt, protocol, pkgRecord$gh_username, pkgRecord$gh_repo, pkgRecord$gh_sha1)
+    archiveUrl <- sprintf(fmt, pkgRecord$remote_host, pkgRecord$gh_username, pkgRecord$gh_repo, pkgRecord$gh_sha1)
 
     srczip <- tempfile(fileext = '.tar.gz')
     on.exit({
@@ -216,8 +212,9 @@ getSourceForPkgRecord <- function(pkgRecord,
         unlink(srczip, recursive = TRUE)
     }, add = TRUE)
 
-    if (!downloadWithRetries(archiveUrl, destfile = srczip, quiet = TRUE, mode = "wb")) {
-      message("FAILED")
+
+    if (githubDownload(archiveUrl, srczip)>0) {
+        message("FAILED")
       stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
     }
 


### PR DESCRIPTION
resolves #442 and #447 by removing hard-coded `api.github.com` URL in download step.  Packages installed from private github repos are not located at api.github.com.  

Instead, this generates the url from the RemoteHost variable from the DESCRIPTION file, which should specify where the package was installed from.  The RemoteHost variable is also used to generate the protocol.  The protocol choice for users using `method='internal'`, has been removed, which could cause unwanted side-effects.

Rather than using `downloadWithRetries()`, which attempts to `inferAppropriateDownloadMethod`, and was leading to `method=libcurl`, which looks like it is not supported in `canUseLibCurlDownloadMethod`, we choose to use `githubDownload()`, since we know it is a github repo.


To work, the user must set the GITHUB_PAT environment variable:
```
#set GITHUB_PAT environment variable
Sys.setenv(GITHUB_PAT='<YOUR_GITHUB_PAT')
#confirm PAT is available with devtools:github_pat(), which is used by githubDownload(...)
devtools::github_pat() 
# before installing any other packages from github.com, user must unset GITHUB_PAT
Sys.unsetenv('GITHUB_PAT')
```

I've confirmed that this works for a test case with both an internal company package and an `github.com/rstats-db/DBI`.