### PR TITLE
hashing ignores Remote* description fields when cran

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -37,6 +37,9 @@ hash <- function(path, descLookup = installedDescLookup) {
   # Remote SHA backwards compatible with cache v2: use 'GithubSHA1' if exists, otherwise all 'Remote' fields
   remote_fields <- if ("GithubSHA1" %in% names(DESCRIPTION)) {
     "GithubSHA1"
+  } else if (is.null(DESCRIPTION[["RemoteType"]]) || DESCRIPTION[["RemoteType"]] == "cran") {
+    # Packages installed with install.packages or locally without remotes
+    c()
   } else {
     # Mirror the order used by devtools when augmenting the DESCRIPTION.
     c("RemoteType", "RemoteHost", "RemoteRepo", "RemoteUsername", "RemoteRef", "RemoteSha", "RemoteSubdir")


### PR DESCRIPTION
Client `DESCRIPTION` files may contain a number of `Remote` fields describing how the package was acquired.

```
RemoteType: cran
RemoteRepos: structure("https://mirror.las.iastate.edu/CRAN", .Names = "CRAN")
RemoteSha: 1.66.0-1
RemotePkgType: source
```

These fields are not present when `packrat` restores a package from CRAN. This causes a hashing difference between the authoring environment and the restoring environment.

This change ignores `Remote*` fields for "cran" repositories when computing hashes.

Related: https://github.com/r-lib/remotes/blob/c509c3acf1ba7231c877352953f055227871e883/R/install-remote.R#L140