### PR TITLE
githubDownload uses remote variables

### DIFF
--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -280,6 +280,9 @@ aliases <- c(
   GithubSha1 = "gh_sha1",
   GithubSubdir = "gh_subdir",
   RemoteHost = "remote_host",
+  RemoteRepo = "remote_repo",
+  RemoteUsername = "remote_username",
+  RemoteSha = "remote_sha",
   SourcePath = "source_path",
   Hash = "hash"
 )

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -301,7 +301,10 @@ inferPackageRecord <- function(df) {
       gh_ref = as.character(df$GithubRef),
       gh_sha1 = as.character(df$GithubSHA1)),
       c(gh_subdir = as.character(df$GithubSubdir)),
-      c(remote_host = as.character(df$RemoteHost))
+      c(remote_host = as.character(df$RemoteHost)),
+      c(remote_repo = as.character(df$RemoteRepo)),
+      c(remote_username = as.character(df$RemoteUsername)),
+      c(remote_sha = as.character(df$RemoteSha))
     ), class = c('packageRecord', 'github')))
   } else if (identical(as.character(df$Priority), 'base')) {
     # It's a base package!

--- a/R/restore.R
+++ b/R/restore.R
@@ -238,9 +238,9 @@ getSourceForPkgRecord <- function(pkgRecord,
       fmt <- "%s/repos/%s/%s/tarball/%s"
       archiveUrl <- sprintf(fmt,
                             pkgRecord$remote_host,
-                            pkgRecord$gh_username,
-                            pkgRecord$gh_repo,
-                            pkgRecord$gh_sha1)
+                            pkgRecord$remote_username,
+                            pkgRecord$remote_repo,
+                            pkgRecord$remote_sha)
     }
 
     srczip <- tempfile(fileext = '.tar.gz')


### PR DESCRIPTION
I've added all remote_ variables to github download as these could be different from the values in the `gh_` fields