### PR TITLE
make a fileDependencies.Rmd.tangle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.5.0-6
+Version: 0.5.0-7
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, Aron Atkins, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Manage the R packages your project depends

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Packrat 0.5.1 (UNRELEASED)
 
+- Fixed an issue where tangled R code chunks containing invalid R code prevented 
+  Packrat from finding any dependencies.  Packrat will now look for package
+  dependencies within each code chunk independently. (#551)
+
 - Packrat no longer sets `LC_ALL=C` when building source packages, as this can
   lead to errors when building packages containing non-ASCII text. (#545)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -669,7 +669,7 @@ fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
   for(r_chunk in r_chunks) {
     if (nchar(r_chunk) == 0) next
     try(silent = TRUE, {
-      parsed <- parse(text = r_chunk, encoding = "UTF-8")
+      parsed <- parse(text = r_chunk, encoding = encoding)
       deps <- c(deps, expressionDependencies(parsed))
     })
   }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -627,8 +627,8 @@ fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
   # discovered packages
   deps <- list()
 
-  # unique key to split R code with
-  key <- paste0("###--packrat", as.numeric(Sys.time()))
+  # unique key (line) to split R code with
+  key <- paste0("###--packrat", as.integer(Sys.time()), "\n")
 
   # rudely override knitr's 'label_code' function so
   # that we can detect dependencies within inline chunks
@@ -638,7 +638,7 @@ fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
     do.call("unlockBinding", list("label_code", knitr))
     assign("label_code", function(...) {
       # paste a known key to the end to split the code chunks with
-      paste0(label_code(...), key)
+      paste0(key, label_code(...))
     }, envir = knitr)
 
     on.exit({
@@ -667,6 +667,7 @@ fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
   # allows for some chunks to be _broken_ but not stop retrieving dependencies
   r_chunks <- strsplit(paste0(readLines(outfile), collapse = "\n"), key)[[1]]
   for(r_chunk in r_chunks) {
+    if (nchar(r_chunk) == 0) next
     try(silent = TRUE, {
       parsed <- parse(text = r_chunk, encoding = "UTF-8")
       deps <- c(deps, expressionDependencies(parsed))

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -318,7 +318,8 @@ fileDependencies.Rmd <- function(file) {
   } else {
     warning("knitr is required to parse dependencies but is not available")
   }
-  deps
+
+  unique(deps)
 }
 
 fileDependencies.knitr <- function(...) {

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -311,28 +311,14 @@ fileDependencies.Rmd <- function(file) {
   }, add = TRUE)
 
   if (requireNamespace("knitr", quietly = TRUE)) {
-
-    tempfile <- tempfile()
-    on.exit(unlink(tempfile))
-
-    tryCatch(silent(
-      knitr::knit(file, output = tempfile, tangle = TRUE, encoding = encoding)
-    ), error = function(e) {
-      message("Unable to tangle file '", file, "'; cannot parse dependencies")
-      character()
-    })
-
-    if (file.exists(tempfile)) {
-      stripAltEngines(tempfile, encoding)
-      c(deps, fileDependencies.R(tempfile))
-    } else {
-      deps
-    }
-
+    deps <- c(
+      deps,
+      fileDependencies.Rmd.tangle(file, encoding = encoding)
+    )
   } else {
     warning("knitr is required to parse dependencies but is not available")
-    deps
   }
+  deps
 }
 
 fileDependencies.knitr <- function(...) {
@@ -628,6 +614,64 @@ fileDependencies.Rmd.evaluate <- function(file) {
     error = identity
   )
   unlink(outfile)
+
+  unique(unlist(deps, recursive = TRUE))
+}
+
+
+
+
+
+fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
+
+  # discovered packages
+  deps <- list()
+
+  # unique key to split R code with
+  key <- paste0("###--packrat", as.numeric(Sys.time()))
+
+  # rudely override knitr's 'label_code' function so
+  # that we can detect dependencies within inline chunks
+  knitr <- asNamespace("knitr")
+  if (exists("label_code", envir = knitr)) {
+    label_code <- yoink("knitr", "label_code")
+    do.call("unlockBinding", list("label_code", knitr))
+    assign("label_code", function(...) {
+      # paste a known key to the end to split the code chunks with
+      paste0(label_code(...), key)
+    }, envir = knitr)
+
+    on.exit({
+      assign("label_code", label_code, envir = knitr)
+      do.call("lockBinding", list("label_code", knitr))
+    }, add = TRUE)
+  }
+
+  # tangle out file
+  outfile <- tempfile()
+  on.exit({
+    unlink(outfile)
+  }, add = TRUE)
+
+  # attempt to tangle document with our custom hook active
+  x <- knitr::purl(file, output = outfile, quiet = TRUE, documentation = 1L)
+
+  if (!file.exists(outfile)) {
+    # nothing was created
+    return(NULL)
+  }
+
+  stripAltEngines(outfile, encoding)
+
+  # parse each r chunk independently to retrieve dependencies
+  # allows for some chunks to be _broken_ but not stop retrieving dependencies
+  r_chunks <- strsplit(paste0(readLines(outfile), collapse = "\n"), key)[[1]]
+  for(r_chunk in r_chunks) {
+    try(silent = TRUE, {
+      parsed <- parse(text = r_chunk, encoding = "UTF-8")
+      deps <- c(deps, expressionDependencies(parsed))
+    })
+  }
 
   unique(unlist(deps, recursive = TRUE))
 }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -622,14 +622,16 @@ fileDependencies.Rmd.evaluate <- function(file) {
 
 
 
-
+# Extract dependencies per chunk rather than per file.
+# Packages like learnr have special R code chunks that are not evaluated at run time.
+# While the .Rmd file can be rendered with rmarkdown, a raw tangled R file may not be able to be processed.
 fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
 
   # discovered packages
   deps <- list()
 
   # unique key (line) to split R code with
-  key <- paste0("###--packrat", as.integer(Sys.time()), "\n")
+  key <- paste0("###--packrat-", paste0(sample(letters, 10, replace = TRUE), collapse = ""), "\n")
 
   # rudely override knitr's 'label_code' function so
   # that we can detect dependencies within inline chunks
@@ -638,7 +640,7 @@ fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
     label_code <- yoink("knitr", "label_code")
     do.call("unlockBinding", list("label_code", knitr))
     assign("label_code", function(...) {
-      # paste a known key to the end to split the code chunks with
+      # paste a known key to split the code chunks by
       paste0(key, label_code(...))
     }, envir = knitr)
 
@@ -655,7 +657,22 @@ fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
   }, add = TRUE)
 
   # attempt to tangle document with our custom hook active
-  x <- knitr::purl(file, output = outfile, quiet = TRUE, documentation = 1L)
+  tryCatch(silent(
+    knitr::purl(
+      file,
+      output = outfile, # tangled file location
+      quiet = TRUE,
+
+      # `An integer specifying the level of documentation to add
+      # to the tangled script. 1L (the default) means to add
+      # the chunk headers to the code`
+      documentation = 1L,
+      encoding = encoding
+    )
+ ), error = function(e) {
+   message("Unable to tangle file '", file, "'; cannot parse dependencies")
+   character()	
+ })
 
   if (!file.exists(outfile)) {
     # nothing was created
@@ -668,7 +685,6 @@ fileDependencies.Rmd.tangle <- function(file, encoding = "UTF-8") {
   # allows for some chunks to be _broken_ but not stop retrieving dependencies
   r_chunks <- strsplit(paste0(readLines(outfile), collapse = "\n"), key)[[1]]
   for(r_chunk in r_chunks) {
-    if (nchar(r_chunk) == 0) next
     try(silent = TRUE, {
       parsed <- parse(text = r_chunk, encoding = encoding)
       deps <- c(deps, expressionDependencies(parsed))

--- a/tests/testthat/resources/broken-chunks.Rmd
+++ b/tests/testthat/resources/broken-chunks.Rmd
@@ -1,0 +1,42 @@
+---
+title: "Rmd with broken chunks"
+runtime: shiny_prerendered
+---
+
+This is an example document with broken chunks.
+
+### OK
+
+```{r}
+library(pkgA)
+library(pkgB)
+```
+
+
+### Broken
+
+```{r}
+library(pkgC)
+log(1
+```
+
+
+### Not Broken
+
+```{r}
+library(pkgD)
+```
+
+### Also Broken
+
+```{r}
+library(pkgE)
+log(1
+```
+
+### OK
+
+```{r}
+library(pkgF)
+library(pkgG)
+```

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -57,3 +57,17 @@ test_that("dependencies are discovered in inline R code", {
   emojiRmd <- file.path("resources", "emoji.Rmd")
   expect_true("emo" %in% packrat:::fileDependencies(emojiRmd))
 })
+
+test_that("dependencies are discovered in R Markdown documents in independent R chunks", {
+  skip_on_cran()
+
+  someBrokenChunksRmd <- file.path("resources", "broken-chunks.Rmd")
+  brokenDeps <- packrat:::fileDependencies(someBrokenChunksRmd)
+
+  # shiny_prerendered file
+  expect_true("shiny" %in% brokenDeps)
+  # check for working chunks
+  expect_true(all(
+    c("pkgA", "pkgB", "pkgD", "pkgF", "pkgG") %in% brokenDeps
+  ))
+})


### PR DESCRIPTION
* Goal: Retrieve dependencies from each chunk independently.  
* Reason: `learnr` encourages users to provide broken code for students.  Currently since the complete tangled file can not be parsed, then no dependencies are found.
* Solution: 
  * Tangle the file
  * Split by a known comment value
  * Parse the code chunks independently
  * Combine dependencies

* Known workaround: source a separate, working R file that contains the library calls.  It seems odd to require this.

Related issue: https://github.com/rstudio/learnr/issues/209