### PR TITLE
Add gitlab

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: packrat
 Type: Package
 Title: A Dependency Management System for Projects and their R Package
     Dependencies
-Version: 0.5.0-8
+Version: 0.5.0-9
 Author: Kevin Ushey, Jonathan McPherson, Joe Cheng, Aron Atkins, JJ Allaire
 Maintainer: Kevin Ushey <kevin@rstudio.com>
 Description: Manage the R packages your project depends

--- a/R/available-updates.R
+++ b/R/available-updates.R
@@ -152,7 +152,7 @@ gitlabUpdates <- function(lib.loc = .libPaths()) {
     names(DESCRIPTIONS) <- pkgs
     DESCRIPTIONS <-
       Filter(function(x) "RemoteType" %in% colnames(x) &&
-               x[,"RemoteType"] == "bitbucket", DESCRIPTIONS)
+               x[,"RemoteType"] == "gitlab", DESCRIPTIONS)
     if (!length(DESCRIPTIONS)) return(NULL)
     if (!requireNamespace("httr")) stop("Need package 'httr' to check for Gitlab updates")
     do.call(rbind, enumerate(DESCRIPTIONS, function(x) {

--- a/R/available-updates.R
+++ b/R/available-updates.R
@@ -140,14 +140,78 @@ bitbucketUpdates <- function(lib.loc = .libPaths()) {
   }))
 }
 
+gitUpdates <- function(lib.loc = .libPaths()) {
+
+  do.call(rbind, enumerate(lib.loc, function(lib) {
+    pkgs <- list.files(lib, full.names = TRUE)
+    DESCRIPTIONS <- enumerate(pkgs, function(pkg) {
+      path <- file.path(pkg, "DESCRIPTION")
+      if (!file.exists(path)) return(NULL)
+      readDcf(path)
+    })
+    names(DESCRIPTIONS) <- pkgs
+    DESCRIPTIONS <-
+      Filter(function(x) any(grepl("^Github", colnames(x))), DESCRIPTIONS)
+    if (!length(DESCRIPTIONS)) return(NULL)
+    if (!requireNamespace("httr")) stop("Need package 'httr' to check for GitHub updates")
+    do.call(rbind, enumerate(DESCRIPTIONS, function(x) {
+      url <- file.path("https://api.github.com",
+                       "repos",
+                       x[, "GithubUsername"],
+                       x[, "GithubRepo"],
+                       "branches")
+      response <- httr::GET(url)
+      status <- response$status
+      if (response$status == 403) {
+        warning("rejected by server", call. = FALSE)
+        sha1 <- NA
+      } else if (!response$status == 200) {
+        warning("failed to get tracking information for GitHub package '",
+                x[, "Package"],
+                "'; did its associated repository move?",
+                call. = FALSE)
+        sha1 <- NA
+      } else {
+        content <- httr::content(response, "parsed")
+        ## Find the index of the response with the appropriate name
+        index <- which(sapply(content, `[[`, "name") == x[, "GithubRef"])
+        if (!length(index)) {
+          warning("no reference '", x[, "GithubRef"],
+                  "' found associated with this repository; was the branch deleted?",
+                  call. = FALSE)
+          sha1 <- NA
+        } else {
+          sha1 <- content[[index]]$commit$sha
+        }
+      }
+
+      data.frame(
+        stringsAsFactors = FALSE,
+        Package = unname(x[, "Package"]),
+        LibPath = lib,
+        Installed = unname(x[, "GithubSHA1"]),
+        Built = gsub(";.*", "", x[, "Built"]),
+        ReposVer = sha1,
+        Repository = file.path("https://github.com",
+                               x[, "GithubUsername"],
+                               x[, "GithubRepo"],
+                               "tree",
+                               x[, "GithubRef"])
+      )
+    }))
+  }))
+}
+
 available_updates <- function() {
   cranUpdates <- as.data.frame(old.packages(), stringsAsFactors = FALSE)
   githubUpdates <- githubUpdates()
   bitbucketUpdates <- bitbucketUpdates()
+  gitlabUpdates <- gitlabUpdates()
 
   list(
     CRAN = cranUpdates,
     GitHub = githubUpdates,
-    Bitbucket = bitbucketUpdates
+    Bitbucket = bitbucketUpdates,
+    GitLab = gitlabUpdates
   )
 }

