### PR TITLE
define setNames ahead of options.R

### DIFF
--- a/R/aaa-globals.R
+++ b/R/aaa-globals.R
@@ -40,3 +40,9 @@ new_defaults = function(value = list()) {
   origLibPaths = NULL,
   project = NULL
 ))
+
+# Work around namespace:stats potentially not being loaded
+setNames <- function(object = nm, nm) {
+  names(object) <- nm
+  object
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -507,12 +507,6 @@ loadedNamespacePaths <- function() {
   result
 }
 
-# Work around namespace:stats potentially not being loaded
-setNames <- function(object = nm, nm) {
-  names(object) <- nm
-  object
-}
-
 # Drop null values in a list
 dropNull <- function(x) {
   Filter(Negate(is.null), x)


### PR DESCRIPTION
The utils.R definition of setNames was not visible to the package-build-time
calls to setNames in options.R because of R file-load order. As a result,
packrat would fall back to stats::setNames or err if stats was not loaded.