### PR TITLE
fix up API URLs when downloading from Bitbucket

### DIFF
--- a/R/bitbucket.R
+++ b/R/bitbucket.R
@@ -7,31 +7,32 @@ canUseBitbucketDownloader <- function() {
 }
 
 bitbucketDownload <- function(url, destfile, ...) {
-  onError(1, {
-    bitbucket_user  <- bitbucket_user
-    bitbucket_pwd   <- bitbucket_pwd
-    authenticate    <- yoink("httr", "authenticate")
-    GET             <- yoink("httr", "GET")
-    content         <- yoink("httr", "content")
+  onError(1, bitbucketDownloadImpl(url, destfile, ...))
+}
 
-    user <- bitbucket_user(quiet=TRUE)
-    pwd <- bitbucket_pwd(quiet=TRUE)
-    auth <- if (!is.null(user) & !is.null(pwd)) {
-      authenticate(user, pwd, type="basic")
-    } else {
-      list()
-    }
+bitbucketDownloadImpl <- function(url, destfile, ...) {
+  authenticate    <- yoink("httr", "authenticate")
+  GET             <- yoink("httr", "GET")
+  content         <- yoink("httr", "content")
 
-    request <- GET(url, auth)
-    if(request$status == 401) {
-      warning("Failed to download package from Bitbucket: not authorized. ",
-              "Did you set BITBUCKET_USERNAME and BITBUCKET_PASSWORD env vars?",
-              call. = FALSE)
-      return(1)
-    }
-    writeBin(content(request, "raw"), destfile)
-    if (file.exists(destfile)) 0 else 1
-  })
+  user <- bitbucket_user(quiet = TRUE)
+  pwd <- bitbucket_pwd(quiet = TRUE)
+  auth <- if (!is.null(user) & !is.null(pwd)) {
+    authenticate(user, pwd, type = "basic")
+  } else {
+    list()
+  }
+
+  request <- GET(url, auth)
+  if (request$status == 401) {
+    warning("Failed to download package from Bitbucket: not authorized. ",
+            "Did you set BITBUCKET_USERNAME and BITBUCKET_PASSWORD env vars?",
+            call. = FALSE)
+    return(1)
+  }
+
+  if (request$status == 200) writeBin(content(request, "raw"), destfile)
+  if (file.exists(destfile)) 0 else 1
 }
 
 

--- a/R/gitlab.R
+++ b/R/gitlab.R
@@ -7,30 +7,32 @@ canUseGitlabDownloader <- function() {
 }
 
 gitlabDownload <- function(url, destfile, ...) {
-  onError(1,{
-    authenticate   <- yoink("httr", "authenticate")
-    GET            <- yoink("httr", "GET")
-    content        <- yoink("httr", "content")
+  onError(1, gitlabDownloadImpl(url, destfile, ...))
+}
 
-    user <- gitlab_user(quiet = TRUE)
-    pwd <- gitlab_pwd(quiet = TRUE)
-    auth <- if (!is.null(user) && !is.null(pwd)) {
-      authenticate(user, pwd, type = "basic")
-    } else {
-      list()
-    }
+gitlabDownloadImpl <- function(url, destfile, ...) {
+  authenticate   <- yoink("httr", "authenticate")
+  GET            <- yoink("httr", "GET")
+  content        <- yoink("httr", "content")
 
-    request <- GET(url, auth)
-    if (request$status == 401) {
-      warning("Failed to download package from GitLab: not authorized. ",
-              "Did you set GITLAB_USERNAME and GITLAB_PASSWORD env vars?",
-              call. = FALSE)
-      return(1)
-    }
+  user <- gitlab_user(quiet = TRUE)
+  pwd <- gitlab_pwd(quiet = TRUE)
+  auth <- if (!is.null(user) && !is.null(pwd)) {
+    authenticate(user, pwd, type = "basic")
+  } else {
+    list()
+  }
 
-    if (request$status == 200) writeBin(content(request, "raw"), destfile)
-    if (file.exists(destfile)) 0 else 1
-  })
+  request <- GET(url, auth)
+  if (request$status == 401) {
+    warning("Failed to download package from GitLab: not authorized. ",
+            "Did you set GITLAB_USERNAME and GITLAB_PASSWORD env vars?",
+            call. = FALSE)
+    return(1)
+  }
+
+  if (request$status == 200) writeBin(content(request, "raw"), destfile)
+  if (file.exists(destfile)) 0 else 1
 }
 
 #' Retrieve GitLab user.

--- a/R/install.R
+++ b/R/install.R
@@ -235,7 +235,7 @@ with_build_tools <- function(code) {
 
 decompress <- function(src, target = tempdir()) {
   tryCatch(
-    decompressImpl(src, target),
+    suppressWarnings(decompressImpl(src, target)),
     error = function(e) {
       fmt <- paste(
         "Failed to extract archive:",

--- a/R/restore.R
+++ b/R/restore.R
@@ -340,6 +340,11 @@ getSourceForPkgRecord <- function(pkgRecord,
       pkgRecord$remote_host <- paste0(protocol, "://bitbucket.org")
     }
 
+    # API URLs get recorded when packages are downloaded with devtools /
+    # remotes, but Packrat just wants to use 'plain' URLs when downloading
+    # package sources.
+    pkgRecord$remote_host <- sub("api.bitbucket.org/2.0", "bitbucket.org", pkgRecord$remote_host, fixed = TRUE)
+
     fmt <- "%s/%s/%s/get/%s.tar.gz"
     archiveUrl <- sprintf(fmt,
                           pkgRecord$remote_host,

--- a/tests/testthat/test-with_extlib.R
+++ b/tests/testthat/test-with_extlib.R
@@ -16,9 +16,6 @@ test_that("with_extlib successfully works with no packages provided", {
   # don't use packrat::on so we can avoid the initialization step
   packrat:::setPackratModeOn(auto.snapshot = FALSE, clean.search.path = FALSE)
 
-  # Wildcard the quotes around 'bread'; newer versions of R emit "smart" quotes.
-  expect_error(packageVersion("bread"), "package .bread. not found", perl = TRUE)
-
   expect_identical(packrat::with_extlib(expr = packageVersion("bread")), package_version("1.0.0"))
 
   packrat::off()


### PR DESCRIPTION
cc: @aronatkins.

Most of the PR is just reformatting (adding `*Impl()` methods so they're easier to debug and step into) + some brown-bag fixes for warnings popping up with R 3.6.0. The meat of the PR is this:

```
    # API URLs get recorded when packages are downloaded with devtools /
    # remotes, but Packrat just wants to use 'plain' URLs when downloading
    # package sources.
    pkgRecord$remote_host <- sub("api.bitbucket.org/2.0", "bitbucket.org", pkgRecord$remote_host, fixed = TRUE)
```