### PR TITLE
optional fields are not in package record when NULL; avoid identical in RemoteType compares

### DIFF
--- a/R/pkg.R
+++ b/R/pkg.R
@@ -283,6 +283,12 @@ getPackageRecords <- function(pkgNames,
   allRecords
 }
 
+# Return TRUE when the data frame for this package has the given RemoteType.
+hasRemoteType <- function(df, remoteType) {
+  # Do not compare with 'identical'; RemoteType may be a factor.
+  return (!is.null(df$RemoteType) && df$RemoteType == remoteType)
+}
+
 # Reads a description file and attempts to infer where the package came from.
 # Currently works only for packages installed from CRAN or from GitHub/Bitbucket/Gitlab using
 # devtools 1.4 or later.
@@ -290,86 +296,86 @@ inferPackageRecord <- function(df, available = availablePackages()) {
   name <- as.character(df$Package)
   ver <- as.character(df$Version)
 
-  if (length(df$GithubRepo) || identical(df$RemoteType, "github")) {
+  if (length(df$GithubRepo) || hasRemoteType(df, "github")) {
     # It's GitHub!
     return(structure(c(list(
-        name = name,
-        source = 'github',
-        version = ver,
-        gh_repo = as.character(df$GithubRepo),
-        gh_username = as.character(df$GithubUsername),
-        gh_ref = as.character(df$GithubRef),
-        gh_sha1 = as.character(df$GithubSHA1)),
-        c(gh_subdir = as.character(df$GithubSubdir)),
-        c(remote_host = as.character(df$RemoteHost)),
-        c(remote_repo = as.character(df$RemoteRepo)),
-        c(remote_username = as.character(df$RemoteUsername)),
-        c(remote_ref = as.character(df$RemoteRef)),
-        c(remote_sha = as.character(df$RemoteSha))),
-        class = c('packageRecord', 'github')))
-  } else if (identical(df$RemoteType, "bitbucket")) {
+      name = name,
+      source = 'github',
+      version = ver,
+      gh_repo = as.character(df$GithubRepo),
+      gh_username = as.character(df$GithubUsername),
+      gh_ref = as.character(df$GithubRef),
+      gh_sha1 = as.character(df$GithubSHA1)),
+      c(gh_subdir = as.character(df$GithubSubdir)),
+      c(remote_host = as.character(df$RemoteHost)),
+      c(remote_repo = as.character(df$RemoteRepo)),
+      c(remote_username = as.character(df$RemoteUsername)),
+      c(remote_ref = as.character(df$RemoteRef)),
+      c(remote_sha = as.character(df$RemoteSha))
+    ), class = c('packageRecord', 'github')))
+  } else if (hasRemoteType(df, "bitbucket")) {
     # It's Bitbucket!
     return(structure(c(list(
-        name = name,
-        source = 'bitbucket',
-        version = ver,
-        remote_repo = as.character(df$RemoteRepo),
-        remote_username = as.character(df$RemoteUsername),
-        remote_ref = as.character(df$RemoteRef),
-        remote_sha = as.character(df$RemoteSha)),
-        c(remote_host = as.character(df$RemoteHost)),
-        c(remote_subdir = as.character(df$RemoteSubdir))),
-        class = c('packageRecord', 'bitbucket')))
-  } else if (identical(df$RemoteType, "gitlab")) {
+      name = name,
+      source = 'bitbucket',
+      version = ver,
+      remote_repo = as.character(df$RemoteRepo),
+      remote_username = as.character(df$RemoteUsername),
+      remote_ref = as.character(df$RemoteRef),
+      remote_sha = as.character(df$RemoteSha)),
+      c(remote_host = as.character(df$RemoteHost)),
+      c(remote_subdir = as.character(df$RemoteSubdir))
+    ), class = c('packageRecord', 'bitbucket')))
+  } else if (hasRemoteType(df, "gitlab")) {
     # It's GitLab!
     return(structure(c(list(
-        name = name,
-        source = 'gitlab',
-        version = ver,
-        remote_repo = as.character(df$RemoteRepo),
-        remote_username = as.character(df$RemoteUsername),
-        remote_ref = as.character(df$RemoteRef),
-        remote_sha = as.character(df$RemoteSha)),
-        c(remote_host = as.character(df$RemoteHost))),
-        class = c('packageRecord', 'gitlab')))
+      name = name,
+      source = 'gitlab',
+      version = ver,
+      remote_repo = as.character(df$RemoteRepo),
+      remote_username = as.character(df$RemoteUsername),
+      remote_ref = as.character(df$RemoteRef),
+      remote_sha = as.character(df$RemoteSha)),
+      c(remote_host = as.character(df$RemoteHost))
+    ), class = c('packageRecord', 'gitlab')))
   } else if (identical(as.character(df$Priority), 'base')) {
     # It's a base package!
     return(NULL)
   } else if (length(df$biocViews)) {
     # It's Bioconductor!
     return(structure(list(
-        name = name,
-        source = 'Bioconductor',
-        version = ver),
-        class = c('packageRecord', 'Bioconductor')))
+      name = name,
+      source = 'Bioconductor',
+      version = ver
+    ), class = c('packageRecord', 'Bioconductor')))
   } else if (length(df$Repository) && identical(as.character(df$Repository), 'CRAN')) {
     # It's CRAN!
     return(structure(list(
-        name = name,
-        source = 'CRAN',
-        version = ver),
-        class = c('packageRecord', 'CRAN')))
+      name = name,
+      source = 'CRAN',
+      version = ver
+    ), class = c('packageRecord', 'CRAN')))
   } else if (length(df$Repository)) {
     # It's a package from a custom CRAN-like repo!
     return(structure(list(
-        name = name,
-        source = as.character(df$Repository),
-        version = ver),
-        class = c('packageRecord', 'CustomCRANLikeRepository')))
+      name = name,
+      source = as.character(df$Repository),
+      version = ver
+    ), class = c('packageRecord', 'CustomCRANLikeRepository')))
   } else if (name %in% rownames(available)) {
     # It's available on CRAN, so get it from CRAN!
     return(structure(list(
-        name = name,
-        source = 'CustomCRANLikeRepository',
-        version = ver),
-        class = c('packageRecord', 'CustomCRANLikeRepository')))
+      name = name,
+      source = 'CustomCRANLikeRepository',
+      version = ver
+    ), class = c('packageRecord', 'CustomCRANLikeRepository')))
   } else if (identical(as.character(df$InstallSource), "source")) {
     # It's a local source package!
     return(structure(list(
-        name = name,
-        source = 'source',
-        version = ver),
-        class = c('packageRecord', 'source')))
+      name = name,
+      source = 'source',
+      version = ver
+    ), class = c('packageRecord', 'source')))
   } else if ((identical(name, "manipulate") || identical(name, "rstudio")) &&
                identical(as.character(df$Author), "RStudio")) {
     # The 'manipulate' and 'rstudio' packages are auto-installed by RStudio
@@ -395,10 +401,10 @@ inferPackageRecord <- function(df, available = availablePackages()) {
     }
 
     return(structure(list(
-        name = name,
-        source = 'unknown',
-        version = ver),
-        class = 'packageRecord'))
+      name = name,
+      source = 'unknown',
+      version = ver
+    ), class = 'packageRecord'))
   }
 }
 
