### PR TITLE
addresses #458 slow snapshot

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -208,7 +208,7 @@ stripAltEngines <- function(file, encoding) {
 
 fileDependencies.Rmd <- function(file) {
 
-  if (!opts$fileDependencies.Rmd.evaluate) {
+  if (FALSE %in% options("fileDependencies.Rmd.evaluate")) {
     return(NULL);
   }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -208,6 +208,10 @@ stripAltEngines <- function(file, encoding) {
 
 fileDependencies.Rmd <- function(file) {
 
+  if (!opts$fileDependencies.Rmd.evaluate) {
+    return(NULL);
+  }
+
   deps <- "rmarkdown"
 
   # try using an evaluate-based approach for dependencies

--- a/R/options.R
+++ b/R/options.R
@@ -25,7 +25,8 @@ VALID_OPTIONS <- list(
   snapshot.recommended.packages = list(TRUE, FALSE),
   snapshot.fields = function(x) {
     is.null(x) || is.character(x)
-  }
+  },
+  fileDependencies.Rmd.evaluate = list(TRUE, FALSE)
 )
 
 default_opts <- function() {
@@ -42,7 +43,8 @@ default_opts <- function() {
     ignored.directories = c("data", "inst"),
     quiet.package.installation = TRUE,
     snapshot.recommended.packages = FALSE,
-    snapshot.fields = c("Imports", "Depends", "LinkingTo")
+    snapshot.fields = c("Imports", "Depends", "LinkingTo"),
+    fileDependencies.Rmd.evaluate = TRUE
   )
 }
 

--- a/R/options.R
+++ b/R/options.R
@@ -25,8 +25,7 @@ VALID_OPTIONS <- list(
   snapshot.recommended.packages = list(TRUE, FALSE),
   snapshot.fields = function(x) {
     is.null(x) || is.character(x)
-  },
-  fileDependencies.Rmd.evaluate = list(TRUE, FALSE)
+  }
 )
 
 default_opts <- function() {
@@ -43,8 +42,7 @@ default_opts <- function() {
     ignored.directories = c("data", "inst"),
     quiet.package.installation = TRUE,
     snapshot.recommended.packages = FALSE,
-    snapshot.fields = c("Imports", "Depends", "LinkingTo"),
-    fileDependencies.Rmd.evaluate = TRUE
+    snapshot.fields = c("Imports", "Depends", "LinkingTo")
   )
 }
 


### PR DESCRIPTION
This PR adds a `fileDependencies.Rmd.evaluate` option (default TRUE) to choose whether or not to recursively search for dependencies in R Markdown documents.