### PR TITLE
fix packageVersion test; it may emit "smart" quotes

### DIFF
--- a/tests/testthat/test-with_extlib.R
+++ b/tests/testthat/test-with_extlib.R
@@ -15,7 +15,8 @@ test_that("with_extlib successfully works with no packages provided", {
   # don't use packrat::on so we can avoid the initialization step
   packrat:::setPackratModeOn(auto.snapshot = FALSE, clean.search.path = FALSE)
 
-  expect_error(packageVersion("bread"), "package 'bread' not found")
+  # Wildcard the quotes around 'bread'; newer versions of R emit "smart" quotes.
+  expect_error(packageVersion("bread"), "package .bread. not found", perl = TRUE)
 
   expect_identical(packrat::with_extlib(expr = packageVersion("bread")), package_version("1.0.0"))
 


### PR DESCRIPTION
`packrat` packrat tests failed without this change.