### PR TITLE
Added code for version specific cache

### DIFF
--- a/R/paths.R
+++ b/R/paths.R
@@ -269,7 +269,7 @@ packratCacheVersion <- function() {
 }
 
 cacheLibDir <- function(...) {
-  file.path(appDataDir(), packratCacheVersion(), "library", ...)
+  file.path(appDataDir(), packratCacheVersion(), paste0(R.version$major, ".", R.version$minor), "library", ...)
 }
 
 untrustedCacheLibDir <- function(...) {

--- a/R/paths.R
+++ b/R/paths.R
@@ -231,11 +231,15 @@ packrat_lib <- function() {
 
 ## A location where "global" packrat data is stored, e.g. the library cache
 appDataDir <- function() {
-  packratOption(
-    "R_PACKRAT_CACHE_DIR",
-    "packrat.cache.dir",
-    defaultAppDataDir()
-  )
+
+  # Root directory
+  rootDir <- packratOption("R_PACKRAT_CACHE_DIR",
+                           "packrat.cache.dir",
+                           defaultAppDataDir())
+
+  # R Version specific sub folder
+  file.path(rootDir, getRversion())
+
 }
 
 defaultAppDataDir <- function() {
@@ -269,7 +273,7 @@ packratCacheVersion <- function() {
 }
 
 cacheLibDir <- function(...) {
-  file.path(appDataDir(), packratCacheVersion(), paste0(R.version$major, ".", R.version$minor), "library", ...)
+  file.path(appDataDir(), packratCacheVersion(), "library", ...)
 }
 
 untrustedCacheLibDir <- function(...) {


### PR DESCRIPTION
To resolve #557 - @kevinushey as discussed here is a very small pull request that sets the cache to be r version specific to avoid the internals problem of restoring with different r major versions. 

Any concerns let me know - happy to build on it to more fit the style if you like.

Adam