### PR TITLE
handle pak RemoteType standard as a package from a cran-like repository

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -37,8 +37,8 @@ hash <- function(path, descLookup = installedDescLookup) {
   # Remote SHA backwards compatible with cache v2: use 'GithubSHA1' if exists, otherwise all 'Remote' fields
   remote_fields <- if ("GithubSHA1" %in% names(DESCRIPTION)) {
     "GithubSHA1"
-  } else if (is.null(DESCRIPTION[["RemoteType"]]) || DESCRIPTION[["RemoteType"]] == "cran") {
-    # Packages installed with install.packages or locally without remotes
+  } else if (is.null(DESCRIPTION[["RemoteType"]]) || DESCRIPTION[["RemoteType"]] %in% c("cran","standard") ) {
+    # Package installed from a CRAN-like repository by install.packages (null) or remotes (cran) or pak (standard)
     c()
   } else {
     # Mirror the order used by devtools when augmenting the DESCRIPTION.


### PR DESCRIPTION
See: https://github.com/r-lib/remotes/pull/310 and https://github.com/r-lib/remotes/issues/309