### PR TITLE
allow user to configure symlinking of system packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.9-6
+Version: 0.4.9-7
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, Aron Atkins, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Manage the R packages your project depends

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Packrat 0.5.0 (UNRELEASED)
 
+- Added the project option `symlink.system.packages`: users can now configure
+  whether base R packages from the system library are symlinked into a private
+  library `packrat/lib-R`. Disabling this can be useful if you intentionally
+  want Packrat to use packages that have been installed into the system library.
+
 - Fixed an issue where attempts to snapshot could fail when
   the R libraries live on a network drive.
 

--- a/R/library-support.R
+++ b/R/library-support.R
@@ -3,6 +3,10 @@
 symlinkSystemPackages <- function(project = NULL) {
   project <- getProjectDir(project)
 
+  # skip symlinking if requested by user
+  if (!packrat::opts$symlink.system.packages())
+    return(FALSE)
+
   # Get the path to the base R library installation
   sysLibPath <- normalizePath(R.home("library"), winslash = "/", mustWork = TRUE)
 

--- a/R/options.R
+++ b/R/options.R
@@ -25,7 +25,8 @@ VALID_OPTIONS <- list(
   snapshot.recommended.packages = list(TRUE, FALSE),
   snapshot.fields = function(x) {
     is.null(x) || is.character(x)
-  }
+  },
+  symlink.system.packages = list(TRUE, FALSE)
 )
 
 default_opts <- function() {
@@ -42,7 +43,8 @@ default_opts <- function() {
     ignored.directories = c("data", "inst"),
     quiet.package.installation = TRUE,
     snapshot.recommended.packages = FALSE,
-    snapshot.fields = c("Imports", "Depends", "LinkingTo")
+    snapshot.fields = c("Imports", "Depends", "LinkingTo"),
+    symlink.system.packages = TRUE
   )
 }
 
@@ -117,6 +119,11 @@ initOptions <- function(project = NULL, options = default_opts()) {
 ##'   What fields of a package's DESCRIPTION file should be used when discovering
 ##'   dependencies?
 ##'   (character, defaults to \code{c("Imports", "Depends", "LinkingTo")})
+##' \tem \code{symlink.system.packages}:
+##'   Symlink base \R packages into a private \code{packrat/lib-R} directory?
+##'   This is done to further encapsulate the project from user packages that
+##'   have been installed into the \R system library.
+##'   (boolean, defaults to \code{TRUE})
 ##' }
 ##'
 ##' @param options A character vector of valid option names.

--- a/inst/resources/init-rprofile.R
+++ b/inst/resources/init-rprofile.R
@@ -1,3 +1,3 @@
-#### -- Packrat Autoloader (version 0.4.9-6) -- ####
+#### -- Packrat Autoloader (version 0.4.9-7) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -186,7 +186,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- "InstallAgent: packrat 0.4.9-6"
+    installAgent <- "InstallAgent: packrat 0.4.9-7"
 
     ## -- InstallSource -- ##
     installSource <- "InstallSource: source"


### PR DESCRIPTION
This allows users to opt-in to using the system libraries as-is, in case the user explicitly wants to use user-installed packages that have found their way into the system library.