### PR TITLE
Make Packrat secure by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -429,7 +429,7 @@
   `packrat::on()` and `packrat::off()`.
 
 - `.Rmd` files are now parsed for YAML dependencies (for
-  [`rmarkdown`](http://rmarkdown.rstudio.com/) dependencies).
+  [`rmarkdown`](https://rmarkdown.rstudio.com/) dependencies).
 
 - Recommended packages (e.g. `lattice`) are now only taken as Packrat
   dependencies if explicitly installed by the user -- for example, if you want

--- a/R/install.R
+++ b/R/install.R
@@ -518,7 +518,7 @@ rtools <- function(path, version) {
 }
 is.rtools <- function(x) inherits(x, "rtools")
 
-rtools_url <- "http://cran.r-project.org/bin/windows/Rtools/"
+rtools_url <- "https://cran.r-project.org/bin/windows/Rtools/"
 version_info <- list(
   "2.11" = list(
     version_min = "2.10.0",

--- a/R/migrate-library.R
+++ b/R/migrate-library.R
@@ -122,7 +122,7 @@ migrate_packages <- function() {
   if (length(biocPkgs)) {
     message("> Installing BioC packages")
     try(unloadNamespace("BiocInstaller"), silent = TRUE)
-    source("http://bioconductor.org/biocLite.R")
+    source("https://bioconductor.org/biocLite.R")
     BiocInstaller::biocLite(biocPkgs, lib.loc = userLib)
   }
 

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -351,7 +351,7 @@ getBiocRepos <- function() {
 activeRepos <- function(project) {
   project <- getProjectDir(project)
   repos <- getOption("repos")
-  repos[repos == "@CRAN@"] <- "http://cran.rstudio.com/"
+  repos[repos == "@CRAN@"] <- "https://cran.rstudio.com/"
 
   # Check to see whether Bioconductor is installed. Bioconductor maintains a
   # private set of repos, which we need to expose here so we can download

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use packrat to make your R projects more:
   and ensures those exact versions are the ones that get installed wherever you
   go.
 
-See the [project page](http://rstudio.github.io/packrat/) for more information,
+See the [project page](https://rstudio.github.io/packrat/) for more information,
 or join the discussion at
 [packrat-discuss](https://groups.google.com/forum/#!forum/packrat-discuss).
 Read the [release
@@ -103,5 +103,5 @@ Packrat supports a set of common analytic workflows:
 # Setting up your own custom, CRAN-like repositories
 
 Please view the [set-up
-guide](http://rstudio.github.io/packrat/custom-repos.html) here for a simple
+guide](https://rstudio.github.io/packrat/custom-repos.html) here for a simple
 walkthrough in how you might set up your own, local, custom CRAN repository.

--- a/announce/packrat-0.3.0.md
+++ b/announce/packrat-0.3.0.md
@@ -7,7 +7,7 @@ in this release:
    `install.packages` call, we can automatically update the lockfile to record
    any new packages),
 2. Packrat integration with the latest release of
-   [RStudio](http://www.rstudio.com/products/rstudio/download/) will make
+   [RStudio](https://www.rstudio.com/products/rstudio/download/) will make
    using Packrat with your projects easier than ever,
 3. Packrat projects now gain project-specific options, allowing you to control
    a number of features -- please see `?"packrat-options"` for more details;
@@ -56,7 +56,7 @@ A full set of NEWS items follows:
   `packrat::on()` and `packrat::off()`.
 
 - `.Rmd` files are now parsed for YAML dependencies (for
-  [`rmarkdown`](http://rmarkdown.rstudio.com/) dependencies).
+  [`rmarkdown`](https://rmarkdown.rstudio.com/) dependencies).
 
 - Recommended packages (e.g. `lattice`) are now only taken as Packrat
   dependencies if explicitly installed by the user -- for example, if you want

--- a/inst/resources/mac_r_userlib.sh
+++ b/inst/resources/mac_r_userlib.sh
@@ -7,7 +7,7 @@ set -e
 # Date: January 14, 2014
 # Author: Joe Cheng <joe@rstudio.com>
 #
-# From http://cran.r-project.org/bin/macosx/RMacOSX-FAQ.html:
+# From https://cran.r-project.org/bin/macosx/RMacOSX-FAQ.html:
 #   The official CRAN binaries come pre-packaged in such a way that
 #   administrator have sufficient privileges to update R and install
 #   packages system-wide.
@@ -28,7 +28,7 @@ set -e
 # writable by root. This will ensure that future install.packages calls
 # will not add more packages to the system library.
 #
-# [0] http://rstudio.github.io/packrat/
+# [0] https://rstudio.github.io/packrat/
 
 
 # The system-wide library

--- a/internal/digestPkg.sh
+++ b/internal/digestPkg.sh
@@ -10,5 +10,5 @@ cd ${PACKAGE_NAME}
 touch foo.R bar.R baz.R
 echo "library(digest)" >> foo.R
 cp ~/git/packrat/internal/digestPkg.Rproj ~/git/${PACKAGE_NAME}/
-R --vanilla -e "options(repos = c(CRAN = 'http://cran.rstudio.org')); library(packrat); dir.create('.git'); init(options = list(local.repos = '~/git'))"
+R --vanilla -e "options(repos = c(CRAN = 'https://cran.rstudio.org')); library(packrat); dir.create('.git'); init(options = list(local.repos = '~/git'))"
 R

--- a/internal/shinyPkg.sh
+++ b/internal/shinyPkg.sh
@@ -10,5 +10,5 @@ cd ${PACKAGE_NAME}
 touch foo.R bar.R baz.R
 echo "library(shiny)" >> foo.R
 cp ~/git/packrat/internal/digestPkg.Rproj ~/git/${PACKAGE_NAME}/
-R --vanilla -e "options(repos = c(CRAN = 'http://cran.rstudio.org')); library(packrat); dir.create('.git'); init(options = list(local.repos = '~/git'))"
+R --vanilla -e "options(repos = c(CRAN = 'https://cran.rstudio.org')); library(packrat); dir.create('.git'); init(options = list(local.repos = '~/git'))"
 R

--- a/internal/testPkg.sh
+++ b/internal/testPkg.sh
@@ -7,5 +7,5 @@ cd testPkg
 touch foo.R bar.R baz.R
 echo "library(digest)" >> foo.R
 cp ~/git/digest/DESCRIPTION ~/git/testPkg/DESCRIPTION
-R --vanilla -e "options(repos = c(CRAN = 'http://cran.rstudio.org')); library(packrat); dir.create('.git'); bootstrap(source='~/git/packrat')"
+R --vanilla -e "options(repos = c(CRAN = 'https://cran.rstudio.org')); library(packrat); dir.create('.git'); bootstrap(source='~/git/packrat')"
 R

--- a/tests/testthat/lockfiles/lockfile-multipleRepos.txt
+++ b/tests/testthat/lockfiles/lockfile-multipleRepos.txt
@@ -1,11 +1,11 @@
 PackratFormat: 1.3
 PackratVersion: 0.2.0.108
 RVersion: 3.2.0
-Repos: CRAN=http://cran.rstudio.org,
-  BioCsoft=http://bioconductor.org/packages/3.0/bioc,
-  BioCann=http://bioconductor.org/packages/3.0/data/annotation,
-  BioCexp=http://bioconductor.org/packages/3.0/data/experiment,
-  BioCextra=http://bioconductor.org/packages/3.0/extra
+Repos: CRAN=https://cran.rstudio.org,
+  BioCsoft=https://bioconductor.org/packages/3.0/bioc,
+  BioCann=https://bioconductor.org/packages/3.0/data/annotation,
+  BioCexp=https://bioconductor.org/packages/3.0/data/experiment,
+  BioCextra=https://bioconductor.org/packages/3.0/extra
 
 
 Package: packrat

--- a/tests/testthat/resources/interactive-doc-example.Rmd
+++ b/tests/testthat/resources/interactive-doc-example.Rmd
@@ -6,7 +6,7 @@ output: html_document
 
 This R Markdown document is made interactive using Shiny. Unlike the more traditional workflow of creating static reports, you can now create documents that allow your readers to change the assumptions underlying your analysis and see the results immediately. 
 
-To learn more, see [Interactive Documents](http://rmarkdown.rstudio.com/authoring_shiny.html).
+To learn more, see [Interactive Documents](https://rmarkdown.rstudio.com/authoring_shiny.html).
 
 ## Inputs and Outputs
 

--- a/tests/testthat/resources/knitr-minimal.Rnw
+++ b/tests/testthat/resources/knitr-minimal.Rnw
@@ -1,4 +1,4 @@
-%% LyX 2.0.3 created this file.  For more info, see http://www.lyx.org/.
+%% LyX 2.0.3 created this file.  For more info, see https://www.lyx.org/.
 %% Do not edit unless you really know what you are doing.
 \documentclass{article}
 \usepackage[sc]{mathpazo}

--- a/tests/testthat/test-lockfile.R
+++ b/tests/testthat/test-lockfile.R
@@ -31,11 +31,11 @@ test_that("Repository is properly split by readLockFile", {
   lf <- readLockFile("lockfiles/lockfile-multipleRepos.txt")
   expect_equal(
     lf$repos,
-    c(CRAN = "http://cran.rstudio.org",
-      BioCsoft = "http://bioconductor.org/packages/3.0/bioc",
-      BioCann = "http://bioconductor.org/packages/3.0/data/annotation",
-      BioCexp = "http://bioconductor.org/packages/3.0/data/experiment",
-      BioCextra = "http://bioconductor.org/packages/3.0/extra"
+    c(CRAN = "https://cran.rstudio.org",
+      BioCsoft = "https://bioconductor.org/packages/3.0/bioc",
+      BioCann = "https://bioconductor.org/packages/3.0/data/annotation",
+      BioCexp = "https://bioconductor.org/packages/3.0/data/experiment",
+      BioCextra = "https://bioconductor.org/packages/3.0/extra"
     )
   )
 

--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -5,7 +5,7 @@ test_that("projects which use shiny implicitly are detected", {
 
   # Try checking to see if packrat believes all example shiny apps
   # are, in fact, shiny apps
-  options(repos = c(CRAN = "http://cran.rstudio.org"))
+  options(repos = c(CRAN = "https://cran.rstudio.org"))
   if ("shiny" %in% rownames(installed.packages())) {
     examplesPath <- system.file("examples", package = "shiny")
     apps <- list.files(examplesPath, full.names = TRUE)


### PR DESCRIPTION
Hey, thanks for this awesome library 👍 

This PR changes Packrat use HTTPS by default. It switches the default repo from `http://cran.rstudio.com/` to `https://cran.rstudio.com/`, as well as updates links in the doc that are also available over HTTPS.