@@ -578,14 +584,8 @@ diff <- function(packageRecordsA, packageRecordsB) {
         return('upgrade')
       else if (verComp > 0)
         return('downgrade')
-      else {
-        ## printPackageRecord("pkgA", pkgA)
-        ## printPackageRecord("pkgB", pkgB)
-        ## printPackageRecord("strippedA", strippedA)
-        ## printPackageRecord("strippedB", strippedB)
-        
+      else
         return('crossgrade')
-      }
     }),
     names = both
   )

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -290,59 +290,86 @@ inferPackageRecord <- function(df, available = availablePackages()) {
   name <- as.character(df$Package)
   ver <- as.character(df$Version)
 
-  # Constructor function
-  record <- function(name, source, version, class, ...) {
-    structure(list(name = name, source = source, version = version, ...),
-              class = c('packageRecord', class))
-  }
-
   if (length(df$GithubRepo) || identical(df$RemoteType, "github")) {
     # It's GitHub!
-    return(record(name, 'github', ver, 'github',
-                  gh_repo = as.character(df$GithubRepo),
-                  gh_username = as.character(df$GithubUsername),
-                  gh_ref = as.character(df$GithubRef),
-                  gh_sha1 = as.character(df$GithubSHA1),
-                  gh_subdir = as.character(df$GithubSubdir),
-                  remote_host = as.character(df$RemoteHost),
-                  remote_repo = as.character(df$RemoteRepo),
-                  remote_username = as.character(df$RemoteUsername),
-                  remote_ref = as.character(df$RemoteRef),
-                  remote_sha = as.character(df$RemoteSha)))
+    return(structure(c(list(
+        name = name,
+        source = 'github',
+        version = ver,
+        gh_repo = as.character(df$GithubRepo),
+        gh_username = as.character(df$GithubUsername),
+        gh_ref = as.character(df$GithubRef),
+        gh_sha1 = as.character(df$GithubSHA1)),
+        c(gh_subdir = as.character(df$GithubSubdir)),
+        c(remote_host = as.character(df$RemoteHost)),
+        c(remote_repo = as.character(df$RemoteRepo)),
+        c(remote_username = as.character(df$RemoteUsername)),
+        c(remote_ref = as.character(df$RemoteRef)),
+        c(remote_sha = as.character(df$RemoteSha))),
+        class = c('packageRecord', 'github')))
   } else if (identical(df$RemoteType, "bitbucket")) {
     # It's Bitbucket!
-    return(record(name, 'bitbucket', ver, 'bitbucket',
-                  remote_repo = as.character(df$RemoteRepo),
-                  remote_username = as.character(df$RemoteUsername),
-                  remote_ref = as.character(df$RemoteRef),
-                  remote_sha = as.character(df$RemoteSha),
-                  remote_host = as.character(df$RemoteHost),
-                  remote_subdir = as.character(df$RemoteSubdir)))
+    return(structure(c(list(
+        name = name,
+        source = 'bitbucket',
+        version = ver,
+        remote_repo = as.character(df$RemoteRepo),
+        remote_username = as.character(df$RemoteUsername),
+        remote_ref = as.character(df$RemoteRef),
+        remote_sha = as.character(df$RemoteSha)),
+        c(remote_host = as.character(df$RemoteHost)),
+        c(remote_subdir = as.character(df$RemoteSubdir))),
+        class = c('packageRecord', 'bitbucket')))
   } else if (identical(df$RemoteType, "gitlab")) {
-    return(record(name, 'gitlab', ver, 'gitlab',
-                  remote_repo = as.character(df$RemoteRepo),
-                  remote_username = as.character(df$RemoteUsername),
-                  remote_ref = as.character(df$RemoteRef),
-                  remote_sha = as.character(df$RemoteSha),
-                  remote_host = as.character(df$RemoteHost)))
+    # It's GitLab!
+    return(structure(c(list(
+        name = name,
+        source = 'gitlab',
+        version = ver,
+        remote_repo = as.character(df$RemoteRepo),
+        remote_username = as.character(df$RemoteUsername),
+        remote_ref = as.character(df$RemoteRef),
+        remote_sha = as.character(df$RemoteSha)),
+        c(remote_host = as.character(df$RemoteHost))),
+        class = c('packageRecord', 'gitlab')))
   } else if (identical(as.character(df$Priority), 'base')) {
     # It's a base package!
     return(NULL)
   } else if (length(df$biocViews)) {
     # It's Bioconductor!
-    return(record(name, 'Bioconductor', ver, 'Bioconductor'))
+    return(structure(list(
+        name = name,
+        source = 'Bioconductor',
+        version = ver),
+        class = c('packageRecord', 'Bioconductor')))
   } else if (length(df$Repository) && identical(as.character(df$Repository), 'CRAN')) {
     # It's CRAN!
-    return(record(name, 'CRAN', ver, 'CRAN'))
+    return(structure(list(
+        name = name,
+        source = 'CRAN',
+        version = ver),
+        class = c('packageRecord', 'CRAN')))
   } else if (length(df$Repository)) {
     # It's a package from a custom CRAN-like repo!
-    return(record(name, as.character(df$Repository), ver, "CustomCRANLikeRepository"))
+    return(structure(list(
+        name = name,
+        source = as.character(df$Repository),
+        version = ver),
+        class = c('packageRecord', 'CustomCRANLikeRepository')))
   } else if (name %in% rownames(available)) {
     # It's available on CRAN, so get it from CRAN!
-    return(record(name, 'CustomCRANLikeRepository', ver, "CustomCRANLikeRepository"))
+    return(structure(list(
+        name = name,
+        source = 'CustomCRANLikeRepository',
+        version = ver),
+        class = c('packageRecord', 'CustomCRANLikeRepository')))
   } else if (identical(as.character(df$InstallSource), "source")) {
     # It's a local source package!
-    return(record(name, 'source', ver, 'source'))
+    return(structure(list(
+        name = name,
+        source = 'source',
+        version = ver),
+        class = c('packageRecord', 'source')))
   } else if ((identical(name, "manipulate") || identical(name, "rstudio")) &&
                identical(as.character(df$Author), "RStudio")) {
     # The 'manipulate' and 'rstudio' packages are auto-installed by RStudio
@@ -367,7 +394,11 @@ inferPackageRecord <- function(df, available = availablePackages()) {
       warning("Couldn't figure out the origin of package ", name)
     }
 
-    return(record(name, 'unknown', ver, NULL))
+    return(structure(list(
+        name = name,
+        source = 'unknown',
+        version = ver),
+        class = 'packageRecord'))
   }
 }
 
