### PR TITLE
Added support for Bitbucket

### DIFF
--- a/R/bitbucket.R
+++ b/R/bitbucket.R
@@ -25,7 +25,7 @@ bitbucketDownload <- function(url, destfile, ...) {
     request <- GET(url, auth)
     if(request$status == 401) {
       warning("Failed to download package from Bitbucket: not authorized. ",
-              "Did you set BITBUCKET_USER and BITBUCKET_PWD env vars?",
+              "Did you set BITBUCKET_USERNAME and BITBUCKET_PASSWORD env vars?",
               call. = FALSE)
       return(1)
     }
@@ -38,15 +38,15 @@ bitbucketDownload <- function(url, destfile, ...) {
 #' Retrieve Bitbucket user.
 #'
 #' A bitbucket user
-#' Looks in env var \code{BITBUCKET_USER}
+#' Looks in env var \code{BITBUCKET_USERNAME}
 #'
 #' @keywords internal
 #'
 bitbucket_user <- function(quiet = FALSE) {
-  user <- Sys.getenv("BITBUCKET_USER")
+  user <- Sys.getenv("BITBUCKET_USERNAME")
   if (nzchar(user)) {
     if (!quiet) {
-      message("Using Bibtucket user from envvar BITBUCKET_USER")
+      message("Using Bitbucket username from envvar BITBUCKET_USERNAME")
     }
     return(user)
   }
@@ -57,15 +57,15 @@ bitbucket_user <- function(quiet = FALSE) {
 #' Retrieve Bitbucket password
 #'
 #' A bitbucket password
-#' Looks in env var \code{BITBUCKET_PWD}
+#' Looks in env var \code{BITBUCKET_PASSWORD}
 #'
 #' @keywords internal
 #'
 bitbucket_pwd <- function(quiet = FALSE) {
-  pwd <- Sys.getenv("BITBUCKET_PWD")
+  pwd <- Sys.getenv("BITBUCKET_PASSWORD")
   if (nzchar(pwd)) {
     if (!quiet) {
-      message("Using Bibtucket password from envvar BITBUCKET_PWD")
+      message("Using Bitbucket password from envvar BITBUCKET_PASSWORD")
     }
     return(pwd)
   }

--- a/R/bitbucket.R
+++ b/R/bitbucket.R
@@ -8,11 +8,67 @@ canUseBitbucketDownloader <- function() {
 
 bitbucketDownload <- function(url, destfile, ...) {
   onError(1, {
+    bitbucket_user  <- bitbucket_user
+    bitbucket_pwd   <- bitbucket_pwd
+    authenticate    <- yoink("httr", "authenticate")
     GET             <- yoink("httr", "GET")
     content         <- yoink("httr", "content")
 
-    request <- GET(url) #, auth)
+    user <- bitbucket_user(quiet=TRUE)
+    pwd <- bitbucket_pwd(quiet=TRUE)
+    auth <- if (!is.null(user) & !is.null(pwd)) {
+      authenticate(user, pwd, type="basic")
+    } else {
+      list()
+    }
+
+    request <- GET(url, auth)
+    if(request$status == 401) {
+      warning("Failed to download package from Bitbucket: not authorized. ",
+              "Did you set BITBUCKET_USER and BITBUCKET_PWD env vars?",
+              call. = FALSE)
+      return(1)
+    }
     writeBin(content(request, "raw"), destfile)
     if (file.exists(destfile)) 0 else 1
   })
 }
+
+
+#' Retrieve Bitbucket user.
+#'
+#' A bitbucket user
+#' Looks in env var \code{BITBUCKET_USER}
+#'
+#' @keywords internal
+#'
+bitbucket_user <- function(quiet = FALSE) {
+  user <- Sys.getenv("BITBUCKET_USER")
+  if (nzchar(user)) {
+    if (!quiet) {
+      message("Using Bibtucket user from envvar BITBUCKET_USER")
+    }
+    return(user)
+  }
+  return(NULL)
+}
+
+
+#' Retrieve Bitbucket password
+#'
+#' A bitbucket password
+#' Looks in env var \code{BITBUCKET_PWD}
+#'
+#' @keywords internal
+#'
+bitbucket_pwd <- function(quiet = FALSE) {
+  pwd <- Sys.getenv("BITBUCKET_PWD")
+  if (nzchar(pwd)) {
+    if (!quiet) {
+      message("Using Bibtucket password from envvar BITBUCKET_PWD")
+    }
+    return(pwd)
+  }
+  return(NULL)
+}
+

--- a/R/bitbucket.R
+++ b/R/bitbucket.R
@@ -1,0 +1,18 @@
+isBitbucketURL <- function(url) {
+  is.string(url) && grepl("^http(?:s)?://(?:www|api).bitbucket.(org|com)", url, perl = TRUE)
+}
+
+canUseBitbucketDownloader <- function() {
+  all(packageVersionInstalled(devtools = "1.9.1", httr = "1.0.0"))
+}
+
+bitbucketDownload <- function(url, destfile, ...) {
+  onError(1, {
+    GET             <- yoink("httr", "GET")
+    content         <- yoink("httr", "content")
+
+    request <- GET(url) #, auth)
+    writeBin(content(request, "raw"), destfile)
+    if (file.exists(destfile)) 0 else 1
+  })
+}

--- a/R/cache.R
+++ b/R/cache.R
@@ -34,10 +34,17 @@ hash <- function(path, descLookup = installedDescLookup) {
   }
   pkgName <- DESCRIPTION[["Package"]]
 
+  # Remote SHA backwards compatible with cache v2: use 'GithubSHA1' if exists, otherwise all 'Remote' fields
+  remote_fields <- if ("GithubSHA1" %in% names(DESCRIPTION)) {
+    "GithubSHA1"
+  } else {
+    c("RemoteType", "RemoteHost", "RemoteRepo", "RemoteUsername", "RemoteRef", "RemoteSha", "RemoteSubdir")
+  }
+
   # TODO: Do we want the 'Built' field used for hashing? The main problem with using that is
   # it essentially makes packages installed from source un-recoverable, since they will get
   # built transiently and installed (and so that field could never be replicated).
-  fields <- c("Package", "Version", "GithubSHA1", "RemoteSha", "Depends", "Imports", "Suggests", "LinkingTo")
+  fields <- c("Package", "Version", remote_fields, "Depends", "Imports", "Suggests", "LinkingTo")
   sub <- DESCRIPTION[names(DESCRIPTION) %in% fields]
 
   # Handle LinkingTo specially -- we need to discover what version of packages in LinkingTo

--- a/R/cache.R
+++ b/R/cache.R
@@ -37,7 +37,7 @@ hash <- function(path, descLookup = installedDescLookup) {
   # TODO: Do we want the 'Built' field used for hashing? The main problem with using that is
   # it essentially makes packages installed from source un-recoverable, since they will get
   # built transiently and installed (and so that field could never be replicated).
-  fields <- c("Package", "Version", "GithubSHA1", "Depends", "Imports", "Suggests", "LinkingTo")
+  fields <- c("Package", "Version", "GithubSHA1", "RemoteSha", "Depends", "Imports", "Suggests", "LinkingTo")
   sub <- DESCRIPTION[names(DESCRIPTION) %in% fields]
 
   # Handle LinkingTo specially -- we need to discover what version of packages in LinkingTo

--- a/R/downloader.R
+++ b/R/downloader.R
@@ -61,6 +61,13 @@ downloadImpl <- function(url, method, ...) {
       return(result)
   }
 
+  # If this is a path to a Bitbucket URL, attempt to download.
+  if (isBitbucketURL(url) && canUseBitbucketDownloader()) {
+    result <- try(bitbucketDownload(url, ...), silent = TRUE)
+    if (!inherits(result, "try-error"))
+      return(result)
+  }
+
   # When on Windows using an 'internal' method, we need to call
   # 'setInternet2' to set some appropriate state.
   if (is.windows() && method == "internal") {

--- a/R/lockfile.R
+++ b/R/lockfile.R
@@ -282,7 +282,9 @@ aliases <- c(
   RemoteHost = "remote_host",
   RemoteRepo = "remote_repo",
   RemoteUsername = "remote_username",
+  RemoteRef = "remote_ref",
   RemoteSha = "remote_sha",
+  RemoteSubdir = "remote_subdir",
   SourcePath = "source_path",
   Hash = "hash"
 )

--- a/R/migrate-library.R
+++ b/R/migrate-library.R
@@ -89,6 +89,9 @@ migrate_packages <- function() {
   githubPkgs <- pkgsToMigrate[sapply(descContent, function(x) {
     "GithubRepo" %in% colnames(x)
   })]
+  bitbucketPkgs <- pkgsToMigrate[sapply(descContent, function(x) {
+    "RemoteType" %in% colnames(x) && x[,"RemoteType"] == "bitbucket"
+  })]
   cranPkgs <- pkgsToMigrate[sapply(descContent, function(x) {
     "Repository" %in% colnames(x) && x[, "Repository"] == "CRAN"
   })]
@@ -96,7 +99,7 @@ migrate_packages <- function() {
     "biocViews" %in% colnames(x)
   })]
 
-  unknownPkgs <- setdiff(pkgsToMigrate, c(githubPkgs, cranPkgs, biocPkgs))
+  unknownPkgs <- setdiff(pkgsToMigrate, c(githubPkgs, bitbucketPkgs, cranPkgs, biocPkgs))
 
   # Ignore RStudio packages
   unknownPkgs <- setdiff(unknownPkgs, c("manipulate", "rstudio"))
@@ -114,6 +117,23 @@ migrate_packages <- function() {
                                username = desc$GithubUsername,
                                ref = ref,
                                quick = TRUE
+      )
+    }
+  }
+
+  ## Install packages from Bitbucket
+  if (length(bitbucketPkgs)) {
+    message("> Installing Bitbucket packages")
+    if (!requireNamespace("devtools")) {
+      install.packages("devtools", lib = userLib())
+    }
+    for (pkg in bitbucketPkgs) {
+      desc <- as.data.frame(descContent[[pkg]], stringsAsFactors = FALSE)
+      ref <- desc$RemoteSha %||% desc$RemoteRef %||% "master"
+      devtools::install_bitbucket(repo = desc$RemoteRepo,
+                                  username = desc$RemoteUsername,
+                                  ref = ref,
+                                  quick = TRUE
       )
     }
   }
@@ -148,6 +168,7 @@ migrate_packages <- function() {
     cran = cranPkgs,
     bioc = biocPkgs,
     github = githubPkgs,
+    bitbucket = bitbucketPkgs,
     missing = setdiff(failures, c("rstudio", "manipulate"))
   )
 

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -402,7 +402,7 @@ restore <- function(project = NULL,
     options(repos = externalRepos)
   }, add = TRUE)
 
-  # Install each package from CRAN or github, from binaries when available and
+  # Install each package from CRAN or github/bitbucket, from binaries when available and
   # then from sources.
   restoreImpl(project, repos, packages, libDir,
               pkgsToIgnore = pkgsToIgnore, prompt = prompt,

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -284,7 +284,7 @@ getPackageRecords <- function(pkgNames,
 }
 
 # Reads a description file and attempts to infer where the package came from.
-# Currently works only for packages installed from CRAN or from GitHub using
+# Currently works only for packages installed from CRAN or from GitHub/Bitbucket using
 # devtools 1.4 or later.
 inferPackageRecord <- function(df) {
   name <- as.character(df$Package)
@@ -306,6 +306,19 @@ inferPackageRecord <- function(df) {
       c(remote_username = as.character(df$RemoteUsername)),
       c(remote_sha = as.character(df$RemoteSha))
     ), class = c('packageRecord', 'github')))
+  } else if (!is.null(df$RemoteType) && df$RemoteType == "bitbucket") {
+    # It's Bitbucket!
+    return(structure(c(list(
+      name = name,
+      source = 'bitbucket',
+      version = ver,
+      remote_repo = as.character(df$RemoteRepo),
+      remote_username = as.character(df$RemoteUsername),
+      remote_ref = as.character(df$RemoteRef),
+      remote_sha = as.character(df$RemoteSha)),
+      c(remote_host = as.character(df$RemoteHost)),
+      c(remote_subdir = as.character(df$RemoteSubdir))
+    ), class = c('packageRecord', 'bitbucket')))
   } else if (identical(as.character(df$Priority), 'base')) {
     # It's a base package!
     return(NULL)

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -193,7 +193,7 @@ snapshot <- function(project = NULL,
 
   # For inferred packages (ie. packages within the code), we try to construct
   # records first from the lockfile, and then from other sources if possible
-  # (CRAN, GitHub, source repository)
+  # (CRAN, GitHub, Bitbucket, source repository)
   inferredPkgRecords <- getPackageRecords(inferredPkgsNotInLib,
                                           project = project,
                                           available = available,

--- a/tests/testthat/test-bitbucket.R
+++ b/tests/testthat/test-bitbucket.R
@@ -1,0 +1,16 @@
+context("Bitbucket")
+
+test_that("we can use devtools:::download to retrieve Bitbucket archives", {
+  skip("run manually for now")
+
+  if (!canUseBitbucketDownloader())
+    skip("requires devtools")
+
+  url <- "https://bitbucket.org/mariamedp/packrat-test-pkg/get/5a6b90280c5fec133efb88aec95014d4f9aef80f.tar.gz"
+  destination <- tempfile("packrat-test-bitbucket-", fileext = ".tar.gz")
+  result <- bitbucketDownload(url, destination)
+  expect_true(result == 0)
+  expect_true(file.exists(destination))
+  unlink(destination)
+
+})


### PR DESCRIPTION
Hi! I've added support for packages in Bitbucket repos (both public and private), I guess it closes #304. 

The code is the same except for some details (API calls, field names in the DESCRIPTION file, ...), so Github and Bitbucket chunks could be probably combined with some adjustments for each case. But I think it would be better to do it with a third case in mind (Gitlab?), so I've just left it separate for the moment.

About private authentication: when installling private Github packages with devtools, there is a `devtools::github_pat` function that retrieves the Personal Access Token stored in the envvar "GITHUB_PAT", but for the moment that's different with Bitbucket: there are no environment variables, and instead you set the user and password directly in the `devtools::install_bitbucket` function call. 
That doesn't fit for packrat, but it will probably [change in the future](https://github.com/r-lib/remotes/pull/104). Until then, I've created two functions `packrat:::bitbucket_user`/`packrat:::bitbucket_pwd`  that read envvars "BITBUCKET_USER" and "BITBUCKET_PWD". I think is easier to have those until the BITBUCKET_PAT envvar is properly documented.