### PR TITLE
relax 'packified' check during restore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Suggests:
 Enhances: BiocInstaller
 URL: https://github.com/rstudio/packrat/
 BugReports: https://github.com/rstudio/packrat/issues
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.4.9-11
+Version: 0.4.9-12
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, Aron Atkins, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Manage the R packages your project depends

--- a/R/disable.R
+++ b/R/disable.R
@@ -24,7 +24,6 @@ disable <- function(project = NULL, restart = TRUE) {
 
   # get the project
   project <- getProjectDir(project)
-  stopIfNotPackified(project)
 
   # remove packrat from the .Rprofile
   editRprofileAutoloader(project, "remove")

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -331,7 +331,7 @@ restore <- function(project = NULL,
                     restart = !dry.run) {
 
   project <- getProjectDir(project)
-  stopIfNotPackified(project)
+  stopIfNoLockfile(project)
 
   if (!dry.run) {
     callHook(project, "restore", TRUE)
@@ -448,7 +448,6 @@ clean <- function(packages = NULL,
                   force = FALSE) {
 
   project <- getProjectDir(project)
-  stopIfNotPackified(project)
 
   callHook(project, "clean", TRUE)
   on.exit(callHook(project, "clean", FALSE), add = TRUE)

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -69,10 +69,6 @@ snapshot <- function(project = NULL,
   }
 
   project <- getProjectDir(project)
-
-  # Prompt the user to initialize if the project has not yet been initialized
-  stopIfNotPackified(project)
-
   if (file.exists(snapshotLockFilePath(project))) {
     stop("An automatic snapshot is currently in progress -- cannot proceed")
   }

--- a/R/status.R
+++ b/R/status.R
@@ -29,7 +29,7 @@
 status <- function(project = NULL, lib.loc = libDir(project), quiet = FALSE) {
 
   project <- getProjectDir(project)
-  stopIfNotPackified(project)
+  stopIfNoLockfile(project)
 
   projectDefault <- identical(project, '.')
   project <- normalizePath(project, winslash = '/', mustWork = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -205,6 +205,16 @@ endswith <- function(str1, str2) {
   })
 }
 
+stopIfNoLockfile <- function(project) {
+  path <- lockFilePath(project)
+  if (!file.exists(path)) {
+    stop("This project does not have a lockfile. (Have you called 'packrat::snapshot()' yet?)",
+         call. = FALSE)
+  }
+
+  invisible(TRUE)
+}
+
 stopIfNotPackified <- function(project) {
 
   if (!checkPackified(project, quiet = TRUE)) {

--- a/inst/resources/init-rprofile.R
+++ b/inst/resources/init-rprofile.R
@@ -1,3 +1,3 @@
-#### -- Packrat Autoloader (version 0.4.9-11) -- ####
+#### -- Packrat Autoloader (version 0.4.9-12) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -186,7 +186,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- "InstallAgent: packrat 0.4.9-11"
+    installAgent <- "InstallAgent: packrat 0.4.9-12"
 
     ## -- InstallSource -- ##
     installSource <- "InstallSource: source"

--- a/man/bundle.Rd
+++ b/man/bundle.Rd
@@ -6,8 +6,8 @@
 \usage{
 bundle(project = NULL, file = NULL, include.src = TRUE,
   include.lib = FALSE, include.bundles = TRUE,
-  include.vcs.history = FALSE, overwrite = FALSE, omit.cran.src = FALSE,
-  ...)
+  include.vcs.history = FALSE, overwrite = FALSE,
+  omit.cran.src = FALSE, ...)
 }
 \arguments{
 \item{project}{The project directory. Defaults to the currently activate

--- a/man/lockfile-metadata.Rd
+++ b/man/lockfile-metadata.Rd
@@ -3,13 +3,13 @@
 \name{lockfile-metadata}
 \alias{lockfile-metadata}
 \alias{set_lockfile_metadata}
-\alias{lockfile-metadata}
 \alias{get_lockfile_metadata}
 \title{Get / Set packrat lockfile metadata}
 \usage{
 set_lockfile_metadata(repos = NULL, r_version = NULL, project = NULL)
 
-get_lockfile_metadata(metadata = NULL, simplify = TRUE, project = NULL)
+get_lockfile_metadata(metadata = NULL, simplify = TRUE,
+  project = NULL)
 }
 \arguments{
 \item{repos}{A named character vector of the form \code{c(<repoName> = "<pathToRepo>")}.}

--- a/man/packrat-external.Rd
+++ b/man/packrat-external.Rd
@@ -3,11 +3,8 @@
 \name{packrat-external}
 \alias{packrat-external}
 \alias{with_extlib}
-\alias{packrat-external}
 \alias{extlib}
-\alias{packrat-external}
 \alias{user_lib}
-\alias{packrat-external}
 \alias{packrat_lib}
 \title{Managing External Libraries}
 \usage{

--- a/man/packrat-mode.Rd
+++ b/man/packrat-mode.Rd
@@ -3,9 +3,7 @@
 \name{packrat-mode}
 \alias{packrat-mode}
 \alias{packrat_mode}
-\alias{packrat-mode}
 \alias{on}
-\alias{packrat-mode}
 \alias{off}
 \title{Packrat Mode}
 \usage{

--- a/man/packrat-options.Rd
+++ b/man/packrat-options.Rd
@@ -4,7 +4,6 @@
 \name{packrat-options}
 \alias{packrat-options}
 \alias{get_opts}
-\alias{packrat-options}
 \alias{set_opts}
 \alias{opts}
 \title{Get/set packrat project options}

--- a/man/repository-management.Rd
+++ b/man/repository-management.Rd
@@ -3,15 +3,10 @@
 \name{repository-management}
 \alias{repository-management}
 \alias{repos_add}
-\alias{repository-management}
 \alias{repos_add_local}
-\alias{repository-management}
 \alias{repos_set}
-\alias{repository-management}
 \alias{repos_set_local}
-\alias{repository-management}
 \alias{repos_remove}
-\alias{repository-management}
 \alias{repos_list}
 \title{Add a Repository}
 \usage{

--- a/man/restore.Rd
+++ b/man/restore.Rd
@@ -4,8 +4,8 @@
 \alias{restore}
 \title{Apply the most recent snapshot to the library}
 \usage{
-restore(project = NULL, overwrite.dirty = FALSE, prompt = interactive(),
-  dry.run = FALSE, restart = !dry.run)
+restore(project = NULL, overwrite.dirty = FALSE,
+  prompt = interactive(), dry.run = FALSE, restart = !dry.run)
 }
 \arguments{
 \item{project}{The project directory. When in packrat mode, if this is \code{NULL},


### PR DESCRIPTION
Now only checks for a lockfile, which is all that's really required during restore.

Closes #494.