### PR TITLE
don't attempt to execute non-R engines; suppress knitr warnings for unknown engines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # Packrat 0.7.0 (UNRELEASED)
 
+- Fixed an issue where Packrat could inadvertently execute non-R code chunks
+  when scanning R Markdown documents for dependencies.
+
+- Fixed an issue where a knitr warning would be emitted when scanning an
+  R Markdown document containing unknown or un-registered knitr engines.
+  (#639)
+
 - Packrat identifies additional code dependencies, including package
   references used to define function argument default values. (#630)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -623,7 +623,7 @@ fileDependencies.evaluate <- function(file) {
 
   # keep going on error
   chunkOptions <- knitr::opts_chunk$get()
-  on.exit(knitr::opts_chunk$restore(chunkOptions))
+  on.exit(knitr::opts_chunk$restore(chunkOptions), add = TRUE)
   knitr::opts_chunk$set(error = TRUE)
 
   # rudely override knitr's 'inline_exec' function so

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -232,7 +232,7 @@ fileDependencies.Markdown <- function(file, implicit = NULL) {
   if (!is.null(implicit)) {
     deps <- c(deps, implicit)
   }
-  
+
   # try using an evaluate-based approach for dependencies
   if (knitrHasEvaluateHook()) {
 
@@ -597,6 +597,16 @@ fileDependencies.evaluate <- function(file) {
   # discovered packages (to be updated by evaluate hook)
   deps <- list()
 
+  # override any existing engines -- we don't want dependency discovery
+  # to, say, run arbitrary bash scripts contained in the document!
+  engines <- knitr::knit_engines$get()
+  on.exit(knitr::knit_engines$restore(engines), add = TRUE)
+
+  overrides <- replicate(length(engines), function(options) {}, FALSE)
+  names(overrides) <- names(engines)
+  overrides$R <- overrides$Rscript <- NULL
+  knitr::knit_engines$set(overrides)
+
   # save old hook and install our custom hook
   evaluate_hook <- knitr::knit_hooks$get("evaluate")
   on.exit(knitr::knit_hooks$set(evaluate = evaluate_hook), add = TRUE)
@@ -636,12 +646,28 @@ fileDependencies.evaluate <- function(file) {
   }
 
   # attempt to render document with our custom hook active
+  # TODO: do we want to report errors here? right now we're just
+  # capturing and silently discarding render errors
   outfile <- tempfile()
+  on.exit(unlink(outfile), add = TRUE)
+
   tryCatch(
-    rmarkdown::render(file, output_file = outfile, quiet = TRUE),
+    withCallingHandlers(
+      rmarkdown::render(file, output_file = outfile, quiet = TRUE),
+      warning = function(w) {
+
+        # ignore warnings emitted by knitr::get_engine()
+        get_engine <- yoink("knitr", "get_engine")
+        for (i in seq_len(sys.nframe())) {
+          fn <- sys.function(i)
+          if (identical(fn, get_engine))
+            invokeRestart("muffleWarning")
+        }
+
+      }
+    ),
     error = identity
   )
-  unlink(outfile)
 
   unique(unlist(deps, recursive = TRUE))
 }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -602,9 +602,13 @@ fileDependencies.evaluate <- function(file) {
   engines <- knitr::knit_engines$get()
   on.exit(knitr::knit_engines$restore(engines), add = TRUE)
 
+  # generate overrides
   overrides <- replicate(length(engines), function(options) {}, FALSE)
   names(overrides) <- names(engines)
-  overrides$R <- overrides$Rscript <- NULL
+
+  # retain the regular R knitr hook, and treat Rscript chunks
+  # the same way as "regular" R chunks
+  overrides$R <- overrides$Rscript <- engines$R
   knitr::knit_engines$set(overrides)
 
   # save old hook and install our custom hook

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -617,6 +617,11 @@ fileDependencies.evaluate <- function(file) {
     })
   })
 
+  # keep going on error
+  chunkOptions <- knitr::opts_chunk$get()
+  on.exit(knitr::opts_chunk$restore(chunkOptions))
+  knitr::opts_chunk$set(error = TRUE)
+
   # rudely override knitr's 'inline_exec' function so
   # that we can detect dependencies within inline chunks
   knitr <- asNamespace("knitr")

--- a/tests/testthat/resources/unknown-engines.Rmd
+++ b/tests/testthat/resources/unknown-engines.Rmd
@@ -9,3 +9,7 @@ an unknown engine
 ```{r engine="mystery"}
 a mysterious engine
 ```
+
+```{Rscript}
+stop("don't run me")
+```

--- a/tests/testthat/resources/unknown-engines.Rmd
+++ b/tests/testthat/resources/unknown-engines.Rmd
@@ -1,0 +1,11 @@
+---
+title: A title.
+---
+
+```{unknown}
+an unknown engine
+```
+
+```{r engine="mystery"}
+a mysterious engine
+```

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -107,6 +107,7 @@ test_that("dependencies in function default values are discovered", {
 
 test_that("knitr doesn't warn about unknown engines in dependency discovery", {
   skip_on_cran()
+
   file <- "resources/unknown-engines.Rmd"
 
   caughtWarning <- NULL

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -116,7 +116,7 @@ test_that("knitr doesn't warn about unknown engines in dependency discovery", {
     warning = function(w) caughtWarning <<- w
   )
 
-  expect_true(is.null(caughtWarning))
+  expect_null(caughtWarning)
   expect_equal(deps, "rmarkdown")
 
 })

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -84,6 +84,7 @@ test_that("dependencies are discovered in R Markdown documents in independent R 
 
   # shiny_prerendered file
   expect_true("shiny" %in% brokenDeps)
+
   # check for working chunks
   expect_true(all(
     c("pkgA", "pkgB", "pkgD", "pkgF", "pkgG") %in% brokenDeps

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -103,3 +103,18 @@ test_that("dependencies in function default values are discovered", {
   emojiR <- file.path("resources", "emoji.R")
   expect_equal(packrat:::fileDependencies(emojiR), "emo")
 })
+
+test_that("knitr doesn't warn about unknown engines in dependency discovery", {
+  skip_on_cran()
+  file <- "resources/unknown-engines.Rmd"
+
+  caughtWarning <- NULL
+  deps <- withCallingHandlers(
+    packrat:::fileDependencies(file),
+    warning = function(w) caughtWarning <<- w
+  )
+
+  expect_true(is.null(caughtWarning))
+  expect_equal(deps, "rmarkdown")
+
+})


### PR DESCRIPTION
Closes https://github.com/rstudio/packrat/issues/639.

This also resolves an issue where Packrat would execute non-R code chunks during the dependency discovery process (😱 ) by overriding any other engines during dependency discovery.