--- a/R/available-updates.R
+++ b/R/available-updates.R
@@ -158,8 +158,9 @@ gitlabUpdates <- function(lib.loc = .libPaths()) {
     do.call(rbind, enumerate(DESCRIPTIONS, function(x) {
       url <- file.path("https://gitlab.com/",
                        "api/v4/projects/",
-                       x[, "RemoteUsername"],
-                       x[, "RemoteRepo"],
+                       paste0(x[, "RemoteUsername"],
+                              "%2F",
+                              x[, "RemoteRepo"]),
                        "repository",
                        "archive.tar.gz")
       response <- httr::GET(url)

--- a/R/downloader.R
+++ b/R/downloader.R
@@ -68,6 +68,13 @@ downloadImpl <- function(url, method, ...) {
       return(result)
   }
 
+  # If this is a path to a Gitlab URL, attempt to download.
+  if (isGitlabURL(url) && canUseGitlabDownloader()) {
+    result <- try(gitlabDownload(url, ...), silent = TRUE)
+    if (!inherits(result, "try-error"))
+      return(result)
+  }
+
   # When on Windows using an 'internal' method, we need to call
   # 'setInternet2' to set some appropriate state.
   if (is.windows() && method == "internal") {

--- a/R/gitlab.R
+++ b/R/gitlab.R
@@ -8,35 +8,34 @@ canUseGitlabDownloader <- function() {
 
 gitlabDownload <- function(url, destfile, ...) {
   onError(1,{
-    gitlab_user    <- gitlab_user
-    gitlab_pwd     <- gitlab_pwd
     authenticate   <- yoink("httr", "authenticate")
     GET            <- yoink("httr", "GET")
     content        <- yoink("httr", "content")
 
     user <- gitlab_user(quiet = TRUE)
     pwd <- gitlab_pwd(quiet = TRUE)
-    auth <- if(!is.null(user) & !is.null(pwd)) {
+    auth <- if (!is.null(user) && !is.null(pwd)) {
       authenticate(user, pwd, type = "basic")
     } else {
       list()
     }
 
     request <- GET(url, auth)
-    if(request$status == 401) {
-      warning("Failed to download package from gitlab: not authorized. ",
+    if (request$status == 401) {
+      warning("Failed to download package from GitLab: not authorized. ",
               "Did you set GITLAB_USERNAME and GITLAB_PASSWORD env vars?",
               call. = FALSE)
       return(1)
     }
-    writeBin(content(request, "raw"), destfile)
+
+    if (request$status == 200) writeBin(content(request, "raw"), destfile)
     if (file.exists(destfile)) 0 else 1
   })
 }
 
-#' Retrieve Gitlab user.
+#' Retrieve GitLab user.
 #'
-#' A gitlab user
+#' A GitLab user
 #' Looks in env var \code{GITLAB_USERNAME}
 #'
 #' @keywords internal
@@ -45,7 +44,7 @@ gitlab_user <- function(quiet = FALSE) {
   user <- Sys.getenv("GITLAB_USERNAME")
   if (nzchar(user)) {
     if (!quiet) {
-      message("Using Gitlab username from envvar GITLAB_USERNAME")
+      message("Using GitLab username from envvar GITLAB_USERNAME")
     }
     return(user)
   }
@@ -53,9 +52,9 @@ gitlab_user <- function(quiet = FALSE) {
 }
 
 
-#' Retrieve Gitlab password
+#' Retrieve GitLab password
 #'
-#' A bitbucket password
+#' A GitLab password
 #' Looks in env var \code{GITLAB_PASSWORD}
 #'
 #' @keywords internal
@@ -64,7 +63,7 @@ gitlab_pwd <- function(quiet = FALSE) {
   pwd <- Sys.getenv("GITLAB_PASSWORD")
   if (nzchar(pwd)) {
     if (!quiet) {
-      message("Using Gitlab password from envvar GITLAB_PASSWORD")
+      message("Using GitLab password from envvar GITLAB_PASSWORD")
     }
     return(pwd)
   }

--- a/R/gitlab.R
+++ b/R/gitlab.R
@@ -1,0 +1,72 @@
+isGitlabURL <- function(url) {
+  is.string(url) && grepl("^http(?:s)?://(?:www|api).gitlab.(org|com)", url, perl = TRUE)
+}
+
+canUseGitlabDownloader <- function() {
+  all(packageVersionInstalled(devtools = "1.9.1", httr = "1.0.0"))
+}
+
+gitlabDownload <- function(url, destfile, ...) {
+  onError(1,{
+    gitlab_user    <- gitlab_user
+    gitlab_pwd     <- gitlab_pwd
+    authenticate   <- yoink("httr", "authenticate")
+    GET            <- yoink("httr", "GET")
+    content        <- yoink("httr", "content")
+
+    user <- gitlab_user(quiet = TRUE)
+    pwd <- gitlab_pwd(quiet = TRUE)
+    auth <- if(!is.null(user) & !is.null(pwd)) {
+      authenticate(user, pwd, type = "basic")
+    } else {
+      list()
+    }
+
+    request <- GET(url, auth)
+    if(request$status == 401) {
+      warning("Failed to download package from gitlab: not authorized. ",
+              "Did you set GITLAB_USERNAME and GITLAB_PASSWORD env vars?",
+              call. = FALSE)
+      return(1)
+    }
+    writeBin(content(request, "raw"), destfile)
+    if (file.exists(destfile)) 0 else 1
+  })
+}
+
+#' Retrieve Gitlab user.
+#'
+#' A gitlab user
+#' Looks in env var \code{GITLAB_USERNAME}
+#'
+#' @keywords internal
+#'
+gitlab_user <- function(quiet = FALSE) {
+  user <- Sys.getenv("GITLAB_USERNAME")
+  if (nzchar(user)) {
+    if (!quiet) {
+      message("Using Gitlab username from envvar GITLAB_USERNAME")
+    }
+    return(user)
+  }
+  return(NULL)
+}
+
+
+#' Retrieve Gitlab password
+#'
+#' A bitbucket password
+#' Looks in env var \code{GITLAB_PASSWORD}
+#'
+#' @keywords internal
+#'
+gitlab_pwd <- function(quiet = FALSE) {
+  pwd <- Sys.getenv("GITLAB_PASSWORD")
+  if (nzchar(pwd)) {
+    if (!quiet) {
+      message("Using Gitlab password from envvar GITLAB_PASSWORD")
+    }
+    return(pwd)
+  }
+  return(NULL)
+}

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -405,7 +405,7 @@ restore <- function(project = NULL,
     options(repos = externalRepos)
   }, add = TRUE)
 
-  # Install each package from CRAN or github/bitbucket, from binaries when available and
+  # Install each package from CRAN or github/bitbucket/gitlab, from binaries when available and
   # then from sources.
   restoreImpl(project, repos, packages, libDir,
               pkgsToIgnore = pkgsToIgnore, prompt = prompt,

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -284,7 +284,7 @@ getPackageRecords <- function(pkgNames,
 }
 
 # Reads a description file and attempts to infer where the package came from.
-# Currently works only for packages installed from CRAN or from GitHub/Bitbucket using
+# Currently works only for packages installed from CRAN or from GitHub/Bitbucket/Gitlab using
 # devtools 1.4 or later.
 inferPackageRecord <- function(df) {
   name <- as.character(df$Package)
@@ -320,6 +320,17 @@ inferPackageRecord <- function(df) {
       c(remote_host = as.character(df$RemoteHost)),
       c(remote_subdir = as.character(df$RemoteSubdir))
     ), class = c('packageRecord', 'bitbucket')))
+  } else if (!is.null(df$RemoteType) && df$RemoteType == "gitlab") {
+    return(structure(c(list(
+      name = name,
+      source = 'gitlab',
+      version = ver,
+      remote_repo = as.character(df$RemoteRepo),
+      remote_username = as.character(df$RemoteUsername),
+      remote_ref = as.character(df$RemoteRef),
+      remote_sha = as.character(df$RemoteSha)),
+      c(remote_host = as.character(df$RemoteHost))
+    ), class = c('packageRecord', 'gitlab')))
   } else if (identical(as.character(df$Priority), 'base')) {
     # It's a base package!
     return(NULL)

--- a/R/restore.R
+++ b/R/restore.R
@@ -2,7 +2,7 @@
 pkgSrcFilename <- function(pkgRecord) {
   if (identical(pkgRecord$source, "github"))
     paste(pkgRecord$gh_sha1, ".tar.gz", sep = "")
-  else if (identical(pkgRecord$source, "bitbucket"))
+  else if (pkgRecord$source %in% c("bitbucket", "gitlab"))
     paste(pkgRecord$remote_sha, ".tar.gz", sep = "")
   else
     paste(pkgRecord$name, "_", pkgRecord$version, ".tar.gz", sep = "")
@@ -23,12 +23,12 @@ isFromCranlikeRepo <- function(pkgRecord, repos) {
   if (!length(source))
     return(TRUE)
 
-  # for records that do declare a source, ensure it's not 'source', 'github' or 'bitbucket'.
+  # for records that do declare a source, ensure it's not 'source', 'github', 'bitbucket', or 'gitlab'.
   # in previous releases of packrat, we attempted to match the repository name
   # with one of the existing repositories; however, this caused issues in
   # certain environments (the names declared repositories in the lockfile, and
   # the the names of the active repositories in the R session, may not match)
-  !tolower(source) %in% c("source", "github", "bitbucket")
+  !tolower(source) %in% c("source", "github", "bitbucket", "gitlab")
 }
 
 # Given a package record and a database of packages, check to see if
@@ -37,7 +37,7 @@ versionMatchesDb <- function(pkgRecord, db) {
   versionMatch <-
     identical(pkgRecord$version, db[pkgRecord$name,"Version"])
 
-  # For GitHub and Bitbucket, we also need to check that the SHA1 is identical
+  # For GitHub, Bitbucket, and Gitlab, we also need to check that the SHA1 is identical
   # (the source may be updated even if the version hasn't been bumped)
   if (versionMatch && identical(pkgRecord$source, "github")) {
     pkgDescFile <- system.file('DESCRIPTION', package = pkgRecord$name)
@@ -45,7 +45,7 @@ versionMatchesDb <- function(pkgRecord, db) {
       inferPackageRecord(as.data.frame(readDcf(pkgDescFile)))
     versionMatch <- identical(pkgRecord$gh_sha1,
                               installedPkgRecord$gh_sha1)
-  } else if (versionMatch && identical(pkgRecord$source, "bitbucket")) {
+  } else if (versionMatch && pkgRecord$source %in% c("gitlab", "bitbucket")) {
     pkgDescFile <- system.file('DESCRIPTION', package = pkgRecord$name)
     installedPkgRecord <-
       inferPackageRecord(as.data.frame(readDcf(pkgDescFile)))
@@ -77,7 +77,8 @@ getSourceForPkgRecord <- function(pkgRecord,
   if (identical(pkgRecord$source, "unknown") && !quiet) {
     stop("No sources available for package ", pkgRecord$name, ". Packrat can ",
          "find sources for packages on CRAN-like repositories and packages ",
-         "installed using devtools::install_github or devtools::install_bitbucket. TODO: local repo")
+         "installed using devtools::install_github, devtools::install_gitlab",
+         "devtools::install_bitbucket. TODO: local repo")
   }
 
   # Create the directory in which to place this package's sources
@@ -366,6 +367,8 @@ getSourceForPkgRecord <- function(pkgRecord,
       }
     }
 
+
+
     local({
       scratchDir <- tempfile()
       on.exit({
@@ -411,6 +414,94 @@ getSourceForPkgRecord <- function(pkgRecord,
     })
 
     type <- "Bitbucket"
+  } else if (identical(pkgRecord$source, "gitlab")) {
+
+    # Prefer using https if possible. Note that 'wininet'
+    # can fail if attempting to download from an 'http'
+    # URL that redirects to an 'https' URL.
+    # https://github.com/rstudio/packrat/issues/269
+    method <- tryCatch(
+      secureDownloadMethod(),
+      error = function(e) "internal"
+    )
+
+    if (is.null(pkgRecord$remote_host) || !nzchar(pkgRecord$remote_host)) {
+      protocol <- if (identical(method, "internal")) "http" else "https"
+      pkgRecord$remote_host <- paste0(protocol, "://gitlab.com")
+    }
+
+    fmt <- "%s/%s/%s/get/%s.tar.gz"
+    archiveUrl <- sprintf(fmt,
+                          pkgRecord$remote_host,
+                          pkgRecord$remote_username,
+                          pkgRecord$remote_repo,
+                          pkgRecord$remote_sha)
+
+    srczip <- tempfile(fileext = '.tar.gz')
+    on.exit({
+      if (file.exists(srczip))
+        unlink(srczip, recursive = TRUE)
+    }, add = TRUE)
+
+    if (canUseGitlabownloader()) {
+      status <- gitlabDownload(archiveUrl, srczip)
+      if (status) {
+        message("FAILED")
+        stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
+      }
+    } else {
+      success <- downloadWithRetries(archiveUrl, destfile = srczip, quiet = TRUE, mode = "wb")
+      if (!success) {
+        message("FAILED")
+        stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
+      }
+    }
+
+    local({
+      scratchDir <- tempfile()
+      on.exit({
+        if (file.exists(scratchDir))
+          unlink(scratchDir, recursive = TRUE)
+      })
+      # untar can emit noisy warnings (e.g. "skipping pax global extended
+      # headers"); hide those
+      suppressWarnings(untar(srczip, exdir = scratchDir, tar = "internal"))
+      # Find the base directory
+      basedir <- if (length(dir(scratchDir)) == 1)
+        file.path(scratchDir, dir(scratchDir))
+      else
+        scratchDir
+
+      if (!is.null(pkgRecord$remote_subdir))
+        basedir <- file.path(basedir, pkgRecord$remote_subdir)
+
+      if (!file.exists(file.path(basedir, 'DESCRIPTION'))) {
+        stop('No DESCRIPTION file was found in the archive for ', pkgRecord$name)
+      }
+
+      remote_info <- as.data.frame(c(list(
+        RemoteRepo = pkgRecord$remote_repo,
+        RemoteUsername = pkgRecord$remote_username,
+        RemoteRef = pkgRecord$remote_ref,
+        RemoteSha = pkgRecord$remote_sha)),
+        c(RemoteSubdir = pkgRecord$remote_subdir)
+      )
+      appendToDcf(file.path(basedir, 'DESCRIPTION'), remote_info)
+
+      file.create(file.path(pkgSrcDir, pkgSrcFile))
+      dest <- normalizePath(file.path(pkgSrcDir, pkgSrcFile), winslash = '/')
+
+      # R's internal tar (which we use here for cross-platform consistency)
+      # emits warnings when there are > 100 characters in the path, due to the
+      # resulting incompatibility with older implementations of tar. This isn't
+      # relevant for our purposes, so suppress the warning.
+      in_dir(dirname(basedir),
+             suppressWarnings(tar(tarfile = dest, files = basename(basedir),
+                                  compression = 'gzip', tar = 'internal'))
+      )
+    })
+
+    type <- "Gitlab"
   }
   if (!quiet) {
     if (file.exists(file.path(pkgSrcDir, pkgSrcFile))) {
@@ -614,7 +705,7 @@ installPkg <- function(pkgRecord,
   }
 
   if (is.null(pkgSrc)) {
-    # When installing from github/bitbucket or an older version, use the cached source
+    # When installing from github/bitbucket/gitlab or an older version, use the cached source
     # tarball or zip created in snapshotSources
     pkgSrc <- file.path(srcDir(project), pkgRecord$name,
                         pkgSrcFilename(pkgRecord))

--- a/R/restore.R
+++ b/R/restore.R
@@ -430,7 +430,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       pkgRecord$remote_host <- paste0(protocol, "://gitlab.com")
     }
 
-    fmt <- "%s/%s/%s/get/%s.tar.gz"
+    fmt <- "%s/api/v4/projects/%s%%2F%s/repository/archive?sha=%s"
     archiveUrl <- sprintf(fmt,
                           pkgRecord$remote_host,
                           pkgRecord$remote_username,

--- a/R/restore.R
+++ b/R/restore.R
@@ -443,7 +443,7 @@ getSourceForPkgRecord <- function(pkgRecord,
         unlink(srczip, recursive = TRUE)
     }, add = TRUE)
 
-    if (canUseGitlabownloader()) {
+    if (canUseGitlabDownloader()) {
       status <- gitlabDownload(archiveUrl, srczip)
       if (status) {
         message("FAILED")

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -189,7 +189,7 @@ snapshot <- function(project = NULL,
 
   # For inferred packages (ie. packages within the code), we try to construct
   # records first from the lockfile, and then from other sources if possible
-  # (CRAN, GitHub, Bitbucket, source repository)
+  # (CRAN, GitHub, Bitbucket, gitlab, source repository)
   inferredPkgRecords <- getPackageRecords(inferredPkgsNotInLib,
                                           project = project,
                                           available = available,

--- a/tests/testthat/test-bitbucket.R
+++ b/tests/testthat/test-bitbucket.R
@@ -1,16 +1,15 @@
-context("Bitbucket")
+context("Gitlab")
 
-test_that("we can use devtools:::download to retrieve Bitbucket archives", {
+test_that("we can use devtools:::download to retrieve Gitlab archives", {
   skip("run manually for now")
 
-  if (!canUseBitbucketDownloader())
+  if (!canUseGitlabDownloader())
     skip("requires devtools")
 
-  url <- "https://bitbucket.org/mariamedp/packrat-test-pkg/get/5a6b90280c5fec133efb88aec95014d4f9aef80f.tar.gz"
-  destination <- tempfile("packrat-test-bitbucket-", fileext = ".tar.gz")
-  result <- bitbucketDownload(url, destination)
+  url <- "https://gitlab.com/alexkgold/packrat-test-pkg"
+  destination <- tempfile("packrat-test-gitlab-", fileext = ".tar.gz")
+  result <- gitlabDownload(url, destination)
   expect_true(result == 0)
   expect_true(file.exists(destination))
   unlink(destination)
-
 })

--- a/tests/testthat/test-bitbucket.R
+++ b/tests/testthat/test-bitbucket.R
@@ -1,15 +1,16 @@
-context("Gitlab")
+context("Bitbucket")
 
-test_that("we can use devtools:::download to retrieve Gitlab archives", {
+test_that("we can use devtools:::download to retrieve Bitbucket archives", {
   skip("run manually for now")
 
-  if (!canUseGitlabDownloader())
+  if (!canUseBitbucketDownloader())
     skip("requires devtools")
 
-  url <- "https://gitlab.com/alexkgold/packrat-test-pkg"
-  destination <- tempfile("packrat-test-gitlab-", fileext = ".tar.gz")
-  result <- gitlabDownload(url, destination)
+  url <- "https://bitbucket.org/mariamedp/packrat-test-pkg/get/5a6b90280c5fec133efb88aec95014d4f9aef80f.tar.gz"
+  destination <- tempfile("packrat-test-bitbucket-", fileext = ".tar.gz")
+  result <- bitbucketDownload(url, destination)
   expect_true(result == 0)
   expect_true(file.exists(destination))
   unlink(destination)
+
 })

--- a/tests/testthat/test-gitlab.R
+++ b/tests/testthat/test-gitlab.R
@@ -1,0 +1,15 @@
+context("Gitlab")
+
+test_that("we can use devtools:::download to retrieve Gitlab archives", {
+  skip("run manually for now")
+
+  if (!canUseGitlabDownloader())
+    skip("requires devtools")
+
+  url <- "https://gitlab.com/api/v4/projects/alexkgold%2Fpackrat-test-pkg/repository/archive?sha=e4c14e817e802ce20ba05acc9657f306094d5d23"
+  destination <- tempfile("packrat-test-gitlab-", fileext = ".tar.gz")
+  result <- gitlabDownload(url, destination)
+  expect_true(result == 0)
+  expect_true(file.exists(destination))
+  unlink(destination)
+})


### PR DESCRIPTION
Closes rstudio/packrat#559 by following pattern from rstudio/packrat#481. 

@kevinushey -- let me know if you have any suggestions/edits. I've tested locally and on deploy to RStudio Connect (after replacing tarball of `packrat` on Connect server) with following in RMarkdown:
```{r}
devtools::install_gitlab("alexkgold/riskgauge_pub")
riskgauge::add2(1, 1)
```