### PR TITLE
Optimise package search tree and insert verbose logger messages

### DIFF
--- a/R/pkg.R
+++ b/R/pkg.R
@@ -277,14 +277,19 @@ getPackageRecords <- function(pkgNames,
         logger(sprintf("- getting dependency %3i of %3i %s", .iii, .nnn, record$name))
         .iii <<- .iii + 1
       }
+
       deps <- getPackageDependencies(pkgs = record$name,
                                      lib.loc = lib.loc,
                                      available.packages = available)
 
       new  <- setdiff(deps, ls(envir = .visited.packages))
+      # Add the newly discovered dependencies to  visited packages
       for (pkg in new) {
         .visited.packages[[pkg]] <- TRUE
       }
+      # Also add the top level package
+      .visited.packages[[record$name]] <- TRUE
+
       deps <- new
 
       if (!is.null(deps) && length(deps)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -719,3 +719,23 @@ quietly <- function(expr) {
 onError <- function(default, expr) {
   tryCatch(expr, error = function(e) default)
 }
+
+
+# logger
+
+logTimestamper <- function() {
+  paste("[", as.character(Sys.time()), " packrat]", sep = "")
+}
+
+timestampedLog <- function(...) {
+  cat(paste(logTimestamper(), ..., "\n"))
+}
+
+# Returns a logging function when enabled, a noop function otherwise.
+verboseLogger <- function(verbose) {
+  if (verbose) {
+    timestampedLog
+  } else {
+    function(...) {}
+  }
+}


### PR DESCRIPTION
Packrat searches for recursive dependencies in the getPackageRecords() function.

However, if a package appears multiple times in the search tree, this recursion will run multiple times.

This PR optimizes the search tree by memorizing whether a package was searched before, and if so, skips the search the next time.

For my test case, this reduces the `packrat` snapshot time from 71 sec to 14 sec.