### PR TITLE
don't use rownames when looking for CRAN packages

### DIFF
--- a/R/pkg.R
+++ b/R/pkg.R
@@ -123,7 +123,7 @@ getPackageRecordsExternalSource <- function(pkgNames,
         result$source <- "CRAN"
       }
 
-    } else if (fallback.ok && pkgName %in% rownames(available)) {
+    } else if (fallback.ok && pkgName %in% available[, "Package"]) {
 
       # The package is not currently installed, but is available on CRAN.
       # Snapshot the latest available version for this package from CRAN.
@@ -362,7 +362,7 @@ inferPackageRecord <- function(df, available = availablePackages()) {
       source = 'Bioconductor',
       version = ver
     ), class = c('packageRecord', 'Bioconductor')))
-  } else if (name %in% rownames(available)) {
+  } else if (name %in% available[, "Package"]) {
     # It's available on CRAN, so get it from CRAN!
     return(structure(list(
       name = name,

--- a/R/restore.R
+++ b/R/restore.R
@@ -143,7 +143,7 @@ getSourceForPkgRecord <- function(pkgRecord,
 
     # Attempt to detect if this is the current version of a package
     # on a CRAN-like repository
-    currentVersion <- if (pkgRecord$name %in% rownames(availablePkgs))
+    currentVersion <- if (pkgRecord$name %in% availablePkgs[, "Package"])
       availablePkgs[pkgRecord$name, "Version"]
     else
       NA
@@ -685,7 +685,7 @@ installPkg <- function(pkgRecord,
   if (!(copiedFromCache || copiedFromUntrustedCache) &&
         hasBinaryRepositories() &&
         isFromCranlikeRepo(pkgRecord, repos) &&
-        pkgRecord$name %in% rownames(availablePackagesBinary(repos = repos)) &&
+        pkgRecord$name %in% availablePackagesBinary(repos = repos)[, "Package"] &&
         versionMatchesDb(pkgRecord, availablePackagesBinary(repos = repos)))
   {
     tempdir <- tempdir()

--- a/inst/resources/init.R
+++ b/inst/resources/init.R
@@ -106,7 +106,7 @@ local({
       }
 
       ## Try downloading packrat from CRAN if available
-      else if ("packrat" %in% rownames(available.packages())) {
+      else if ("packrat" %in% available.packages()[, "Package"]) {
         message("> Installing packrat from CRAN")
         install.packages("packrat")
       }


### PR DESCRIPTION
It's possible for an R session to be configured with multiple repositories, each providing different versions of a particular package. In such a case, the rownames of `available.packages()` may no longer be the package name; they may instead be e.g. `digest.1` with tags appended to ensure uniqueness.

To avoid this issue, we should query the `"Package"` field of the `available.packages()` output directly.

(Note that normally there will only be a single entry for each package, but this behavior can be adjusted by modifying the filters passed to `available.packages()`)