### PR TITLE
support repository names with commas

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,9 @@
 - Infer package dependencies from `requireNamespace()` and `loadNamespace()`
   only when the package name is character input. (#602)
 
+- Allow repository names with commas. Repository URLs containing commas are
+  still not supported. (#587)
+
 # Packrat 0.5.0
 
 - Packrat now supports both of BiocManager and BiocInstaller (as used for

--- a/tests/testthat/test-lockfile.R
+++ b/tests/testthat/test-lockfile.R
@@ -40,3 +40,75 @@ test_that("Repository is properly split by readLockFile", {
   )
 
 })
+
+test_that("multiple styles of repository parsing are supported", {
+  # One old style repository, no name. Assumed to be CRAN.
+  expect_equal(
+    parseRepositories("A"),
+    c(CRAN = "A")
+  )
+
+  # Two old repositories, no names.
+  expect_warning(parseRepositories("A,B"))
+
+  # One repository, no whitespace separating name and URL
+  expect_equal(
+    parseRepositories("A=B"),
+    c(A = "B")
+  )
+
+  # One repository, whitespace separating name and URL
+  expect_equal(
+    parseRepositories("A = B"),
+    c(A = "B")
+  )
+
+  # Two repositories, no whitespace.
+  expect_equal(
+    parseRepositories("A=B,C=D"),
+    c(A = "B", C = "D")
+  )
+
+  # Two repositories, with whitespace.
+  expect_equal(
+    parseRepositories("A = B , C = D"),
+    c(A = "B", C = "D")
+  )
+
+  # Two repositories, with newlines.
+  expect_equal(
+    parseRepositories("A = B,\nC = D\n"),
+    c(A = "B", C = "D")
+  )
+
+  # Three repositories
+  repos <- parseRepositories("A = B,\nC = D,\nE = F\n")
+  expect_equal(
+    repos,
+    c(A = "B", C = "D", E = "F")
+  )
+
+  # Four repositories
+  expect_equal(
+    parseRepositories("A = B,\nC = D,\nE = F,\nG = H\n"),
+    c(A = "B", C = "D", E = "F", G = "H")
+  )
+
+  # One repository name with a comma
+  expect_equal(
+    parseRepositories("A,B=C"),
+    c("A,B" = "C")
+  )
+
+  # Two repository names with commas
+  expect_equal(
+    parseRepositories("A,B=C,D,E=F"),
+    c("A,B" = "C", "D,E" = "F")
+  )
+
+  # Three repository names with commas
+  expect_equal(
+    parseRepositories("A,B=C,D,E=F,G,H=I"),
+    c("A,B" = "C", "D,E" = "F", "G,H" = "I")
+  )
+})


### PR DESCRIPTION
This change adds repository name support to lockfile parsing without
introducing quoting or escaping. It assumes that URLs may be part of repository
names but are unlikely to occur in repository URLs.

This means that a repository value of:

    A=B,C,D=E

is interpreted as:

    A=B
    "C,D"=E

We will need to introduce quoting / escaping if we encounter commas in URLs as
well as repository names.

fixes #587