### PR TITLE
packrat:::hash has consistent output regardless of DESCRIPTION order

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -50,15 +50,12 @@ hash <- function(path, descLookup = installedDescLookup) {
   # it essentially makes packages installed from source un-recoverable, since they will get
   # built transiently and installed (and so that field could never be replicated).
 
-  # Create a "sub" data frame with a consistently ordered set of columns by
-  # first ensuring that every column has a (blank) value and then selecting
-  # with the ordered columns.
+  # Create a "sub" data frame with a consistently ordered set of columns.
   #
   # This ensures that package hashing is not sensitive to DESCRIPTION field
   # order.
-  missing <- setdiff(fields, names(DESCRIPTION))
-  DESCRIPTION[missing] <- ""
-  sub <- DESCRIPTION[fields]
+  common <- intersect(fields, names(DESCRIPTION))
+  sub <- DESCRIPTION[common]
 
   # Handle LinkingTo specially -- we need to discover what version of packages in LinkingTo
   # were actually linked against in order to properly disambiguate e.g. httpuv 1.0 linked


### PR DESCRIPTION
With `packrat:::hash` and its `descLookup` argument, hashing is occasionally requested against DESCRIPTION files that are not within packages installed in an R library. `rsconnect` records description files as it creates a bundle; description information is also in the `manifest.json`.

Prior to this change, `packrat:::hash` produced different output if any field reordering occurred on the hashed description file.

DESCRIPTION file reordering initially feels unexpected, but is unavoidable when passing description data through an unordered construct, like a JSON object.

The field order used by `packrat:::hash` corresponds to common DESCRIPTION-file field order. This will help reduce the number of existing cached packages that see hash changes.