### PR TITLE
ignore remote fields when cleaning a github-sourced package record

### DIFF
--- a/tests/testthat/resources/descriptions/falsy.packrat
+++ b/tests/testthat/resources/descriptions/falsy.packrat
@@ -1,0 +1,27 @@
+Package: falsy
+Title: Define Truthy and Falsy Values
+Version: 1.0.1
+Authors@R: person("Gabor", "Csardi", , "csardi.gabor@gmail.com", role =
+    c("aut", "cre"))
+Description: A value is falsy if it is NULL, FALSE, the empty string,
+    zero, or an empty vector or list. Other values are truthy. The new
+    %&&% and %||% operators work with falsy and truthy values and can
+    be used for concise conditional execution.
+License: MIT + file LICENSE
+Suggests: testthat
+URL: https://github.com/gaborcsardi/falsy
+BugReports: https://github.com/gaborcsardi/falsy/issues
+NeedsCompilation: no
+Packaged: 2015-04-08 15:30:21 UTC; gaborcsardi
+Author: Gabor Csardi [aut, cre]
+Maintainer: Gabor Csardi <csardi.gabor@gmail.com>
+Repository: CRAN
+Date/Publication: 2015-04-09 00:36:26
+GithubRepo: falsy
+GithubUsername: cran
+GithubRef: master
+GithubSHA1: 26a36cf957a18569e311ef75b6f61f822de945ef
+Built: R 3.4.4; ; 2019-06-17 18:35:06 UTC; unix
+InstallAgent: packrat 0.5.0.11
+InstallSource: github
+Hash: 463f9bedd8d616a3cdb766e6fb524100

--- a/tests/testthat/resources/descriptions/falsy.remotes
+++ b/tests/testthat/resources/descriptions/falsy.remotes
@@ -1,0 +1,29 @@
+Package: falsy
+Title: Define Truthy and Falsy Values
+Version: 1.0.1
+Authors@R: person("Gabor", "Csardi", , "csardi.gabor@gmail.com", role = c("aut", "cre"))
+Description: A value is falsy if it is NULL, FALSE, the empty string,
+    zero, or an empty vector or list. Other values are truthy. The new
+    %&&% and %||% operators work with falsy and truthy values and
+    can be used for concise conditional execution.
+License: MIT + file LICENSE
+Suggests: testthat
+URL: https://github.com/gaborcsardi/falsy
+BugReports: https://github.com/gaborcsardi/falsy/issues
+NeedsCompilation: no
+Packaged: 2019-06-18 13:40:33 UTC; aron
+Author: Gabor Csardi [aut, cre]
+Maintainer: Gabor Csardi <csardi.gabor@gmail.com>
+Repository: CRAN
+Date/Publication: 2015-04-09 00:36:26
+RemoteType: github
+RemoteHost: api.github.com
+RemoteRepo: falsy
+RemoteUsername: cran
+RemoteRef: master
+RemoteSha: 26a36cf957a18569e311ef75b6f61f822de945ef
+GithubRepo: falsy
+GithubUsername: cran
+GithubRef: master
+GithubSHA1: 26a36cf957a18569e311ef75b6f61f822de945ef
+Built: R 3.5.1; ; 2019-06-18 13:40:33 UTC; unix

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -297,4 +297,17 @@ withTestContext({
     expect_true(desc$RemoteHost == "api.bitbucket.org/2.0")
   })
 
+  test_that("packrat and remotes annotated descriptions are comparable", {
+    remotesDesc <- as.data.frame(readDcf("resources/descriptions/falsy.remotes"), stringsAsFactors = FALSE)
+    remotesRecord <- inferPackageRecord(remotesDesc)
+    packratDesc <- as.data.frame(readDcf("resources/descriptions/falsy.packrat"), stringsAsFactors = FALSE)
+    packratRecord <- inferPackageRecord(packratDesc)
+    diffed <- diff(list("falsy" = remotesRecord),
+                   list("falsy" = packratRecord))
+    expected <- c(
+      structure(rep.int('remove', 0), names = c()),
+      structure(rep.int('add', 0), names = c()),
+      structure(c(NA), names = c("falsy")))
+    expect_identical(diffed, expected)
+  })
 })


### PR DESCRIPTION
This change makes a `packrat` annotated DESCRIPTION and a `remotes` annotated DESCRIPTION more compatible; strip the `remote_*` fields before comparing package records.