@@ -503,6 +534,12 @@ diffableRecord <- function(record) {
   record[recordNames]
 }
 
+# debug helper to print a package record. includes field names, type of value, and value.
+printPackageRecord <- function(name, record) {
+  cat(name, "\n")
+  cat(paste(names(record), lapply(record,typeof), record, sep = ":", collapse = "\n"),"\n")
+}
+
 # states: NA (unchanged), remove, add, upgrade, downgrade, crossgrade
 # (crossgrade means name and version was the same but something else was
 # different, i.e. different source or GitHub SHA1 hash or something)
@@ -525,6 +562,13 @@ diff <- function(packageRecordsA, packageRecordsB) {
       strippedA <- diffableRecord(pkgA)
       strippedB <- diffableRecord(pkgB)
 
+      ## Helpful when debugging unexpected differences between two package records.
+      ##
+      ## printPackageRecord("pkgA", pkgA)
+      ## printPackageRecord("pkgB", pkgB)
+      ## printPackageRecord("strippedA", strippedA)
+      ## printPackageRecord("strippedB", strippedB)
+
       if (identical(strippedA, strippedB)) {
         return(NA)
       }
@@ -534,8 +578,14 @@ diff <- function(packageRecordsA, packageRecordsB) {
         return('upgrade')
       else if (verComp > 0)
         return('downgrade')
-      else
+      else {
+        ## printPackageRecord("pkgA", pkgA)
+        ## printPackageRecord("pkgB", pkgB)
+        ## printPackageRecord("strippedA", strippedA)
+        ## printPackageRecord("strippedB", strippedB)
+        
         return('crossgrade')
+      }
     }),
     names = both
   )

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -279,12 +279,16 @@ withTestContext({
 
     # validate the installed package has properly annotated DESCRIPTION
     descpath <- file.path(libDir(projRoot), "falsy/DESCRIPTION")
-    desc <- as.data.frame(readDcf(descpath), stringsAsFactors = FALSE)
+    desc <- as.data.frame(readDcf(descpath))
     expect_true(desc$RemoteType == "gitlab")
     expect_true(desc$RemoteHost == "gitlab.com")
+
+    # confirm that packrat interprets this package as coming from gitlab.
+    record <- inferPackageRecord(desc)
+    expect_true(record$source == "gitlab")
   })
 
