### PR TITLE
verbose package dependency analysis

### DIFF
--- a/R/pkg.R
+++ b/R/pkg.R
@@ -195,13 +195,12 @@ getPackageRecords <- function(pkgNames,
 
   # Prior recursive steps may have already computed this package record and
   # its recursive dependencies. Avoid constructing this package record.
-  priorPkgRecords <- c()
-  for (pkgName in pkgNames) {
-    if (exists(pkgName, envir = .visited.packages)) {
-      append(priorPkgRecords, get(pkgName, envir = .visited.packages))
-    }
+  priorPkgRecords <- dropNull(lapply(pkgNames, function(pkgName) {
+    get0(pkgName, envir = .visited.packages, ifnotfound = NULL)
+  }))
+  if (length(priorPkgRecords)) {
+    pkgNames <- setdiff(pkgNames, sapply(priorPkgRecords, "[[", "name"))
   }
-  pkgNames <- setdiff(pkgNames, sapply(priorPkgRecords, "[[", "name"))
 
   if (check.lockfile) {
     lockfilePkgRecords <- getPackageRecordsLockfile(pkgNames, project = project)

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -279,7 +279,7 @@ getPackageRecords <- function(pkgNames,
           missing.package = missing.package,
           check.lockfile = check.lockfile,
           fallback.ok = fallback.ok,
-          .visited.packages
+          .visited.packages = .visited.packages
         )
       }
 

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -196,7 +196,11 @@ getPackageRecords <- function(pkgNames,
   # Prior recursive steps may have already computed this package record and
   # its recursive dependencies. Avoid constructing this package record.
   priorPkgRecords <- dropNull(lapply(pkgNames, function(pkgName) {
-    get0(pkgName, envir = .visited.packages, ifnotfound = NULL)
+    if (exists(pkgName, envir = .visited.packages)) {
+      get(pkgName, envir = .visited.packages)
+    } else {
+      NULL
+    }
   }))
   if (length(priorPkgRecords)) {
     pkgNames <- setdiff(pkgNames, sapply(priorPkgRecords, "[[", "name"))

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -184,13 +184,19 @@ getPackageRecords <- function(pkgNames,
                               lib.loc = NULL,
                               missing.package = error_not_installed,
                               check.lockfile = FALSE,
-                              fallback.ok = FALSE)
+                              fallback.ok = FALSE,
+                              .visited.packages = new.env(parent = emptyenv()))
 {
   project <- getProjectDir(project)
   local.repos <- get_opts("local.repos", project = project)
 
   # screen out empty package names that might have snuck in
   pkgNames <- setdiff(pkgNames, "")
+
+  # avoid visiting other packages that have been recursively visited
+  pkgNames <- setdiff(pkgNames, ls(envir = .visited.packages))
+  # ... and then remember that we have visited these packages.
+  for (pkg in pkgNames) { .visited.packages[[pkg]] <- TRUE }
 
   if (check.lockfile) {
     lockfilePkgRecords <- getPackageRecordsLockfile(pkgNames, project = project)
@@ -272,7 +278,8 @@ getPackageRecords <- function(pkgNames,
           lib.loc = lib.loc,
           missing.package = missing.package,
           check.lockfile = check.lockfile,
-          fallback.ok = fallback.ok
+          fallback.ok = fallback.ok,
+          .visited.packages
         )
       }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -719,3 +719,21 @@ quietly <- function(expr) {
 onError <- function(default, expr) {
   tryCatch(expr, error = function(e) default)
 }
+
+# logger
+logTimestamper <- function() {
+  paste("[", as.character(Sys.time()), " packrat]", sep = "")
+}
+
+timestampedLog <- function(...) {
+  cat(paste(logTimestamper(), ..., "\n"))
+}
+
+# Returns a logging function when enabled, a noop function otherwise.
+verboseLogger <- function(verbose) {
+  if (verbose) {
+    timestampedLog
+  } else {
+    function(...) {}
+  }
+}


### PR DESCRIPTION
The option packrat.verbose.snapshot.dependencies prints additional detail about
the package dependency walk while constructing a project snapshot.

This is separate from the verbose option to .snapshotImpl, which is enabled
during normal packrat::snapshot use.

Note: This PR is layered on top of https://github.com/rstudio/packrat/pull/615 and replaces https://github.com/aronatkins/packrat/pull/1

Until https://github.com/rstudio/packrat/pull/615 is merged, those changes will show as differences, as well. You can see a more minimal diff at https://github.com/aronatkins/packrat/pull/2

CC @andrie

```R
# Enable additional tracing of the dependency walk...
options("packrat.verbose.snapshot.dependencies" = TRUE)
```

Sample output from a simple Shiny application; the trace indicates the walk depth, the current package, and if we are using prior results or computing as-new:

```
[2020-11-30 12:50:37 packrat] Detecting project dependencies 
[2020-11-30 12:50:37 packrat] Getting package records 
[2020-11-30 12:50:37 packrat] Getting inferred package records 
[2020-11-30 12:50:37 packrat] - (  1 /  21; depth=1) BH - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  2 /  21; depth=1) R6 - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  3 /  21; depth=1) Rcpp - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  4 /  21; depth=1) base64enc - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  5 /  21; depth=1) commonmark - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  6 /  21; depth=1) crayon - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  7 /  21; depth=1) digest - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  8 /  21; depth=1) fastmap - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  9 /  21; depth=1) glue - calculating dependencies 
[2020-11-30 12:50:37 packrat] - ( 10 /  21; depth=1) htmltools - calculating dependencies 
[2020-11-30 12:50:37 packrat] - (  1 /   3; depth=2) base64enc - using cached dependencies 
[2020-11-30 12:50:37 packrat] - (  2 /   3; depth=2) digest - using cached dependencies 
[2020-11-30 12:50:37 packrat] - (  3 /   3; depth=2) rlang - calculating dependencies 
[2020-11-30 12:50:37 packrat] - ( 11 /  21; depth=1) httpuv - calculating dependencies 
[2020-11-30 12:50:38 packrat] - (  1 /   5; depth=2) BH - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  2 /   5; depth=2) R6 - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  3 /   5; depth=2) Rcpp - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  4 /   5; depth=2) later - calculating dependencies 
[2020-11-30 12:50:38 packrat] - (  1 /   3; depth=3) BH - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  2 /   3; depth=3) Rcpp - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  3 /   3; depth=3) rlang - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  5 /   5; depth=2) promises - calculating dependencies 
[2020-11-30 12:50:38 packrat] - (  1 /   5; depth=3) R6 - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  2 /   5; depth=3) Rcpp - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  3 /   5; depth=3) later - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  4 /   5; depth=3) rlang - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  5 /   5; depth=3) magrittr - calculating dependencies 
[2020-11-30 12:50:38 packrat] - ( 12 /  21; depth=1) jsonlite - calculating dependencies 
[2020-11-30 12:50:38 packrat] - ( 13 /  21; depth=1) later - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 14 /  21; depth=1) magrittr - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 15 /  21; depth=1) mime - calculating dependencies 
[2020-11-30 12:50:38 packrat] - ( 16 /  21; depth=1) promises - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 17 /  21; depth=1) rlang - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 18 /  21; depth=1) shiny - calculating dependencies 
[2020-11-30 12:50:38 packrat] - (  1 /  16; depth=2) R6 - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  2 /  16; depth=2) commonmark - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  3 /  16; depth=2) crayon - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  4 /  16; depth=2) digest - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  5 /  16; depth=2) fastmap - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  6 /  16; depth=2) glue - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  7 /  16; depth=2) htmltools - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  8 /  16; depth=2) httpuv - using cached dependencies 
[2020-11-30 12:50:38 packrat] - (  9 /  16; depth=2) jsonlite - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 10 /  16; depth=2) later - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 11 /  16; depth=2) mime - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 12 /  16; depth=2) promises - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 13 /  16; depth=2) rlang - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 14 /  16; depth=2) sourcetools - calculating dependencies 
[2020-11-30 12:50:38 packrat] - ( 15 /  16; depth=2) withr - calculating dependencies 
[2020-11-30 12:50:38 packrat] - ( 16 /  16; depth=2) xtable - calculating dependencies 
[2020-11-30 12:50:38 packrat] - ( 19 /  21; depth=1) sourcetools - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 20 /  21; depth=1) withr - using cached dependencies 
[2020-11-30 12:50:38 packrat] - ( 21 /  21; depth=1) xtable - using cached dependencies 
[2020-11-30 12:50:38 packrat] Getting stale package records 
```