### PR TITLE
stop requiring devtools for SCM restores

### DIFF
--- a/R/bitbucket.R
+++ b/R/bitbucket.R
@@ -3,7 +3,7 @@ isBitbucketURL <- function(url) {
 }
 
 canUseBitbucketDownloader <- function() {
-  all(packageVersionInstalled(devtools = "1.9.1", httr = "1.0.0"))
+  all(packageVersionInstalled(httr = "1.0.0"))
 }
 
 bitbucketDownload <- function(url, destfile, ...) {

--- a/R/github.R
+++ b/R/github.R
@@ -7,20 +7,22 @@ canUseGitHubDownloader <- function() {
 }
 
 githubDownload <- function(url, destfile, ...) {
-  onError(1, {
-    authenticate    <- yoink("httr", "authenticate")
-    GET             <- yoink("httr", "GET")
-    content         <- yoink("httr", "content")
+  onError(1, githubDownloadImpl(url, destfile, ...))
+}
 
-    token <- github_pat(quiet = TRUE)
-    auth <- if (!is.null(token))
-      authenticate(token, "x-oauth-basic", "basic")
-    else
-      list()
-    request <- GET(url, auth)
-    writeBin(content(request, "raw"), destfile)
-    if (file.exists(destfile)) 0 else 1
-  })
+githubDownloadImpl <- function(url, destfile, ...) {
+  authenticate    <- yoink("httr", "authenticate")
+  GET             <- yoink("httr", "GET")
+  content         <- yoink("httr", "content")
+
+  token <- github_pat(quiet = TRUE)
+  auth <- if (!is.null(token))
+            authenticate(token, "x-oauth-basic", "basic")
+          else
+            list()
+  request <- GET(url, auth)
+  if (request$status == 200) writeBin(content(request, "raw"), destfile)
+  if (file.exists(destfile)) 0 else 1
 }
 
 #' Retrieve GitHub personal access token.

--- a/R/github.R
+++ b/R/github.R
@@ -3,12 +3,11 @@ isGitHubURL <- function(url) {
 }
 
 canUseGitHubDownloader <- function() {
-  all(packageVersionInstalled(devtools = "1.9.1", httr = "1.0.0"))
+  all(packageVersionInstalled(httr = "1.0.0"))
 }
 
 githubDownload <- function(url, destfile, ...) {
   onError(1, {
-    github_pat      <- yoink("devtools", "github_pat")
     authenticate    <- yoink("httr", "authenticate")
     GET             <- yoink("httr", "GET")
     content         <- yoink("httr", "content")
@@ -22,4 +21,21 @@ githubDownload <- function(url, destfile, ...) {
     writeBin(content(request, "raw"), destfile)
     if (file.exists(destfile)) 0 else 1
   })
+}
+
+#' Retrieve GitHub personal access token.
+#'
+#' A GitHub personal access token
+#' Looks in env var `GITHUB_PAT`
+#'
+#' @keywords internal
+github_pat <- function(quiet = TRUE) {
+  pat <- Sys.getenv("GITHUB_PAT")
+  if (nzchar(pat)) {
+    if (!quiet) {
+      message("Using GitHub PAT from envvar GITHUB_PAT")
+    }
+    return(pat)
+  }
+  return(NULL)
 }

--- a/R/gitlab.R
+++ b/R/gitlab.R
@@ -3,7 +3,7 @@ isGitlabURL <- function(url) {
 }
 
 canUseGitlabDownloader <- function() {
-  all(packageVersionInstalled(devtools = "1.9.1", httr = "1.0.0"))
+  all(packageVersionInstalled(httr = "1.0.0"))
 }
 
 gitlabDownload <- function(url, destfile, ...) {


### PR DESCRIPTION
Playing with this idea as we're debugging an issue when downloading private GitHub packages. Untested at this point.