-  test_that("Packages restored from GitLab have RemoteType+RemoteHost in their DESCRIPTION", {
+  test_that("Packages restored from BitBucket have RemoteType+RemoteHost in their DESCRIPTION", {
     skip_on_cran()
     projRoot <- cloneTestProject("falsy-bitbucket")
 
@@ -293,15 +297,22 @@ withTestContext({
 
     # validate the installed package has properly annotated DESCRIPTION
     descpath <- file.path(libDir(projRoot), "falsy/DESCRIPTION")
-    desc <- as.data.frame(readDcf(descpath), stringsAsFactors = FALSE)
+    desc <- as.data.frame(readDcf(descpath))
     expect_true(desc$RemoteType == "bitbucket")
     expect_true(desc$RemoteHost == "api.bitbucket.org/2.0")
+
+    # confirm that packrat interprets this package as coming from bitbucket.
+    record <- inferPackageRecord(desc)
+    expect_true(record$source == "bitbucket")
+
+    # confirm remote subdir is not in the record (unused by this lockfile)
+    expect_false("remote_subdir" %in% names(record))
   })
 
   test_that("packrat and remotes annotated descriptions are comparable", {
-    remotesDesc <- as.data.frame(readDcf("resources/descriptions/falsy.remotes"), stringsAsFactors = FALSE)
+    remotesDesc <- as.data.frame(readDcf("resources/descriptions/falsy.remotes"))
     remotesRecord <- inferPackageRecord(remotesDesc)
-    packratDesc <- as.data.frame(readDcf("resources/descriptions/falsy.packrat"), stringsAsFactors = FALSE)
+    packratDesc <- as.data.frame(readDcf("resources/descriptions/falsy.packrat"))
     packratRecord <- inferPackageRecord(packratDesc)
     diffed <- diff(list("falsy" = remotesRecord),
                    list("falsy" = packratRecord))


### PR DESCRIPTION
The commit https://github.com/rstudio/packrat/commit/e329cf15ddfaed7786d2b6831d749d87c66eec2c from https://github.com/rstudio/packrat/pull/569 created a function to help construct package records. Unfortunately, those new records included fields that are sometimes NULL and should be omitted from the package record when NULL. Reverted the constructor for now.

The commit https://github.com/rstudio/packrat/commit/29a4fdcb5d34113222b73e4eb2affd0e3fc3f1fd started using `identical` to compare the `RemoteType` field. This will not compare if the incoming data frame was read from DCF with strings-as-factors.

The test failures on `master` were caused by these commits. This PR also includes a couple extra checks that would have helped identify the problems.