### PR TITLE
initial forklift of renv dependency scanning

### DIFF
--- a/R/renv-bootstrap.R
+++ b/R/renv-bootstrap.R
@@ -1,0 +1,571 @@
+
+bootstrap <- function(version, library) {
+
+  # attempt to download renv
+  tarball <- tryCatch(renv_bootstrap_download(version), error = identity)
+  if (inherits(tarball, "error"))
+    stop("failed to download renv ", version)
+
+  # now attempt to install
+  status <- tryCatch(renv_bootstrap_install(version, tarball, library), error = identity)
+  if (inherits(status, "error"))
+    stop("failed to install renv ", version)
+
+}
+
+renv_bootstrap_tests_running <- function() {
+  getOption("renv.tests.running", default = FALSE)
+}
+
+renv_bootstrap_repos <- function() {
+
+  # check for repos override
+  repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
+  if (!is.na(repos))
+    return(repos)
+
+  # if we're testing, re-use the test repositories
+  if (renv_bootstrap_tests_running())
+    return(getOption("renv.tests.repos"))
+
+  # retrieve current repos
+  repos <- getOption("repos")
+
+  # ensure @CRAN@ entries are resolved
+  repos[repos == "@CRAN@"] <- getOption(
+    "renv.repos.cran",
+    "https://cloud.r-project.org"
+  )
+
+  # add in renv.bootstrap.repos if set
+  default <- c(FALLBACK = "https://cloud.r-project.org")
+  extra <- getOption("renv.bootstrap.repos", default = default)
+  repos <- c(repos, extra)
+
+  # remove duplicates that might've snuck in
+  dupes <- duplicated(repos) | duplicated(names(repos))
+  repos[!dupes]
+
+}
+
+renv_bootstrap_download <- function(version) {
+
+  # if the renv version number has 4 components, assume it must
+  # be retrieved via github
+  nv <- numeric_version(version)
+  components <- unclass(nv)[[1]]
+
+  methods <- if (length(components) == 4L) {
+    list(
+      renv_bootstrap_download_github
+    )
+  } else {
+    list(
+      renv_bootstrap_download_cran_latest,
+      renv_bootstrap_download_cran_archive
+    )
+  }
+
+  for (method in methods) {
+    path <- tryCatch(method(version), error = identity)
+    if (is.character(path) && file.exists(path))
+      return(path)
+  }
+
+  stop("failed to download renv ", version)
+
+}
+
+renv_bootstrap_download_impl <- function(url, destfile) {
+
+  mode <- "wb"
+
+  # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17715
+  fixup <-
+    Sys.info()[["sysname"]] == "Windows" &&
+    substring(url, 1L, 5L) == "file:"
+
+  if (fixup)
+    mode <- "w+b"
+
+  utils::download.file(
+    url      = url,
+    destfile = destfile,
+    mode     = mode,
+    quiet    = TRUE
+  )
+
+}
+
+renv_bootstrap_download_cran_latest <- function(version) {
+
+  spec <- renv_bootstrap_download_cran_latest_find(version)
+
+  message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+
+  type  <- spec$type
+  repos <- spec$repos
+
+  info <- tryCatch(
+    utils::download.packages(
+      pkgs    = "renv",
+      destdir = tempdir(),
+      repos   = repos,
+      type    = type,
+      quiet   = TRUE
+    ),
+    condition = identity
+  )
+
+  if (inherits(info, "condition")) {
+    message("FAILED")
+    return(FALSE)
+  }
+
+  # report success and return
+  message("OK (downloaded ", type, ")")
+  info[1, 2]
+
+}
+
+renv_bootstrap_download_cran_latest_find <- function(version) {
+
+  # check whether binaries are supported on this system
+  binary <-
+    getOption("renv.bootstrap.binary", default = TRUE) &&
+    !identical(.Platform$pkgType, "source") &&
+    !identical(getOption("pkgType"), "source") &&
+    Sys.info()[["sysname"]] %in% c("Darwin", "Windows")
+
+  types <- c(if (binary) "binary", "source")
+
+  # iterate over types + repositories
+  for (type in types) {
+    for (repos in renv_bootstrap_repos()) {
+
+      # retrieve package database
+      db <- tryCatch(
+        as.data.frame(
+          utils::available.packages(type = type, repos = repos),
+          stringsAsFactors = FALSE
+        ),
+        error = identity
+      )
+
+      if (inherits(db, "error"))
+        next
+
+      # check for compatible entry
+      entry <- db[db$Package %in% "renv" & db$Version %in% version, ]
+      if (nrow(entry) == 0)
+        next
+
+      # found it; return spec to caller
+      spec <- list(entry = entry, type = type, repos = repos)
+      return(spec)
+
+    }
+  }
+
+  # if we got here, we failed to find renv
+  fmt <- "renv %s is not available from your declared package repositories"
+  stop(sprintf(fmt, version))
+
+}
+
+renv_bootstrap_download_cran_archive <- function(version) {
+
+  name <- sprintf("renv_%s.tar.gz", version)
+  repos <- renv_bootstrap_repos()
+  urls <- file.path(repos, "src/contrib/Archive/renv", name)
+  destfile <- file.path(tempdir(), name)
+
+  message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+
+  for (url in urls) {
+
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
+      condition = identity
+    )
+
+    if (identical(status, 0L)) {
+      message("OK")
+      return(destfile)
+    }
+
+  }
+
+  message("FAILED")
+  return(FALSE)
+
+}
+
+renv_bootstrap_download_github <- function(version) {
+
+  enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
+  if (!identical(enabled, "TRUE"))
+    return(FALSE)
+
+  # prepare download options
+  pat <- Sys.getenv("GITHUB_PAT")
+  if (nzchar(Sys.which("curl")) && nzchar(pat)) {
+    fmt <- "--location --fail --header \"Authorization: token %s\""
+    extra <- sprintf(fmt, pat)
+    saved <- options("download.file.method", "download.file.extra")
+    options(download.file.method = "curl", download.file.extra = extra)
+    on.exit(do.call(base::options, saved), add = TRUE)
+  } else if (nzchar(Sys.which("wget")) && nzchar(pat)) {
+    fmt <- "--header=\"Authorization: token %s\""
+    extra <- sprintf(fmt, pat)
+    saved <- options("download.file.method", "download.file.extra")
+    options(download.file.method = "wget", download.file.extra = extra)
+    on.exit(do.call(base::options, saved), add = TRUE)
+  }
+
+  message("* Downloading renv ", version, " from GitHub ... ", appendLF = FALSE)
+
+  url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
+  name <- sprintf("renv_%s.tar.gz", version)
+  destfile <- file.path(tempdir(), name)
+
+  status <- tryCatch(
+    renv_bootstrap_download_impl(url, destfile),
+    condition = identity
+  )
+
+  if (!identical(status, 0L)) {
+    message("FAILED")
+    return(FALSE)
+  }
+
+  message("OK")
+  return(destfile)
+
+}
+
+renv_bootstrap_install <- function(version, tarball, library) {
+
+  # attempt to install it into project library
+  message("* Installing renv ", version, " ... ", appendLF = FALSE)
+  dir.create(library, showWarnings = FALSE, recursive = TRUE)
+
+  # invoke using system2 so we can capture and report output
+  bin <- R.home("bin")
+  exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
+  r <- file.path(bin, exe)
+  args <- c("--vanilla", "CMD", "INSTALL", "-l", shQuote(library), shQuote(tarball))
+  output <- system2(r, args, stdout = TRUE, stderr = TRUE)
+  message("Done!")
+
+  # check for successful install
+  status <- attr(output, "status")
+  if (is.numeric(status) && !identical(status, 0L)) {
+    header <- "Error installing renv:"
+    lines <- paste(rep.int("=", nchar(header)), collapse = "")
+    text <- c(header, lines, output)
+    writeLines(text, con = stderr())
+  }
+
+  status
+
+}
+
+renv_bootstrap_platform_prefix <- function() {
+
+  # construct version prefix
+  version <- paste(R.version$major, R.version$minor, sep = ".")
+  prefix <- paste("R", numeric_version(version)[1, 1:2], sep = "-")
+
+  # include SVN revision for development versions of R
+  # (to avoid sharing platform-specific artefacts with released versions of R)
+  devel <-
+    identical(R.version[["status"]],   "Under development (unstable)") ||
+    identical(R.version[["nickname"]], "Unsuffered Consequences")
+
+  if (devel)
+    prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
+
+  # build list of path components
+  components <- c(prefix, R.version$platform)
+
+  # include prefix if provided by user
+  prefix <- renv_bootstrap_platform_prefix_impl()
+  if (!is.na(prefix) && nzchar(prefix))
+    components <- c(prefix, components)
+
+  # build prefix
+  paste(components, collapse = "/")
+
+}
+
+renv_bootstrap_platform_prefix_impl <- function() {
+
+  # if an explicit prefix has been supplied, use it
+  prefix <- Sys.getenv("RENV_PATHS_PREFIX", unset = NA)
+  if (!is.na(prefix))
+    return(prefix)
+
+  # if the user has requested an automatic prefix, generate it
+  auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
+  if (auto %in% c("TRUE", "True", "true", "1"))
+    return(renv_bootstrap_platform_prefix_auto())
+
+  # empty string on failure
+  ""
+
+}
+
+renv_bootstrap_platform_prefix_auto <- function() {
+
+  prefix <- tryCatch(renv_bootstrap_platform_os(), error = identity)
+  if (inherits(prefix, "error") || prefix %in% "unknown") {
+
+    msg <- paste(
+      "failed to infer current operating system",
+      "please file a bug report at https://github.com/rstudio/renv/issues",
+      sep = "; "
+    )
+
+    warning(msg)
+
+  }
+
+  prefix
+
+}
+
+renv_bootstrap_platform_os <- function() {
+
+  sysinfo <- Sys.info()
+  sysname <- sysinfo[["sysname"]]
+
+  # handle Windows + macOS up front
+  if (sysname == "Windows")
+    return("windows")
+  else if (sysname == "Darwin")
+    return("macos")
+
+  # check for os-release files
+  for (file in c("/etc/os-release", "/usr/lib/os-release"))
+    if (file.exists(file))
+      return(renv_bootstrap_platform_os_via_os_release(file, sysinfo))
+
+  # check for redhat-release files
+  if (file.exists("/etc/redhat-release"))
+    return(renv_bootstrap_platform_os_via_redhat_release())
+
+  "unknown"
+
+}
+
+renv_bootstrap_platform_os_via_os_release <- function(file, sysinfo) {
+
+  # read /etc/os-release
+  release <- utils::read.table(
+    file             = file,
+    sep              = "=",
+    quote            = c("\"", "'"),
+    col.names        = c("Key", "Value"),
+    comment.char     = "#",
+    stringsAsFactors = FALSE
+  )
+
+  vars <- as.list(release$Value)
+  names(vars) <- release$Key
+
+  # get os name
+  os <- tolower(sysinfo[["sysname"]])
+
+  # read id
+  id <- "unknown"
+  for (field in c("ID", "ID_LIKE")) {
+    if (field %in% names(vars) && nzchar(vars[[field]])) {
+      id <- vars[[field]]
+      break
+    }
+  }
+
+  # read version
+  version <- "unknown"
+  for (field in c("UBUNTU_CODENAME", "VERSION_CODENAME", "VERSION_ID", "BUILD_ID")) {
+    if (field %in% names(vars) && nzchar(vars[[field]])) {
+      version <- vars[[field]]
+      break
+    }
+  }
+
+  # join together
+  paste(c(os, id, version), collapse = "-")
+
+}
+
+renv_bootstrap_platform_os_via_redhat_release <- function() {
+
+  # read /etc/redhat-release
+  contents <- readLines("/etc/redhat-release", warn = FALSE)
+
+  # infer id
+  id <- if (grepl("centos", contents, ignore.case = TRUE))
+    "centos"
+  else if (grepl("redhat", contents, ignore.case = TRUE))
+    "redhat"
+  else
+    "unknown"
+
+  # try to find a version component (very hacky)
+  version <- "unknown"
+
+  parts <- strsplit(contents, "[[:space:]]")[[1L]]
+  for (part in parts) {
+
+    nv <- tryCatch(numeric_version(part), error = identity)
+    if (inherits(nv, "error"))
+      next
+
+    version <- nv[1, 1]
+    break
+
+  }
+
+  paste(c("linux", id, version), collapse = "-")
+
+}
+
+renv_bootstrap_library_root_name <- function(project) {
+
+  # use project name as-is if requested
+  asis <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT_ASIS", unset = "FALSE")
+  if (asis)
+    return(basename(project))
+
+  # otherwise, disambiguate based on project's path
+  id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
+  paste(basename(project), id, sep = "-")
+
+}
+
+renv_bootstrap_library_root <- function(project) {
+
+  path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
+  if (!is.na(path))
+    return(path)
+
+  path <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
+  if (!is.na(path)) {
+    name <- renv_bootstrap_library_root_name(project)
+    return(file.path(path, name))
+  }
+
+  prefix <- renv_bootstrap_profile_prefix()
+  paste(c(project, prefix, "renv/library"), collapse = "/")
+
+}
+
+renv_bootstrap_validate_version <- function(version) {
+
+  loadedversion <- utils::packageDescription("renv", fields = "Version")
+  if (version == loadedversion)
+    return(TRUE)
+
+  # assume four-component versions are from GitHub; three-component
+  # versions are from CRAN
+  components <- strsplit(loadedversion, "[.-]")[[1]]
+  remote <- if (length(components) == 4L)
+    paste("rstudio/renv", loadedversion, sep = "@")
+  else
+    paste("renv", loadedversion, sep = "@")
+
+  fmt <- paste(
+    "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
+    "Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
+    "Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
+    sep = "\n"
+  )
+
+  msg <- sprintf(fmt, loadedversion, version, remote)
+  warning(msg, call. = FALSE)
+
+  FALSE
+
+}
+
+renv_bootstrap_hash_text <- function(text) {
+
+  hashfile <- tempfile("renv-hash-")
+  on.exit(unlink(hashfile), add = TRUE)
+
+  writeLines(text, con = hashfile)
+  tools::md5sum(hashfile)
+
+}
+
+renv_bootstrap_load <- function(project, libpath, version) {
+
+  # try to load renv from the project library
+  if (!requireNamespace("renv", lib.loc = libpath, quietly = TRUE))
+    return(FALSE)
+
+  # warn if the version of renv loaded does not match
+  renv_bootstrap_validate_version(version)
+
+  # load the project
+  renv::load(project)
+
+  TRUE
+
+}
+
+renv_bootstrap_profile_load <- function(project) {
+
+  # if RENV_PROFILE is already set, just use that
+  profile <- Sys.getenv("RENV_PROFILE", unset = NA)
+  if (!is.na(profile) && nzchar(profile))
+    return(profile)
+
+  # check for a profile file (nothing to do if it doesn't exist)
+  path <- file.path(project, "renv/local/profile")
+  if (!file.exists(path))
+    return(NULL)
+
+  # read the profile, and set it if it exists
+  contents <- readLines(path, warn = FALSE)
+  if (length(contents) == 0L)
+    return(NULL)
+
+  # set RENV_PROFILE
+  profile <- contents[[1L]]
+  if (nzchar(profile))
+    Sys.setenv(RENV_PROFILE = profile)
+
+  profile
+
+}
+
+renv_bootstrap_profile_prefix <- function() {
+  profile <- renv_bootstrap_profile_get()
+  if (!is.null(profile))
+    return(file.path("renv/profiles", profile))
+}
+
+renv_bootstrap_profile_get <- function() {
+  profile <- Sys.getenv("RENV_PROFILE", unset = "")
+  renv_bootstrap_profile_normalize(profile)
+}
+
+renv_bootstrap_profile_set <- function(profile) {
+  profile <- renv_bootstrap_profile_normalize(profile)
+  if (is.null(profile))
+    Sys.unsetenv("RENV_PROFILE")
+  else
+    Sys.setenv(RENV_PROFILE = profile)
+}
+
+renv_bootstrap_profile_normalize <- function(profile) {
+
+  if (is.null(profile) || profile %in% c("", "default"))
+    return(NULL)
+
+  profile
+
+}

--- a/R/renv-call.R
+++ b/R/renv-call.R
@@ -1,0 +1,78 @@
+
+# given a call of the form e.g. 'pkg::foo()' or 'foo()',
+# check that method 'foo()' is truly being called and
+# strip off the 'pkg::' part for easier parsing
+renv_call_expect <- function(node, package, methods) {
+
+  if (!is.call(node))
+    return(NULL)
+
+  # check for call of the form 'pkg::foo(a, b, c)'
+  colon <-
+    is.call(node[[1L]]) &&
+    is.name(node[[1L]][[1L]]) &&
+    as.character(node[[1L]][[1L]]) %in% c("::", ":::")
+
+  if (colon) {
+
+    # validate the package name
+    lhs <- node[[1L]][[2L]]
+    if (as.character(lhs) != package)
+      return(NULL)
+
+    # extract the inner call
+    rhs <- node[[1L]][[3L]]
+    node[[1L]] <- rhs
+  }
+
+  # check for method match
+  match <-
+    is.name(node[[1L]]) &&
+    as.character(node[[1L]]) %in% methods
+
+  if (!match)
+    return(NULL)
+
+  node
+
+}
+
+renv_call_normalize <- function(node, stack) {
+
+  # check for magrittr pipe -- if this part of the expression is
+  # being piped into, then we need to munge the call
+  ispipe <-
+    is.call(node) &&
+    is.symbol(node[[1L]]) &&
+    as.character(node[[1L]]) %in% c("%>%", "%T>%", "%<>%")
+
+  if (!ispipe)
+    return(node)
+
+  # get lhs and rhs of piped expression
+  lhs <- node[[2L]]
+  rhs <- node[[3L]]
+
+  # handle rhs symbols
+  if (is.symbol(rhs))
+    rhs <- call(as.character(rhs))
+
+  # check for usage of '.'
+  # if it exists, replace each with lhs
+  hasdot <- FALSE
+  dot <- as.symbol(".")
+  for (i in seq_along(rhs)) {
+    if (identical(dot, rhs[[i]])) {
+      hasdot <- TRUE
+      rhs[[i]] <- lhs
+    }
+  }
+
+  if (hasdot)
+    return(rhs)
+
+  # otherwise, mutate rhs call with lhs passed as first argument
+  args <- as.list(rhs)
+  as.call(c(args[[1L]], lhs, args[-1L]))
+
+}

--- a/R/renv-condition.R
+++ b/R/renv-condition.R
@@ -1,0 +1,10 @@
+
+renv_condition_signal <- function(class = NULL, data = NULL) {
+  condition <- list(message = character(), call = NULL, data = data)
+  class(condition) <- c(class, "renv.condition", "condition")
+  signalCondition(condition)
+}
+
+renv_condition_data <- function(condition) {
+  condition$data
+}

--- a/R/renv-dependencies.R
+++ b/R/renv-dependencies.R
@@ -1,0 +1,1505 @@
+
+`_renv_dependencies` <- new.env(parent = emptyenv())
+
+#' Find R Package Dependencies in a Project
+#'
+#' Find \R packages used within a project.
+#'
+#' `dependencies()` will crawl files within your project, looking for \R files
+#' and the packages used within those \R files. This is done primarily by
+#' parsing the code and looking for calls of the form:
+#'
+#' - `library(package)`
+#' - `require(package)`
+#' - `requireNamespace("package")`
+#' - `package::method()`
+#'
+#' For \R package projects, dependencies expressed in the `DESCRIPTION` file
+#' will also be discovered. Note that the `rmarkdown` package is required in
+#' order to crawl dependencies in R Markdown files.
+#'
+#' @section Suppressing Errors:
+#'
+#' Depending on how you've structured your code, `renv` may emit errors when
+#' attempting to enumerate dependencies within `.Rmd` / `.Rnw` documents.
+#' For code chunks that you'd explicitly like `renv` to ignore, you can
+#' include `renv.ignore=TRUE` in the chunk header. For example:
+#'
+#'     ```{r chunk-label, renv.ignore=TRUE}
+#'     # code in this chunk will be ignored by renv
+#'     ```
+#'
+#' Similarly, if you'd like `renv` to parse a chunk that is otherwise ignored
+#' (e.g. because it has `eval=FALSE` as a chunk header), you can set:
+#'
+#'     ```{r chunk-label, eval=FALSE, renv.ignore=FALSE}
+#'     # code in this chunk will _not be ignored
+#'     ```
+#'
+#' @section Ignoring Files:
+#'
+#' By default, `renv` will read your project's `.gitignore`s (if any) to
+#' determine whether certain files or folders should be included when traversing
+#' directories. If preferred, you can also create a `.renvignore` file (with
+#' entries of the same format as a standard `.gitignore` file) to tell `renv`
+#' which files to ignore within a directory. If both `.renvignore` and
+#' `.gitignore` exist within a folder, the `.renvignore` will be used in lieu of
+#' the `.gitignore`.
+#'
+#' See <https://git-scm.com/docs/gitignore> for documentation on the
+#' `.gitignore` format. Some simple examples here:
+#'
+#' ```
+#' # ignore all R Markdown files
+#' *.Rmd
+#'
+#' # ignore all data folders
+#' data/
+#'
+#' # ignore only data folders from the root of the project
+#' /data/
+#' ```
+#'
+#' @inheritParams renv-params
+#'
+#' @param path The path to a (possibly multi-mode) \R file, or a directory
+#'   containing such files. By default, all files within the current working
+#'   directory are checked, recursively.
+#'
+#' @param root The root directory to be used for dependency discovery.
+#'   Defaults to the active project directory. You may need to set this
+#'   explicitly to ensure that your project's `.renvignore`s (if any) are
+#'   properly handled.
+#'
+#' @param progress Boolean; report progress output while enumerating
+#'   dependencies?
+#'
+#' @param errors How should errors that occur during dependency enumeration be
+#'   handled? See **Errors** for more details.
+#'
+#' @param dev Boolean; include 'development' dependencies as well? That is,
+#'   packages which may be required during development but are unlikely to be
+#'   required during runtime for your project. By default, only runtime
+#'   dependencies are returned.
+#'
+#' @return An \R `data.frame` of discovered dependencies, mapping inferred
+#'   package names to the files in which they were discovered.
+#'
+#' @section Errors:
+#'
+#' `renv`'s attempts to enumerate package dependencies in your project can fail
+#' -- most commonly, because of parse errors in your \R code. The `errors`
+#' parameter can be used to control how `renv` responds to errors that occur.
+#'
+#' \tabular{ll}{
+#' **Name** \tab **Action** \cr
+#' `"reported"` \tab Errors are reported to the user, but are otherwise ignored. \cr
+#' `"fatal"`    \tab Errors are fatal and stop execution. \cr
+#' `"ignored"`  \tab Errors are ignored and not reported to the user. \cr
+#' }
+#'
+#' Depending on the structure of your project, you may want `renv` to ignore
+#' errors that occur when attempting to enumerate dependencies. However, a more
+#' robust solution would be to use an `.renvignore` file to tell `renv` not to
+#' scan such files for dependencies, or to configure the project to require
+#' explicit dependency management (`renv::settings$snapshot.type("explicit")`)
+#' and enumerate your dependencies in a project `DESCRIPTION` file.
+#'
+#' @section Development Dependencies:
+#'
+#' `renv` attempts to distinguish between 'development' dependencies and
+#' 'runtime' dependencies. For example, you might rely on e.g.
+#' [devtools](https://cran.r-project.org/package=devtools) and
+#' [roxygen2](https://cran.r-project.org/package=roxygen2) during development
+#' for a project, but may not actually require these packages at runtime.
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#'
+#' # find R package dependencies in the current directory
+#' renv::dependencies()
+#'
+#' }
+dependencies <- function(
+  path = getwd(),
+  root = NULL,
+  ...,
+  progress = TRUE,
+  errors = c("reported", "fatal", "ignored"),
+  dev = FALSE)
+{
+  renv_scope_error_handler()
+
+  deps <- renv_dependencies_impl(
+    path     = path,
+    root     = root,
+    progress = progress,
+    errors   = errors,
+    dev      = dev,
+    ...
+  )
+
+  if (empty(deps) || nrow(deps) == 0L)
+    return(deps)
+
+  if (identical(dev, FALSE))
+    deps <- deps[!deps$Dev, ]
+
+  deps
+}
+
+renv_dependencies_impl <- function(
+  path = getwd(),
+  root = NULL,
+  ...,
+  progress = TRUE,
+  errors = c("reported", "fatal", "ignored"),
+  dev = FALSE)
+{
+  # special case: if 'path' is a function, parse its body for dependencies
+  if (is.function(path))
+    return(renv_dependencies_discover_r(expr = body(path)))
+
+  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+  root <- root %||% renv_dependencies_root(path)
+
+  # ignore errors when testing, unless explicitly asked for
+  if (renv_tests_running() && missing(errors))
+    errors <- "ignored"
+
+  # check and see if we've pre-computed dependencies for this path, and
+  # retrieve those pre-computed dependencies if so
+  if (length(path) == 1)
+    if (exists(path, envir = `_renv_dependencies`))
+      return(get(path, envir = `_renv_dependencies`))
+
+  renv_dependencies_begin(root = root)
+  on.exit(renv_dependencies_end(), add = TRUE)
+
+  dots <- list(...)
+  if (identical(dots[["quiet"]], TRUE)) {
+    progress <- FALSE
+    errors <- "ignored"
+  }
+
+  files <- renv_dependencies_find(path, root)
+  deps <- renv_dependencies_discover(files, progress, errors)
+  renv_dependencies_report(errors)
+
+  deps
+}
+
+renv_dependencies_root <- function(path = getwd()) {
+
+  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+
+  project <- Sys.getenv("RENV_PROJECT", unset = NA)
+  if (!is.na(project) && all(renv_path_within(path, project)))
+    return(project)
+
+  roots <- uapply(path, renv_dependencies_root_impl)
+  if (empty(roots))
+    return(NULL)
+
+  uniroot <- unique(roots)
+  if (length(uniroot) > 1)
+    return(NULL)
+
+  uniroot
+
+}
+
+renv_dependencies_root_impl <- function(path) {
+
+  renv_file_find(path, function(parent) {
+    anchors <- c("DESCRIPTION", ".git", ".Rproj.user", "renv.lock", "renv")
+    for (anchor in anchors)
+      if (file.exists(file.path(parent, anchor)))
+        return(parent)
+  })
+
+}
+
+renv_dependencies_callback <- function(path) {
+
+  cbname <- list(
+    ".Rprofile"     = function(path) renv_dependencies_discover_r(path),
+    "DESCRIPTION"   = function(path) renv_dependencies_discover_description(path),
+    "_bookdown.yml" = function(path) renv_dependencies_discover_bookdown(path),
+    "_pkgdown.yml"  = function(path) renv_dependencies_discover_pkgdown(path),
+    "renv.lock"     = function(path) renv_dependencies_discover_renv_lock(path),
+    "rsconnect"     = function(path) renv_dependencies_discover_rsconnect(path)
+  )
+
+  cbext <- list(
+    ".rproj"       = function(path) renv_dependencies_discover_rproj(path),
+    ".r"           = function(path) renv_dependencies_discover_r(path),
+    ".qmd"         = function(path) renv_dependencies_discover_multimode(path, "rmd"),
+    ".rmd"         = function(path) renv_dependencies_discover_multimode(path, "rmd"),
+    ".rmarkdown"   = function(path) renv_dependencies_discover_multimode(path, "rmd"),
+    ".rnw"         = function(path) renv_dependencies_discover_multimode(path, "rnw")
+  )
+
+  cbname[[basename(path)]] %||% cbext[[tolower(fileext(path))]] %||% {
+    if (is_r_executable(path)) function(path) renv_dependencies_discover_r(path)
+  }
+
+}
+
+is_r_executable <- function(path) {
+  # don't check executability via `file.access` since this is implemented
+  # differently on Windows, and would thus lead to different dependencies being
+  # discovered across platforms
+  if (nzchar(fileext(path)))
+    return(FALSE)
+
+  grepl("\\b(R|r|Rscript)\\b", renv_file_shebang(path))
+}
+
+renv_dependencies_find_extra <- function(root) {
+
+  # if we don't have a root, we don't have a project
+  if (is.null(root))
+    return(NULL)
+
+  # only run for root-level dependency checks
+  if (!renv_path_same(root, renv_project_resolve()))
+    return(NULL)
+
+  # only run if we have a custom profile
+  prefix <- renv_profile_prefix()
+  if (is.null(prefix))
+    return(NULL)
+
+  # collect deps
+  path <- file.path(root, prefix)
+  renv_dependencies_find_impl(path, root, 0)
+
+}
+
+renv_dependencies_find <- function(path = getwd(), root = getwd()) {
+  files <- lapply(path, renv_dependencies_find_impl, root = root, depth = 0)
+  extra <- renv_dependencies_find_extra(root)
+  unlist(c(files, extra), recursive = TRUE, use.names = FALSE)
+}
+
+renv_dependencies_find_impl <- function(path, root, depth) {
+
+  # check file type
+  info <- file.info(path, extra_cols = FALSE)
+
+  # the file might have been removed after listing -- if so, just ignore it
+  if (is.na(info$isdir))
+    return(NULL)
+
+  # if this is a directory, recurse
+  if (info$isdir)
+    return(renv_dependencies_find_dir(path, root, depth))
+
+  # otherwise, check and see if we have a registered callback
+  callback <- renv_dependencies_callback(path)
+  if (is.function(callback))
+    return(path)
+
+}
+
+renv_dependencies_find_dir <- function(path, root, depth) {
+
+  # check if this path should be ignored
+  path <- renv_renvignore_exec(path, root, path)
+  if (empty(path))
+    return(character())
+
+  # check if we've already scanned this directory
+  # (necessary to guard against recursive symlinks)
+  if (!renv_platform_windows()) {
+    norm <- renv_path_normalize(path, mustWork = FALSE)
+    state <- renv_dependencies_state()
+    if (visited(norm, state$scanned))
+      return(character())
+  }
+
+  # list children
+  children <- renv_dependencies_find_dir_children(path, root, depth)
+
+  # find recursive dependencies
+  depth <- depth + 1
+  paths <- map(children, renv_dependencies_find_impl, root = root, depth = depth)
+
+  # explicitly include rsconnect folder
+  # (so we can infer a dependency on rsconnect when appropriate)
+  rsconnect <- file.path(path, "rsconnect")
+  if (file.exists(rsconnect))
+    paths <- c(rsconnect, paths)
+
+  paths
+
+}
+
+# return the set of files / subdirectories within a directory that should be
+# crawled for dependencies
+renv_dependencies_find_dir_children <- function(path, root, depth) {
+
+  # list files in the folder
+  children <- renv_file_list(path, full.names = TRUE)
+
+  # remove files which are broken symlinks
+  children <- children[file.exists(children)]
+
+  # remove hard-coded ignores
+  # (only keep DESCRIPTION files at the top level)
+  ignored <- c("renv", "packrat", "revdep", if (depth) "DESCRIPTION")
+  children <- children[!basename(children) %in% ignored]
+
+  # exclude ignored paths
+  renv_renvignore_exec(path, root, children)
+
+}
+
+renv_dependencies_discover <- function(paths, progress, errors) {
+
+  if (!renv_dependencies_discover_preflight(paths, errors))
+    return(invisible(NULL))
+
+  # short path if we're not showing progress
+  if (identical(progress, FALSE))
+    return(bapply(paths, renv_dependencies_discover_impl))
+
+  # otherwise, run with progress reporting
+
+  # nocov start
+  vprintf("Finding R package dependencies ... ")
+  discover <- renv_progress(renv_dependencies_discover_impl, length(paths))
+  deps <- lapply(paths, discover)
+  vwritef("Done!")
+
+  bind_list(deps)
+  # nocov end
+
+}
+
+renv_dependencies_discover_impl <- function(path) {
+
+  callback <- renv_dependencies_callback(path)
+  if (is.null(callback)) {
+    fmt <- "internal error: no callback registered for file %s"
+    warningf(fmt, renv_path_pretty(path))
+  }
+
+  result <- tryCatch(callback(path), error = warning)
+  if (inherits(result, "condition"))
+    return(NULL)
+
+  result
+
+}
+
+renv_dependencies_discover_preflight <- function(paths, errors) {
+
+  if (identical(errors, "ignored"))
+    return(TRUE)
+
+  # TODO: worth customizing?
+  limit <- 1000L
+  if (length(paths) < limit)
+    return(TRUE)
+
+  lines <- c(
+    "A large number of files (%i in total) have been discovered.",
+    "It may take renv a long time to crawl these files for dependencies.",
+    "Consider using .renvignore to ignore irrelevant files.",
+    "See `?dependencies` for more information.",
+    "Set `options(renv.config.dependencies.limit = Inf)` to disable this warning.",
+    ""
+  )
+  vwritef(lines, length(paths))
+
+  if (identical(errors, "reported"))
+    return(TRUE)
+
+  if (interactive() && !proceed()) {
+    renv_report_user_cancel()
+    return(FALSE)
+  }
+
+  TRUE
+
+}
+
+renv_dependencies_discover_renv_lock <- function(path) {
+  renv_dependencies_list(path, "renv")
+}
+
+renv_dependencies_discover_description <- function(path, fields = NULL) {
+
+  dcf <- catch(renv_description_read(path))
+  if (inherits(dcf, "error"))
+    return(renv_dependencies_error(path, error = dcf))
+
+  # read fields from project options if available
+  fields <-
+    fields %||%
+    renv_dependencies_discover_description_fields() %||%
+    c("Depends", "Imports", "LinkingTo")
+
+  pattern <- paste0(
+    "([a-zA-Z0-9._]+)",                      # package name
+    "(?:\\s*\\(([><=]+)\\s*([0-9.-]+)\\))?"  # optional version specification
+  )
+
+  # if this is the DESCRIPTION file for the active project, include
+  # Suggests since they're often needed as well. such packages will be
+  # considered development dependencies, except for package projects
+  state <- renv_dependencies_state()
+  type <- "unknown"
+  if (identical(file.path(state$root, "DESCRIPTION"), path)) {
+
+    # collect profile-specific dependencies as well
+    profile <- renv_profile_get()
+    field <- if (length(profile))
+      sprintf("Config/renv/profiles/%s/dependencies", profile)
+
+    fields <- c(fields, "Suggests", field)
+    type <- renv_description_type(desc = dcf)
+
+  }
+
+  data <- lapply(fields, function(field) {
+
+    # read field
+    contents <- dcf[[field]]
+    if (!is.character(contents))
+      return(list())
+
+    # split on commas
+    parts <- strsplit(dcf[[field]], "\\s*,\\s*")[[1]]
+
+    # drop any empty fields
+    x <- parts[nzchar(parts)]
+
+    # match to split on package name, version
+    m <- regexec(pattern, x)
+    matches <- regmatches(x, m)
+    if (empty(matches))
+      return(list())
+
+    # create dependency list
+    dev <- field == "Suggests" && type != "package"
+    renv_dependencies_list(
+      path,
+      extract_chr(matches, 2L),
+      extract_chr(matches, 3L),
+      extract_chr(matches, 4L),
+      dev
+    )
+
+  })
+
+  bind_list(data)
+
+}
+
+renv_dependencies_discover_description_fields <- function() {
+
+  # this is all very gross -- the project should be passed
+  # along by the caller instead
+  project <- NULL
+
+  # are we being called as part of renv::dependencies()?
+  # if so, then use the root directory as the project root
+  state <- renv_dependencies_state()
+  if (!is.null(state))
+    project <- state$root
+
+  # are we being called as part of renv::restore()?
+  # if so, then use the associated project directory
+  state <- renv_restore_state()
+  if (!is.null(state))
+    project <- state$project
+
+  # all else fails, use the active project
+  project <- project %||% renv_project()
+  renv::settings$package.dependency.fields(project = project)
+
+}
+
+renv_dependencies_discover_pkgdown <- function(path) {
+
+  # TODO: other dependencies to parse from pkgdown?
+  renv_dependencies_list(path, "pkgdown")
+}
+
+renv_dependencies_discover_bookdown <- function(path) {
+
+  # TODO: other dependencies to parse from bookdown?
+  renv_dependencies_list(path, "bookdown")
+}
+
+renv_dependencies_discover_rsconnect <- function(path) {
+  renv_dependencies_list(path, "rsconnect")
+}
+
+renv_dependencies_discover_multimode <- function(path, mode) {
+
+  # TODO: find in-line R code?
+  deps <- stack()
+
+  if (identical(mode, "rmd"))
+    deps$push(renv_dependencies_discover_rmd_yaml_header(path))
+
+  deps$push(renv_dependencies_discover_chunks(path))
+
+  bind_list(Filter(NROW, deps$data()))
+
+}
+
+renv_dependencies_discover_rmd_yaml_header <- function(path) {
+
+  for (package in c("rmarkdown", "yaml"))
+    if (!renv_dependencies_require(package, "R Markdown"))
+      return(renv_dependencies_list(path, packages = "rmarkdown"))
+
+  yaml <- catch(rmarkdown::yaml_front_matter(path))
+  if (inherits(yaml, "error"))
+    return(renv_dependencies_error(path, error = yaml, packages = "rmarkdown"))
+
+  deps <- stack()
+  deps$push("rmarkdown")
+
+  # check for Shiny runtime
+  runtime <- yaml[["runtime"]] %||% ""
+  if (pstring(runtime) && grepl("shiny", runtime, fixed = TRUE))
+    deps$push("shiny")
+
+  server <- yaml[["server"]] %||% ""
+  if (identical(server, "shiny"))
+    deps$push("shiny")
+
+  if (is.list(server) && identical(server[["type"]], "shiny"))
+    deps$push("shiny")
+
+  # check for custom output function from another package
+  for (output in list(yaml[["output"]], yaml[["site"]])) {
+
+    # if the output is named, then the output is mapping the
+    # function name to the parameters to be used; use names
+    output <- names(output) %||% output
+
+    # skip non-character arguments
+    if (!is.character(output))
+      next
+
+    # parse calls of the form <package>::<function>
+    parts <- strsplit(output, ":{2,3}")
+    map(parts, function(part) {
+      if (length(part) == 2L)
+        deps$push(part[[1L]])
+    })
+
+  }
+
+  # check for dependency on bslib
+  theme <- catchall(yaml[[c("output", "html_document", "theme")]])
+  if (!inherits(theme, "error") && is.list(theme))
+    deps$push("bslib")
+
+  packages <- as.character(deps$data())
+  renv_dependencies_list(path, packages)
+
+}
+
+renv_dependencies_discover_chunks_ignore <- function(chunk) {
+
+  # if renv.ignore is set, respect it
+  ignore <- chunk$params$renv.ignore
+  if (!is.null(ignore))
+    return(truthy(ignore))
+
+  # skip non-R chunks
+  engine <- chunk$params$engine
+  if (!(identical(engine, "r") || identical(engine, "rscript")))
+    return(TRUE)
+
+  # skip un-evaluated chunks
+  if (!truthy(chunk$params$eval, default = TRUE))
+    return(TRUE)
+
+  # skip learnr exercises
+  if (truthy(chunk$params[["exercise"]], default = FALSE))
+    return(TRUE)
+
+  # skip chunks whose labels end in '-display'
+  label <- chunk$params$label %||% ""
+  if (grepl("-display$", label))
+    return(TRUE)
+
+  # ok, don't ignore this chunk
+  FALSE
+
+}
+
+renv_dependencies_discover_chunks <- function(path) {
+
+  # ensure 'knitr' is installed / available
+  if (!renv_dependencies_require("knitr", "multi-mode"))
+    return(list())
+
+  # figure out the appropriate begin, end patterns
+  type <- tolower(tools::file_ext(path))
+  if (type %in% c("rmd", "qmd", "rmarkdown"))
+    type <- "md"
+
+  patterns <- knitr::all_patterns[[type]]
+  if (is.null(patterns)) {
+    condition <- simpleCondition("not a recognized multi-mode R document")
+    return(renv_dependencies_error(path, error = condition))
+  }
+
+  # parse the chunks within
+  # NOTE: we need to proceed line-by-line since the chunk end pattern might
+  # end chunks not started by the chunk begin pattern (sad face)
+  encoding <- if (type == "md") "UTF-8" else "unknown"
+  contents <- readLines(path, warn = FALSE, encoding = encoding)
+  ranges <- renv_dependencies_discover_chunks_ranges(path, contents, patterns)
+
+  # extract chunk code from the used ranges
+  chunks <- .mapply(function(lhs, rhs) {
+
+    # parse params in header
+    header <- contents[[lhs]]
+    params <- renv_dependencies_discover_parse_params(header, type)
+
+    # extract chunk contents (preserve newlines for nicer error reporting)
+    range <- seq.int(lhs + 1, length.out = rhs - lhs - 1)
+    code <- rep.int("", length(contents))
+    code[range] <- contents[range]
+
+    # return list of outputs
+    list(params = params, code = code)
+
+  }, ranges, NULL)
+
+  # iterate over chunks, and attempt to parse dependencies from each
+  cdeps <- bapply(chunks, function(chunk) {
+
+    # check whether this chunk should be ignored
+    if (renv_dependencies_discover_chunks_ignore(chunk))
+      return(character())
+
+    # remove reused chunk placeholders
+    pattern <- "<<[^>]+>>"
+    code <- gsub(pattern, "", chunk$code)
+
+    # okay, now we can discover deps
+    deps <- catch(renv_dependencies_discover_r(path = path, text = code))
+    if (inherits(deps, "error"))
+      return(renv_dependencies_error(path, error = deps))
+
+    deps
+
+  })
+
+  # check for dependencies in inline chunks as well
+  ideps <- renv_dependencies_discover_chunks_inline(path, contents)
+
+  deps <- bind_list(list(cdeps, ideps))
+  if (is.null(deps))
+    return(deps)
+
+  deps$Source <- path
+  deps
+
+}
+
+renv_dependencies_discover_chunks_inline <- function(path, contents) {
+
+  pasted <- paste(contents, collapse = "\n")
+  matches <- gregexpr("`r ([^`]+)`", pasted)
+  if (identical(c(matches[[1L]]), -1L))
+    return(list())
+
+  text <- unlist(regmatches(pasted, matches), use.names = FALSE, recursive = FALSE)
+  code <- substring(text, 4L, nchar(text) - 1L)
+  deps <- renv_dependencies_discover_r(path = path, text = code)
+  if (inherits(deps, "error"))
+    return(renv_dependencies_error(path, error = deps))
+
+  deps
+
+}
+
+renv_dependencies_discover_chunks_ranges <- function(path, contents, patterns) {
+
+  output <- list()
+
+  chunk <- FALSE
+  start <- 1; end <- 1
+  for (i in seq_along(contents)) {
+
+    line <- contents[[i]]
+
+    if (chunk == FALSE && grepl(patterns$chunk.begin, line)) {
+      chunk <- TRUE
+      start <- i
+      next
+    }
+
+    if (chunk == TRUE && grepl(patterns$chunk.begin, line)) {
+      end <- i
+      output[[length(output) + 1]] <- list(lhs = start, rhs = end)
+      start <- i
+      next
+    }
+
+    if (chunk == TRUE && grepl(patterns$chunk.end, line)) {
+      chunk <- FALSE
+      end <- i
+      output[[length(output) + 1]] <- list(lhs = start, rhs = end)
+      next
+    }
+
+  }
+
+  if (chunk) {
+    message <- sprintf("chunk starting on line %i is not closed", start)
+    error <- simpleError(message)
+    renv_dependencies_error(path, error = error)
+  }
+
+  bind_list(output)
+
+}
+
+renv_dependencies_discover_rproj <- function(path) {
+
+  props <- renv_properties_read(path)
+
+  deps <- stack()
+  if (identical(props$PackageUseDevtools, "Yes")) {
+    deps$push("devtools")
+    deps$push("roxygen2")
+  }
+
+  renv_dependencies_list(path, deps$data(), dev = TRUE)
+
+}
+
+renv_dependencies_discover_r <- function(path = NULL,
+                                         text = NULL,
+                                         expr = NULL)
+{
+  packages <- renv_dependencies_discover_r_impl(path, text, expr)
+  if (empty(packages))
+    return(list())
+
+  renv_dependencies_list(path, packages)
+}
+
+renv_dependencies_discover_r_impl <- function(path  = NULL,
+                                              text  = NULL,
+                                              expr  = NULL,
+                                              envir = NULL)
+{
+  expr <- case(
+    is.function(expr)  ~ body(expr),
+    is.language(expr)  ~ expr,
+    is.character(expr) ~ catch(renv_parse_text(expr)),
+    is.character(text) ~ catch(renv_parse_text(text)),
+    is.character(path) ~ catch(renv_parse_file(path)),
+    ~ stop("internal error")
+  )
+
+  if (inherits(expr, "error"))
+    return(renv_dependencies_error(path, error = expr))
+
+  # update current path
+  state <- renv_dependencies_state()
+  if (!is.null(state))
+    renv_scope_var("path", path, envir = state)
+
+  methods <- c(
+    renv_dependencies_discover_r_methods,
+    renv_dependencies_discover_r_xfun,
+    renv_dependencies_discover_r_library_require,
+    renv_dependencies_discover_r_require_namespace,
+    renv_dependencies_discover_r_colon,
+    renv_dependencies_discover_r_pacman,
+    renv_dependencies_discover_r_modules,
+    renv_dependencies_discover_r_import,
+    renv_dependencies_discover_r_box,
+    renv_dependencies_discover_r_targets,
+    renv_dependencies_discover_r_glue,
+    renv_dependencies_discover_r_parsnip,
+    renv_dependencies_discover_r_database
+  )
+
+  envir <- envir %||% new.env(parent = emptyenv())
+  recurse(expr, function(node, stack) {
+
+    # normalize calls (handle magrittr pipes)
+    node <- renv_call_normalize(node, stack)
+
+    # invoke methods on call objects
+    if (is.call(node))
+      for (method in methods)
+        method(node, stack, envir)
+
+    # return node
+    node
+
+  })
+
+  ls(envir = envir, all.names = TRUE)
+
+}
+
+renv_dependencies_discover_r_methods <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "methods", c("setClass", "setGeneric"))
+  if (is.null(node))
+    return(FALSE)
+
+  envir[["methods"]] <- TRUE
+  TRUE
+
+}
+
+renv_dependencies_discover_r_xfun <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "xfun", c("pkg_attach", "pkg_attach2"))
+  if (is.null(node))
+    return(FALSE)
+
+  # attempt to match the call
+  prototype <- function(..., install = FALSE, message = TRUE) {}
+  matched <- catch(match.call(prototype, node, expand.dots = FALSE))
+  if (inherits(matched, "error"))
+    return(FALSE)
+
+  # extract character vectors from `...`
+  strings <- stack()
+  recurse(matched[["..."]], function(node, stack) {
+    if (is.character(node))
+      strings$push(node)
+  })
+
+  # mark packages as known
+  packages <- strings$data()
+  if (empty(packages))
+    return(FALSE)
+
+  for (package in packages)
+    envir[[package]] <- TRUE
+
+  TRUE
+}
+
+renv_dependencies_discover_r_library_require <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "base", c("library", "require"))
+  if (is.null(node))
+    return(FALSE)
+
+  # attempt to match the call
+  matched <- catch(match.call(base::library, node))
+  if (inherits(matched, "error"))
+    return(FALSE)
+
+  # if the 'package' argument is a character vector of length one, we're done
+  if (is.character(matched$package) &&
+      length(matched$package) == 1)
+  {
+    envir[[matched$package]] <- TRUE
+    return(TRUE)
+  }
+
+  # if it's a symbol, double check character.only argument
+  if (is.symbol(matched$package) &&
+      identical(matched$character.only %||% FALSE, FALSE))
+  {
+    envir[[as.character(matched$package)]] <- TRUE
+    return(TRUE)
+  }
+
+  FALSE
+
+}
+
+renv_dependencies_discover_r_require_namespace <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "base", c("requireNamespace", "loadNamespace"))
+  if (is.null(node))
+    return(FALSE)
+
+  f <- get(as.character(node[[1]]), envir = .BaseNamespaceEnv, inherits = FALSE)
+  matched <- catch(match.call(f, node))
+  if (inherits(matched, "error"))
+    return(FALSE)
+
+  package <- matched$package
+  if (is.character(package) && length(package == 1)) {
+    envir[[package]] <- TRUE
+    return(TRUE)
+  }
+
+  FALSE
+
+
+}
+
+renv_dependencies_discover_r_colon <- function(node, stack, envir) {
+
+  ok <-
+    is.call(node) &&
+    length(node) == 3 &&
+    is.name(node[[1]]) &&
+    as.character(node[[1]]) %in% c("::", ":::")
+
+  if (!ok)
+    return(FALSE)
+
+  package <- node[[2L]]
+  if (is.symbol(package))
+    package <- as.character(package)
+
+  if (!is.character(package) || length(package) != 1)
+    return(FALSE)
+
+  envir[[package]] <- TRUE
+  TRUE
+
+}
+
+renv_dependencies_discover_r_pacman <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "pacman", "p_load")
+  if (is.null(node) || length(node) < 2)
+    return(FALSE)
+
+  # check for character.only
+  chonly <- node[["character.only"]] %||% FALSE
+
+  # consider all unnamed arguments
+  parts <- as.list(node[-1L])
+
+  # consider packages passed to 'char' parameter
+  char <- node[["char"]]
+
+  # detect vector of packages passed as vector
+  if (is.call(char) && identical(char[[1L]], as.name("c")))
+    parts <- c(parts, as.list(char[-1L]))
+
+  # detect plain old package name
+  if (is.character(char))
+    parts <- c(parts, as.list(char))
+
+  # ensure names
+  names(parts) <- names(parts) %||% rep.int("", length(parts))
+  unnamed <- parts[!nzchar(names(parts))]
+
+  # extract symbols / characters
+  for (arg in unnamed) {
+
+    # skip symbols if necessary
+    if (chonly && is.symbol(arg))
+      next
+
+    # check for character or symbol
+    ok <-
+      length(arg) == 1 &&
+      is.character(arg) ||
+      is.symbol(arg)
+
+    if (!ok)
+      next
+
+    # add it
+    envir[[as.character(arg)]] <- TRUE
+
+  }
+
+  TRUE
+
+}
+
+renv_dependencies_discover_r_modules <- function(node, stack, envir) {
+
+  # check for call of the form 'pkg::foo(a, b, c)'
+  colon <-
+    is.call(node[[1L]]) &&
+    is.name(node[[1L]][[1L]]) &&
+    as.character(node[[1L]][[1L]]) %in% c("::", ":::")
+
+  node <- renv_call_expect(node, "modules", c("import"))
+  if (is.null(node))
+    return(FALSE)
+
+  ok <- FALSE
+  if (colon) {
+    # include if fully qualified call to modules::import
+    ok <- TRUE
+  } else {
+    # otherwise only consider calls within a 'module' block
+    # (to reduce confusion with reticulate::import)
+    for (parent in stack) {
+      parent <- renv_call_expect(parent, "modules", c("amodule", "module"))
+      if (!is.null(parent)) {
+        ok <- TRUE
+        break
+      }
+    }
+  }
+
+  if (!ok)
+    return(FALSE)
+
+  # attempt to match the call
+  prototype <- function(from, ..., attach = TRUE, where = parent.frame()) {}
+  matched <- catch(match.call(prototype, node, expand.dots = FALSE))
+  if (inherits(matched, "error"))
+    return(FALSE)
+
+  # extract character vector or symbol from `from`
+  package <- matched[["from"]]
+  if (empty(package))
+    return(FALSE)
+
+  # package could be symbols or character so call as.character
+  # to be safe then mark packages as known
+  envir[[as.character(package)]] <- TRUE
+
+  TRUE
+}
+
+renv_dependencies_discover_r_import <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "import", c("from", "here", "into"))
+  if (is.null(node))
+    return(FALSE)
+
+  # attempt to match the call
+  name <- as.character(node[[1L]])
+  matched <- if (name == "from") {
+    catch(match.call(function(.from, ...) {}, node, expand.dots = FALSE))
+  } else {
+    catch(match.call(function(..., .from) {}, node, expand.dots = FALSE))
+  }
+
+  if (inherits(matched, "error"))
+    return(FALSE)
+
+  # the '.from' argument is the package name, either a character vector of length one or a symbol
+  from <- matched$.from
+  if (is.symbol(from))
+    from <- as.character(from)
+
+  ok <-
+    is.character(from) &&
+    length(from) == 1
+
+  if (!ok)
+    return(FALSE)
+
+  envir[[from]] <- TRUE
+  TRUE
+
+}
+
+renv_dependencies_discover_r_box <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "box", "use")
+  if (is.null(node))
+    return(FALSE)
+
+  for (i in seq.int(2L, length.out = length(node) - 1L))
+    renv_dependencies_discover_r_box_impl(node[[i]], stack, envir)
+
+  TRUE
+
+}
+
+renv_dependencies_discover_r_box_impl <- function(node, stack, envir) {
+
+  # if the node is just a symbol, then it's the name of a package
+  # otherwise, if it's a call to `[`, the first argument is the package name
+  name <- if (is.symbol(node) && ! identical(node, quote(expr = ))) {
+    as.character(node)
+  } else if (
+    is.call(node) &&
+      length(node) > 1L &&
+      identical(node[[1L]], as.name("[")) &&
+      is.symbol(node[[2L]])) {
+    as.character(node[[2L]])
+  }
+
+  # the names `.` and `..` are special place holders and don't refer to packages
+  if (is.null(name) || name == "." || name == "..")
+    return(FALSE)
+
+  envir[[name]] <- TRUE
+  TRUE
+
+}
+
+renv_dependencies_discover_r_targets <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "targets", "tar_option_set")
+  if (is.null(node))
+    return(FALSE)
+
+  envir[["targets"]] <- TRUE
+
+  packages <- tryCatch(
+    renv_dependencies_eval(node$packages),
+    error = identity
+  )
+
+  if (inherits(packages, "error")) {
+    warning(packages)
+    return(TRUE)
+  }
+
+  if (is.character(packages))
+    for (package in packages)
+      envir[[package]] <- TRUE
+
+  TRUE
+
+}
+
+renv_dependencies_discover_r_glue <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "glue", "glue")
+  if (is.null(node))
+    return(FALSE)
+
+  # analyze all unnamed strings in the call
+  args <- as.list(node)[-1L]
+  nm <- names(args) %||% rep.int("", length(args))
+  strings <- args[!nzchar(nm) & map_lgl(args, is.character)]
+
+  # construct pattern
+  open  <- node$.open  %||% "{"
+  close <- node$.close %||% "}"
+  pattern <- sprintf("\\Q%s\\E(.*?)\\Q%s\\E", open, close)
+
+  for (string in strings) {
+    m <- gregexpr(pattern, string, perl = TRUE)
+    matches <- unlist(regmatches(string, m), recursive = FALSE)
+    code <- substring(matches, 2L, nchar(matches) - 1L)
+    renv_dependencies_discover_r_impl(text = code, envir = envir)
+  }
+
+  TRUE
+
+}
+
+renv_dependencies_discover_r_parsnip <- function(node, stack, envir) {
+
+  node <- renv_call_expect(node, "parsnip", "set_engine")
+  if (is.null(node))
+    return(FALSE)
+
+  matched <- catch(match.call(function(object, engine, ...) {}, node))
+  if (inherits(matched, "error"))
+    return(FALSE)
+
+  engine <- matched$engine
+  if (!is.character(engine) || length(engine) != 1L)
+    return(FALSE)
+
+  map <- getOption("renv.parsnip.engines", default = list(
+    glm    = "stats",
+    glmnet = "glmnet",
+    keras  = "keras",
+    kknn   = "kknn",
+    nnet   = "nnet",
+    rpart  = "rpart",
+    spark  = "sparklyr",
+    stan   = "rstanarm"
+  ))
+
+  packages <- if (is.function(map))
+    tryCatch(map(engine), error = function(e) NULL)
+  else
+    map[[engine]]
+
+  if (is.null(packages))
+    return(FALSE)
+
+  for (package in packages)
+    envir[[package]] <- TRUE
+
+  # TODO: a number of model routines appear to depend on dials;
+  # should we just assume it's required by default? or should
+  # users normally be using tidymodels instead of parsnip directly?
+  TRUE
+
+}
+
+renv_dependencies_discover_r_database <- function(node, stack, envir) {
+
+  found <- FALSE
+
+  db <- renv_dependencies_database()
+  enumerate(db, function(package, dependencies) {
+    enumerate(dependencies, function(method, requirements) {
+
+      expect <- renv_call_expect(node, package, method)
+      if (is.null(expect))
+        return(FALSE)
+
+      for (requirement in requirements)
+        envir[[requirement]] <- TRUE
+
+      found <<- TRUE
+      TRUE
+
+    })
+  })
+
+  found
+
+}
+
+renv_dependencies_database <- function() {
+  # TODO: make this user-accessible?
+  renv_global(
+    "dependencies.database",
+    renv_dependencies_database_impl()
+  )
+}
+
+renv_dependencies_database_impl <- function() {
+
+  db <- list()
+
+  db$ggplot2 <- list(
+    geom_hex = "hexbin"
+  )
+
+  db
+
+}
+
+renv_dependencies_list <- function(source,
+                                   packages,
+                                   require = "",
+                                   version = "",
+                                   dev = FALSE)
+{
+  if (empty(packages))
+    return(list())
+
+  source <- source %||% rep.int(NA_character_, length(packages))
+
+  data.frame(
+    Source  = as.character(source),
+    Package = as.character(packages),
+    Require = require,
+    Version = version,
+    Dev     = dev,
+    stringsAsFactors = FALSE
+  )
+
+}
+
+renv_dependencies_discover_parse_params <- function(header, type) {
+
+  engine <- "r"
+  rest <- sub(knitr::all_patterns[[type]]$chunk.begin, "\\1", header)
+
+  # if this is an R Markdown document, parse the initial engine chunk
+  if (type == "md") {
+    idx <- regexpr("(?:[ ,]|$)", rest)
+    engine <- substring(rest, 1, idx - 1)
+    rest <- sub("^,*\\s*", "", substring(rest, idx + 1))
+  }
+
+  # extract an unquoted label
+  label <- ""
+  pattern <- "(^\\s*[^=]+)(,|\\s*$)"
+  matches <- regexec(pattern, rest)[[1]]
+  if (!identical(c(matches), -1L)) {
+    submatches <- regmatches(rest, list(matches))[[1]]
+    label <- trimws(submatches[[2L]])
+    rest <- substring(rest, matches[[3L]] + 1L)
+  }
+
+  params <- catch(parse(text = sprintf("alist(%s)", rest))[[1]])
+  if (inherits(params, "error"))
+    return(list(engine = engine))
+
+  # inject the label back in
+  names(params) <- names(params) %||% rep.int("", length(params))
+  if (length(params) > 1 && names(params)[[2L]] == "")
+    names(params)[[2L]] <- "label"
+
+  # fix up 'label' if it's a missing value
+  if (identical(params[["label"]], quote(expr = )))
+    params[["label"]] <- NULL
+
+  if (is.null(params[["label"]]) && nzchar(label))
+    params[["label"]] <- label
+
+  if (is.null(params[["engine"]]))
+    params[["engine"]] <- engine
+
+  eval(params, envir = parent.frame())
+
+}
+
+renv_dependencies_require <- function(package, type) {
+
+  if (requireNamespace(package, quietly = TRUE))
+    return(TRUE)
+
+  fmt <- lines(
+    "The '%1$s' package is required to parse dependencies within %2$s files.",
+    "Consider installing it with `install.packages(\"%1$s\")`."
+  )
+  msg <- sprintf(fmt, package, type)
+
+  if (renv_once())
+    warning(msg, call. = FALSE)
+
+  return(FALSE)
+
+}
+
+renv_dependencies_state <- function() {
+  renv_global_get("dependencies.state")
+}
+
+renv_dependencies_begin <- function(root = NULL) {
+  state <- env(root = root, scanned = env(), problems = stack())
+  renv_global_set("dependencies.state", state)
+}
+
+renv_dependencies_end <- function() {
+  renv_global_clear("dependencies.state")
+}
+
+renv_dependencies_error <- function(path, error = NULL, packages = NULL) {
+
+  # if no error, return early
+  if (is.null(error))
+    return(renv_dependencies_list(path, packages))
+
+  # check for missing state (e.g. if internal method called directly)
+  state <- renv_dependencies_state()
+  if (!is.null(state)) {
+    path <- path %||% state$path
+    problem <- list(file = path, error = error)
+    state$problems$push(problem)
+  }
+
+  # return dependency list
+  renv_dependencies_list(path, packages)
+
+}
+
+renv_dependencies_report <- function(errors) {
+
+  if (identical(errors, "ignored"))
+    return(FALSE)
+
+  state <- renv_dependencies_state()
+  if (is.null(state))
+    return(FALSE)
+
+  problems <- state$problems$data()
+  if (empty(problems))
+    return(TRUE)
+
+  ewritef("WARNING: One or more problems were discovered while enumerating dependencies.\n")
+
+  # bind into list
+  bound <- bapply(problems, function(problem) {
+    fields <- c(aliased_path(problem$file), problem$line, problem$column)
+    header <- paste(fields, collapse = ":")
+    message <- conditionMessage(problem$error)
+    c(file = problem$file, header = header, message = message)
+  })
+
+  # split based on header (group errors from same file)
+  splat <- split(bound, bound$file)
+
+  # emit messages
+  enumerate(splat, function(file, problem) {
+    lines <- paste(rep.int("-", nchar(file)), collapse = "")
+    prefix <- format(paste("ERROR", seq_along(problem$message)))
+    messages <- paste(prefix, problem$message, sep = ": ", collapse = "\n\n")
+    text <- c(file, lines, "", messages, "")
+    ewritef(text)
+  })
+
+  ewritef("Please see `?renv::dependencies` for more information.")
+
+  if (identical(errors, "fatal")) {
+    fmt <- "one or more errors occurred while enumerating dependencies"
+    stopf(fmt)
+  }
+
+  renv_condition_signal("renv.dependencies.error", problems)
+  TRUE
+
+}
+
+renv_dependencies_scope <- function(path, action, .envir = NULL) {
+
+  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+  if (exists(path, envir = `_renv_dependencies`))
+    return(get(path, envir = `_renv_dependencies`))
+
+  errors <- config$dependency.errors()
+  message <- paste(action, "aborted")
+
+  deps <- withCallingHandlers(
+    dependencies(path, progress = FALSE, errors = errors, dev = TRUE),
+    renv.dependencies.error = renv_dependencies_error_handler(message, errors)
+  )
+
+  assign(path, deps, envir = `_renv_dependencies`)
+
+  envir <- .envir %||% parent.frame()
+  defer(rm(list = path, envir = `_renv_dependencies`), envir = envir)
+
+}
+
+renv_dependencies_error_handler <- function(message, errors) {
+
+  force(message)
+  force(errors)
+
+  function(condition) {
+
+    if (identical(errors, "fatal") || interactive() && !proceed()) {
+
+      condition <- structure(
+        list(message = message, call = NULL, traceback = FALSE),
+        class = c("renv.dependencies.error", "error", "condition")
+      )
+
+      stop(condition)
+
+    }
+
+    renv_condition_data(condition)
+
+  }
+}
+
+renv_dependencies_eval <- function(expr) {
+
+  # create environment with small subset of symbols
+  syms <- c("list", "c")
+  vals <- mget(syms, envir = baseenv())
+  envir <- list2env(vals, parent = emptyenv())
+
+  # evaluate in that environment
+  eval(expr, envir = envir)
+
+}

--- a/R/renv-errors.R
+++ b/R/renv-errors.R
@@ -1,0 +1,160 @@
+
+renv_error_format_srcref <- function(call, srcref) {
+
+  srcfile <- attr(srcref, "srcfile", exact = TRUE)
+
+  if (inherits(srcfile, c("srcfilecopy", "srcfilealias"))) {
+    start <- srcref[7L]
+    end   <- srcref[8L]
+  } else {
+    start <- srcref[1L]
+    end   <- srcref[3L]
+  }
+
+  srclines <- getSrcLines(srcfile, start, end)
+  index <- regexpr("[^[:space:]]", srclines)
+  indent <- min(index)
+  code <- substring(srclines, indent)
+
+  if (length(code) >= 8L) {
+    simplified <- renv_error_simplify(call)
+    if (!identical(simplified, call))
+      code <- format(simplified)
+  }
+
+  n <- length(code)
+  postfix <- sprintf("at %s#%i", basename(srcfile$filename), srcref[1L])
+  code[n] <- paste(code[n], postfix)
+
+  code
+
+}
+
+renv_error_simplify <- function(object) {
+
+  case(
+    is.function(object)  ~ renv_error_simplify_function(object),
+    is.recursive(object) ~ renv_error_simplify_recursive(object),
+    TRUE                 ~ object
+  )
+
+}
+
+renv_error_simplify_function <- function(object) {
+  f <- function() {}
+  formals(f) <- formals(object)
+  body(f) <- quote({ ... })
+  f
+}
+
+renv_error_simplify_recursive <- function(object) {
+
+  longcall <-
+    is.call(object) &&
+    is.symbol(object[[1]]) &&
+    object[[1]] == as.name("{") &&
+    length(object) >= 8
+
+  if (longcall)
+    return(quote(...))
+
+  for (i in seq_along(object))
+    if (!is.null(object[[i]]))
+      object[[i]] <- renv_error_simplify(object[[i]])
+
+  object
+
+}
+
+renv_error_format <- function(calls, frames) {
+
+  # first, format calls
+  formatted <- lapply(calls, function(call) {
+
+    srcref <- attr(call, "srcref", exact = TRUE)
+    if (!is.null(srcref)) {
+      formatted <- catch(renv_error_format_srcref(call, srcref))
+      if (!inherits(formatted, "error"))
+        return(formatted)
+    }
+
+    if (is.function(call[[1]]))
+      return("<condition-handler>(...)")
+
+    format(renv_error_simplify(call))
+
+  })
+
+  # compute prefixes
+  numbers <- format(seq_along(formatted))
+  prefixes <- sprintf("%s: ", rev(numbers))
+
+  # generate indent
+  indent <- paste(rep.int(" ", min(nchar(prefixes))), collapse = "")
+
+  # attach prefixes + indent
+  annotated <- uapply(seq_along(formatted), function(i) {
+    code <- formatted[[i]]
+    prefix <- c(prefixes[[i]], rep.int(indent, length(code) - 1L))
+    paste(prefix, code, sep = "")
+  })
+
+  header <- "Traceback (most recent calls last):"
+  c(header, annotated)
+
+}
+
+renv_error_find <- function(calls, frames) {
+
+  for (i in rev(seq_along(frames))) {
+
+    fn <- sys.function(which = i)
+    if (!identical(fn, stop))
+      next
+
+    frame <- frames[[i]]
+    args <- frame[["args"]]
+    if (is.null(args) || empty(args))
+      next
+
+    first <- args[[1L]]
+    if (!inherits(first, "condition"))
+      next
+
+    return(first)
+
+  }
+
+}
+
+renv_error_handler <- function(...) {
+
+  calls <- head(sys.calls(), n = -1L)
+  frames <- head(sys.frames(), n = -1L)
+
+  error <- renv_error_find(calls, frames)
+  if (identical(error$traceback, FALSE))
+    return(character())
+
+  formatted <- renv_error_format(calls, frames)
+  writeLines(formatted, con = stderr())
+
+  formatted
+
+}
+
+renv_error_capture <- function(e) {
+  calls <- head(sys.calls(), n = -2L)
+  frames <- head(sys.frames(), n = -2L)
+  traceback <- renv_error_format(calls, frames)
+  renv_global_set("traceback", traceback)
+}
+
+renv_error_tag <- function(e) {
+  e$traceback <- renv_global_get("traceback")
+  e
+}
+
+renv_error_handler_call <- function() {
+  as.call(list(renv_error_handler))
+}

--- a/R/renv-files.R
+++ b/R/renv-files.R
@@ -1,0 +1,516 @@
+
+# NOTE: all methods here should either return TRUE if they were able to
+# operate successfully, or throw an error if not
+#
+# TODO: some of these operations are a bit racy
+renv_file_preface <- function(source, target, overwrite) {
+
+  callback <- function() {}
+  if (!renv_file_exists(source))
+    stopf("source file '%s' does not exist", source)
+
+  if (overwrite)
+    callback <- renv_file_backup(target)
+
+  if (renv_file_exists(target))
+    stopf("target file '%s' already exists", target)
+
+  callback
+
+}
+
+renv_file_copy <- function(source, target, overwrite = FALSE) {
+
+  if (renv_file_same(source, target))
+    return(TRUE)
+
+  callback <- renv_file_preface(source, target, overwrite)
+  on.exit(callback(), add = TRUE)
+
+  # check to see if we're copying a plain file -- if so, things are simpler
+  if (dir.exists(source))
+    renv_file_copy_dir(source, target)
+  else
+    renv_file_copy_file(source, target)
+
+}
+
+renv_file_copy_file <- function(source, target) {
+
+  # copy to temporary path
+  tmpfile <- renv_scope_tempfile(".renv-copy-", tmpdir = dirname(target))
+  status <- catchall(file.copy(source, tmpfile))
+  if (inherits(status, "condition"))
+    stop(status)
+
+  # move from temporary path to final target
+  status <- catchall(renv_file_move(tmpfile, target))
+  if (inherits(status, "condition"))
+    stop(status)
+
+  # validate that the target file exists
+  if (renv_file_exists(target))
+    return(TRUE)
+
+  fmt <- "attempt to copy file %s to %s failed (unknown reason)"
+  stopf(fmt, renv_path_pretty(source), renv_path_pretty(target))
+
+}
+
+renv_file_copy_dir_robocopy <- function(source, target) {
+
+  flags <- c("/E", "/Z", "/R:5", "/W:10")
+  args <- c(flags, shQuote(source), shQuote(target))
+
+  # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy
+  # > Any value greater than 8 indicates that there was at least one failure
+  # > during the copy operation.
+  renv_system_exec(
+    "robocopy",
+    args,
+    action = "copying directory",
+    success = 0:8
+  )
+
+}
+
+# TODO: the version of rsync distributed with macOS
+# does not reliably copy file modified times, etc.
+renv_file_copy_dir_rsync <- function(source, target) {
+  source <- sub("/*$", "/", source)
+  flags <- if (renv_platform_macos()) "-aAX" else "-a"
+  args <- c(flags, shQuote(source), shQuote(target))
+  renv_system_exec("rsync", args, action = "copying directory")
+}
+
+renv_file_copy_dir_cp <- function(source, target) {
+  source <- sub("/*$", "/", source)
+  args <- c("-pPR", shQuote(source), shQuote(target))
+  renv_system_exec("cp", args, action = "copying directory")
+}
+
+renv_file_copy_dir_r <- function(source, target) {
+
+  # create sub-directory to host copy attempt
+  tempdir <- renv_scope_tempfile(".renv-copy-", tmpdir = dirname(target))
+  ensure_directory(tempdir)
+
+  # attempt to copy to generated folder
+  status <- catchall(
+    file.copy(
+      source,
+      tempdir,
+      recursive = TRUE,
+      copy.mode = TRUE,
+      copy.date = TRUE
+    )
+  )
+
+  if (inherits(status, "error"))
+    stop(status)
+
+  # R will copy the directory to a sub-directory in the
+  # requested folder with the same filename as the source
+  # folder, so peek into that folder to grab it and rename
+  tempfile <- file.path(tempdir, basename(source))
+  status <- catchall(renv_file_move(tempfile, target))
+  if (inherits(status, "condition"))
+    stop(status)
+
+}
+
+renv_file_copy_dir_impl <- function(source, target) {
+
+  methods <- list(
+    cp       = renv_file_copy_dir_cp,
+    r        = renv_file_copy_dir_r,
+    robocopy = renv_file_copy_dir_robocopy,
+    rsync    = renv_file_copy_dir_rsync
+  )
+
+  copy <- config$copy.method()
+  if (is.function(copy))
+    return(copy(source, target))
+
+  method <- methods[[tolower(copy)]]
+  if (!is.null(method))
+    return(method(source, target))
+
+  if (renv_platform_windows())
+    renv_file_copy_dir_robocopy(source, target)
+  else if (renv_platform_unix())
+    renv_file_copy_dir_cp(source, target)
+  else
+    renv_file_copy_dir_r(source, target)
+
+  file.exists(target)
+
+}
+
+renv_file_copy_dir <- function(source, target) {
+
+  # create temporary sub-directory
+  tmpdir <- dirname(target)
+  ensure_directory(tmpdir)
+  tempdir <- renv_scope_tempfile(".renv-copy-", tmpdir = tmpdir)
+
+  # copy to that directory
+  status <- catchall(renv_file_copy_dir_impl(source, tempdir))
+  if (inherits(status, "condition"))
+    stop(status)
+
+  # move directory to final location
+  status <- catchall(renv_file_move(tempdir, target))
+  if (inherits(status, "condition"))
+    stop(status)
+
+  # validate that the target file exists
+  if (renv_file_exists(target))
+    return(TRUE)
+
+  fmt <- "attempt to copy directory %s to %s failed (unknown reason)"
+  stopf(fmt, renv_path_pretty(source), renv_path_pretty(target))
+
+}
+
+renv_file_move <- function(source, target, overwrite = FALSE) {
+
+  if (renv_file_same(source, target))
+    return(TRUE)
+
+  callback <- renv_file_preface(source, target, overwrite)
+  on.exit(callback(), add = TRUE)
+
+  # first, attempt to do a plain rename
+  # use catchall since this might fail for e.g. cross-device links
+  move <- catchall(file.rename(source, target))
+  if (renv_file_exists(target))
+    return(TRUE)
+
+  # on unix, try using 'mv' command directly
+  # (can handle cross-device copies / moves a bit more efficiently)
+  if (renv_platform_unix()) {
+    args <- shQuote(c(source, target))
+    status <- catchall(system2("mv", args, stdout = FALSE, stderr = FALSE))
+    if (renv_file_exists(target))
+      return(TRUE)
+  }
+
+  # on Windows, similarly try 'move' command
+  if (renv_platform_windows()) {
+    args <- c("/Y", shQuote(source), shQuote(target))
+    status <- catchall(system2("move", args, stdout = FALSE, stderr = FALSE))
+    if (renv_file_exists(target))
+      return(TRUE)
+  }
+
+  # nocov start
+  # rename failed; fall back to copying (and be sure to remove
+  # the source file / directory on success)
+  copy <- catchall(renv_file_copy(source, target, overwrite = overwrite))
+  if (identical(copy, TRUE) && file.exists(target)) {
+    unlink(source, recursive = TRUE)
+    return(TRUE)
+  }
+
+  # rename and copy both failed: inform the user
+  fmt <- stack()
+  fmt$push("could not copy / move file '%s' to '%s'")
+  if (inherits(move, "condition"))
+    fmt$push(paste("move:", conditionMessage(move)))
+  if (inherits(copy, "condition"))
+    fmt$push(paste("copy:", conditionMessage(copy)))
+
+  text <- paste(fmt$data(), collapse = "\n")
+  stopf(text, source, target)
+  # nocov end
+
+}
+
+renv_file_link <- function(source, target, overwrite = FALSE) {
+
+  if (renv_file_same(source, target))
+    return(TRUE)
+
+  callback <- renv_file_preface(source, target, overwrite)
+  on.exit(callback(), add = TRUE)
+
+  if (renv_platform_windows()) {
+
+    # use junction points on Windows by default as symlinks
+    # are unreliable / un-deletable in some circumstances
+    status <- catchall(Sys.junction(source, target))
+    if (identical(status, TRUE))
+      return(TRUE)
+
+    # if Sys.junction() fails, it may leave behind an empty
+    # directory. this may occur if the source and target files
+    # reside on different volumes. either way, remove an empty
+    # left-behind directory on failure
+    unlink(target, recursive = TRUE, force = TRUE)
+
+  } else {
+
+    # on non-Windows, we can try to create a symlink
+    status <- catchall(file.symlink(source, target))
+    if (identical(status, TRUE))
+      return(TRUE)
+
+  }
+
+  # all else fails, just perform a copy
+  renv_file_copy(source, target, overwrite = overwrite)
+
+}
+
+renv_file_junction <- function(source, target) {
+
+  if (!renv_platform_windows())
+    stopf("'renv_file_junction()' is only available on Windows")
+
+  if (renv_file_exists(target))
+    stopf("file '%s' already exists")
+
+  status <- catchall(Sys.junction(source, target))
+  if (inherits(status, "condition")) {
+    unlink(target, recursive = TRUE, force = TRUE)
+    stop(status)
+  }
+
+  TRUE
+
+}
+
+renv_file_same <- function(source, target) {
+
+  # if the paths are the same, we can return early
+  if (identical(source, target))
+    return(TRUE)
+
+  # check to see if they're equal after normalization
+  # (e.g. for symlinks pointing to same file)
+  source <- renv_path_normalize(source, mustWork = FALSE)
+  target <- renv_path_normalize(target, mustWork = FALSE)
+  if (identical(source, target))
+    return(TRUE)
+
+  # if either file is missing, return false
+  if (!renv_file_exists(source) || !renv_file_exists(target))
+    return(FALSE)
+
+  # for hard links + junction points, it's difficult to detect
+  # whether the two files point to the same object; use some
+  # heuristics to guess (note that these aren't perfect)
+  sinfo <- file.info(source, extra_cols = FALSE)
+  tinfo <- file.info(target, extra_cols = FALSE)
+  if (!identical(c(sinfo), c(tinfo)))
+    return(FALSE)
+
+  TRUE
+
+}
+
+# NOTE: returns a callback which should be used in e.g. an on.exit handler
+# to restore the file if the attempt to update the file failed
+renv_file_backup <- function(path) {
+
+  force(path)
+
+  # if no file exists then nothing to backup
+  if (!renv_file_exists(path))
+    return(function() {})
+
+  # normalize the path (since the working directory could change
+  # by the time the callback is invoked). note that the file may
+  # be a broken symlink so construct the path by normalizing the
+  # parent directory and building path relative to that
+  parent <- renv_path_normalize(dirname(path), winslash = "/", mustWork = TRUE)
+  path <- file.path(parent, basename(path))
+
+  # attempt to rename the file
+  pattern <- sprintf(".renv-backup-%s", basename(path))
+  tempfile <- tempfile(pattern, tmpdir = dirname(path))
+  if (!renv_file_move(path, tempfile))
+    return(function() {})
+
+  # return callback that will restore if needed
+  function() {
+
+    if (!renv_file_exists(path))
+      renv_file_move(tempfile, path)
+    else
+      unlink(tempfile, recursive = TRUE)
+
+  }
+
+}
+
+renv_file_normalize <- function(path, winslash = "\\", mustWork = NA) {
+  parent <- renv_path_normalize(dirname(path), winslash = winslash, mustWork = mustWork)
+  file.path(parent, basename(path))
+}
+
+# NOTE: returns true for files that are broken symlinks
+renv_file_exists <- function(path) {
+
+  if (renv_platform_windows())
+    return(file.exists(path))
+
+  !is.na(Sys.readlink(path)) | file.exists(path)
+
+}
+
+renv_file_list <- function(path, full.names = TRUE) {
+
+  # list files
+  files <- renv_file_list_impl(path)
+
+  # NOTE: paths may be marked with UTF-8 encoding;
+  # if that's the case we need to use paste rather
+  # than file.path to preserve the encoding
+  if (full.names)
+    files <- paste(path, files, sep = "/")
+
+  files
+
+}
+
+renv_file_list_impl <- function(path) {
+  renv_methods_error()
+}
+
+renv_file_list_impl_unix <- function(path) {
+  list.files(path, all.files = TRUE, no.. = TRUE)
+}
+
+# nocov start
+renv_file_list_impl_win32 <- function(path) {
+
+  # first, try a plain list.files to see if we can get away with that
+  files <- list.files(path, all.files = TRUE, no.. = TRUE)
+  if (!any(grepl("?", files, fixed = TRUE)))
+    return(files)
+
+  # otherwise, try some madness ...
+  #
+  # change working directory (done just to avoid encoding issues
+  # when submitting path to cmd shell)
+  owd <- setwd(path)
+  on.exit(setwd(owd), add = TRUE)
+
+  # NOTE: a sub-shell is required here in some contexts; e.g. when running
+  # tests non-interactively or building in the RStudio pane
+  command <- paste(comspec(), "/U /C dir /B")
+  conn <- pipe(command, open = "rb", encoding = "native.enc")
+  on.exit(close(conn), add = TRUE)
+
+  # read binary output from connection
+  output <- stack()
+
+  while (TRUE) {
+
+    data <- readBin(conn, what = "raw", n = 1024L)
+    if (empty(data))
+      break
+
+    output$push(data)
+
+  }
+
+  # join into single raw vector
+  encoded <- unlist(output$data(), recursive = FALSE, use.names = FALSE)
+
+  # convert raw data (encoded as UTF-16LE) to UTF-8
+  converted <- iconv(list(encoded), from = "UTF-16LE", to = "UTF-8")
+
+  # split on (Windows) newlines
+  paths <- strsplit(converted, "\r\n", fixed = TRUE)[[1]]
+
+  # just in case?
+  paths[nzchar(paths)]
+
+}
+# nocov end
+
+renv_file_type <- function(paths, symlinks = TRUE) {
+
+  info <- file.info(paths, extra_cols = FALSE)
+
+  types <- character(length(paths))
+  types[info$isdir %in% FALSE] <- "file"
+  types[info$isdir %in% TRUE ] <- "directory"
+
+  if (symlinks && !renv_platform_windows()) {
+    links <- Sys.readlink(paths)
+    types[!is.na(links) & nzchar(links)] <- "symlink"
+  }
+
+  types
+
+}
+
+# nocov start
+renv_file_edit <- function(path) {
+
+  # https://github.com/rstudio/renv/issues/44
+  dlls <- getLoadedDLLs()
+  if (is.null(dlls[["(embedding)"]]))
+    return(utils::file.edit(path))
+
+  routines <- getDLLRegisteredRoutines("(embedding)")
+  routine <- routines[[".Call"]][["rs_editFile"]]
+  if (is.null(routine))
+    return(utils::file.edit(path))
+
+  do.call(.Call, list(routine, path, PACKAGE = "(embedding)"))
+
+}
+# nocov end
+
+renv_file_find <- function(path, predicate) {
+
+  # canonicalize path
+  # (note: don't normalize as we don't want to follow symlinks)
+  path <- renv_path_canonicalize(path)
+  parent <- dirname(path)
+
+  # compute number of slashes (avoid searching beyond home directory)
+  slashes <- gregexpr("/", path, fixed = TRUE)[[1L]]
+  n <- length(slashes) - 2L
+
+  for (i in 1:n) {
+
+    if (file.exists(path)) {
+      status <- predicate(path)
+      if (!is.null(status))
+        return(status)
+    }
+
+    path <- parent
+    parent <- dirname(path)
+
+  }
+
+  predicate(path)
+
+}
+
+renv_file_read <- function(path) {
+  contents <- readLines(path, warn = FALSE, encoding = "UTF-8")
+  paste(contents, collapse = "\n")
+}
+
+renv_file_shebang <- function(path) {
+  con <- file(path, open = "rb")
+  on.exit(close(con), add = TRUE)
+
+  signature <- charToRaw("#!")
+  first_two_bytes <- readBin(con, what = "raw", n = length(signature))
+  looks_like_script <- identical(first_two_bytes, signature)
+
+  # skip binary files with potentially very long first "lines"
+  if (looks_like_script)
+    readLines(con, n = 1L, warn = FALSE)
+  else
+    ""
+}

--- a/R/renv-globals.R
+++ b/R/renv-globals.R
@@ -1,0 +1,20 @@
+
+`_renv_globals` <- new.env(parent = emptyenv())
+
+renv_global <- function(name, value) {
+  (`_renv_globals`[[name]]) %||% (`_renv_globals`[[name]] <- value)
+}
+
+renv_global_get <- function(name) {
+  `_renv_globals`[[name]]
+}
+
+renv_global_set <- function(name, value) {
+  `_renv_globals`[[name]] <- value
+}
+
+renv_global_clear <- function(name) {
+  if (exists(name, envir = `_renv_globals`, inherits = FALSE))
+    rm(list = name, envir = `_renv_globals`, inherits = FALSE)
+}
+

--- a/R/renv-methods.R
+++ b/R/renv-methods.R
@@ -1,0 +1,42 @@
+
+renv_methods_map <- function() {
+
+  list(
+
+    renv_path_normalize = c(
+      unix  = "renv_path_normalize_unix",
+      win32 = "renv_path_normalize_win32"
+    ),
+
+    renv_file_list_impl = c(
+      unix  = "renv_file_list_impl_unix",
+      win32 = "renv_file_list_impl_win32"
+    )
+
+  )
+
+}
+
+renv_methods_init <- function() {
+
+  # get list of method mappings
+  methods <- renv_methods_map()
+
+  # determine appropriate lookup key for finding alternative
+  key <- if (renv_platform_windows()) "win32" else "unix"
+  alts <- map(methods, `[[`, key)
+
+  # update methods in namespace
+  renv <- asNamespace("packrat")
+  enumerate(alts, function(name, alt) {
+    replacement <- eval(parse(text = alt), envir = renv)
+    assign(name, replacement, envir = renv)
+  })
+
+}
+
+renv_methods_error <- function() {
+  call <- sys.call(sys.parent())
+  fmt <- "internal error: '%s()' not initialized in .onLoad()"
+  stopf(fmt, as.character(call[[1L]]), call. = FALSE)
+}

--- a/R/renv-parse.R
+++ b/R/renv-parse.R
@@ -1,0 +1,71 @@
+
+renv_parse_file <- function(file = "", ...) {
+  if (nzchar(file)) {
+    text <- readLines(file, warn = FALSE, encoding = "UTF-8")
+    renv_parse_impl(text, srcfile = file, ...)
+  }
+}
+
+renv_parse_text <- function(text = NULL, ...) {
+  if (is.character(text)) {
+    renv_parse_impl(text, ...)
+  }
+}
+
+renv_parse_impl <- function(text, ...) {
+
+  # save default encoding
+  enc <- Encoding(text)
+
+  # disable warnings + encoding conversions
+  renv_scope_options(
+    warn     = 1L,
+    encoding = "native.enc"
+  )
+
+  # attempt multiple parse methods
+  methods <- list(
+    renv_parse_impl_asis,
+    renv_parse_impl_native,
+    renv_parse_impl_utf8
+  )
+
+  # attempt with different guessed encodings
+  encodings <- c("UTF-8", "unknown")
+
+  for (encoding in encodings) {
+    Encoding(text) <- encoding
+    for (method in methods) {
+      parsed <- catch(method(text, ...))
+      if (!inherits(parsed, "error"))
+        return(parsed)
+    }
+  }
+
+  # if these all fail, then just try the default
+  # parse and let the error propagate
+  on.exit(Sys.setlocale(), add = TRUE)
+  Encoding(text) <- enc
+  parse(text = text, ...)
+
+}
+
+renv_parse_impl_asis <- function(text, ...) {
+  on.exit(Sys.setlocale(), add = TRUE)
+  parse(text = text, ...)
+}
+
+renv_parse_impl_native <- function(text, ...) {
+  on.exit(Sys.setlocale(), add = TRUE)
+  parse(text = enc2native(text), encoding = "unknown", ...)
+}
+
+renv_parse_impl_utf8 <- function(text, ...) {
+  on.exit(Sys.setlocale(), add = TRUE)
+  parse(text = enc2utf8(text), encoding = "UTF-8", ...)
+}
+
+
+renv_deparse <- function(expr, width.cutoff = 500L, ...) {
+  paste(deparse(expr = expr, width.cutoff = width.cutoff, ...), collapse = " ")
+}

--- a/R/renv-path.R
+++ b/R/renv-path.R
@@ -1,0 +1,98 @@
+
+renv_path_absolute <- function(path) {
+  grepl("^(?:[~/\\]|[a-zA-Z]:)", path)
+}
+
+renv_path_within <- function(path, parent) {
+  path <- renv_path_canonicalize(path)
+  prefix <- paste(renv_path_canonicalize(parent), "/", sep = "")
+  path == parent | substring(path, 1L, nchar(prefix)) == prefix
+}
+
+renv_path_normalize <- function(path, winslash = "/", mustWork = FALSE) {
+  renv_methods_error()
+}
+
+renv_path_normalize_unix <- function(path,
+                                     winslash = "/",
+                                     mustWork = FALSE)
+{
+  normalizePath(path, winslash, mustWork)
+}
+
+# NOTE: in versions of R < 4.0.0, normalizePath() does not normalize path
+# casing; e.g. normalizePath("~/MyPaTh") will not normalize to "~/MyPath"
+# (assuming that is the "true" underlying casing on the filesystem)
+#
+# we work around this by round-tripping between the short name and
+# the long name, as Windows then has no choice but to figure out
+# the correct casing for us
+#
+# this isn't 100% reliable (not all paths have a short-path equivalent)
+# but seems to be good enough in practice ...
+#
+# except that, if the path contains characters that cannot be represented in the
+# current encoding, then attempting to normalize the short version of that path
+# will fail -- so if the path is already UTF-8, then we need to avoid
+# round-tripping through the short path.
+#
+# furthermore, it appears that shortPathName() can mis-encode its result for
+# strings marked with latin1 encoding?
+# https://github.com/rstudio/renv/issues/629
+#
+# https://github.com/rstudio/renv/issues/629
+renv_path_normalize_win32 <- function(path,
+                                      winslash = "/",
+                                      mustWork = FALSE)
+{
+
+  # see the NOTE above, this workaround is only necessary for R < 4 and it complicates things unnecessarily
+  if (getRversion() >= "4.0.0")
+    return(normalizePath(path, winslash, mustWork))
+
+  # get encoding for this set of paths
+  enc <- Encoding(path)
+
+  # perform separate operations for each
+  utf8    <- enc == "UTF-8"
+  latin1  <- enc == "latin1"
+  unknown <- enc == "unknown"
+
+  # normalize based on their encoding
+  path[utf8]    <- normalizePath(path[utf8], winslash, mustWork)
+  path[latin1]  <- normalizePath(path[latin1], winslash, mustWork)
+  path[unknown] <- renv_path_normalize_win32_impl(path[unknown], winslash, mustWork)
+
+  # return resulting path
+  path
+}
+
+renv_path_normalize_win32_impl <- function(path,
+                                           winslash = "/",
+                                           mustWork = FALSE)
+{
+  short <- shortPathName(path.expand(path))
+  normalizePath(short, winslash, mustWork)
+}
+
+# TODO: this is a lie; for existing paths symlinks will be resolved
+renv_path_canonicalize <- function(path) {
+  parent <- dirname(path)
+  root <- renv_path_normalize(parent, winslash = "/", mustWork = FALSE)
+  trimmed <- sub("/+$", "", root)
+  file.path(trimmed, basename(path))
+}
+
+renv_path_same <- function(lhs, rhs) {
+  renv_path_canonicalize(lhs) == renv_path_canonicalize(rhs)
+}
+
+# get the nth path component from the end of the path
+renv_path_component <- function(path, index = 1) {
+  splat <- strsplit(path, "[/\\]+")
+  map_chr(splat, function(parts) parts[length(parts) - index + 1])
+}
+
+renv_path_pretty <- function(path) {
+  renv_json_quote(aliased_path(path))
+}

--- a/R/renv-paths.R
+++ b/R/renv-paths.R
@@ -1,0 +1,400 @@
+
+renv_paths_common <- function(name, prefixes = NULL, ...) {
+
+  # check for single absolute path supplied by user
+  # TODO: handle multiple?
+  end <- file.path(...)
+  if (length(end) == 1 && renv_path_absolute(end))
+    return(end)
+
+  # compute root path
+  envvar <- paste("RENV_PATHS", toupper(name), sep = "_")
+  root <-
+    Sys.getenv(envvar, unset = NA) %NA%
+    renv_paths_root(name)
+
+  # check if the cache consists of multiple paths, if yes then split the paths
+  # this allows mixing read-only and read+write cache directories.
+  # https://github.com/rstudio/renv/issues/628
+  if (identical(name, "cache")) {
+    pattern <- if (renv_platform_windows()) "[;]" else "[;:]"
+    root <- strsplit(root, pattern)[[1L]]
+  }
+
+  # form rest of path
+  prefixed <- if (length(prefixes))
+    file.path(root, paste(prefixes, collapse = "/"))
+  else
+    root
+
+  file.path(prefixed, ...) %||% ""
+
+}
+
+renv_paths_project <- function(..., project = NULL) {
+  project <- renv_project_resolve(project)
+  file.path(project, ...) %||% ""
+}
+
+renv_paths_library_root <- function(project) {
+  renv_bootstrap_library_root(project)
+}
+
+renv_paths_library <- function(..., project = NULL) {
+  project <- renv_project_resolve(project)
+  root <- renv_paths_library_root(project)
+  file.path(root, renv_platform_prefix(), ...) %||% ""
+}
+
+renv_paths_lockfile <- function(project = NULL) {
+  project <- renv_project_resolve(project)
+  components <- c(project, renv_profile_prefix(), "renv.lock")
+  paste(components, collapse = "/")
+}
+
+renv_paths_settings <- function(project = NULL) {
+  project <- renv_project_resolve(project)
+  components <- c(project, renv_profile_prefix(), "renv/settings.dcf")
+  paste(components, collapse = "/")
+}
+
+renv_paths_local <- function(...) {
+  renv_paths_common("local", c(), ...)
+}
+
+renv_paths_source <- function(...) {
+  renv_paths_common("source", c(), ...)
+}
+
+renv_paths_binary <- function(...) {
+  renv_paths_common("binary", c(renv_platform_prefix()), ...)
+}
+
+renv_paths_cache <- function(..., version = NULL) {
+  platform <- renv_platform_prefix()
+  version <- version %||% renv_cache_version()
+  renv_paths_common("cache", c(version, platform), ...)
+}
+
+renv_paths_rtools <- function(...) {
+
+  root <- Sys.getenv("RENV_PATHS_RTOOLS", unset = NA)
+  if (!is.na(root))
+    return(root)
+
+  # TODO: this was a typo in a previous usage; preserved
+  # for backwards compatibility
+  root <- Sys.getenv("RENV_PATH_RTOOLS", unset = NA)
+  if (!is.na(root))
+    return(root)
+
+  spec <- renv_rtools_find()
+  file.path(spec$root, ...) %||% ""
+
+}
+
+renv_paths_extsoft <- function(...) {
+  renv_paths_common("extsoft", c(), ...)
+}
+
+renv_paths_mran <- function(...) {
+  renv_paths_common("mran", c(), ...)
+}
+
+
+
+renv_paths_root <- function(...) {
+
+  root <-
+    Sys.getenv("RENV_PATHS_ROOT", unset = NA) %NA%
+    renv_paths_root_default()
+
+  file.path(root, ...) %||% ""
+
+}
+
+# nocov start
+renv_paths_root_default <- function() {
+
+  # use tempdir for cache when running tests
+  # this check is necessary here to support packages which might use renv
+  # during testing (and we don't want those to try to use the user dir)
+  checking <-
+    "CheckExEnv" %in% search() ||
+    !is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", unset = NA)) ||
+    !is.na(Sys.getenv("TESTTHAT", unset = NA))
+
+  if (checking)
+    return(renv_paths_root_default_tempdir())
+
+  # resolve path to cache
+  path <- renv_paths_root_default_impl()
+
+  # check for user consent
+  consenting <- identical(getOption("renv.consenting"), TRUE)
+  if (consenting)
+    return(path)
+
+  consented <- renv_consent_check()
+  if (consented) {
+    ensure_directory(path)
+    return(path)
+  }
+
+  # if this root directory has not yet been created, then use a path
+  # in the temporary directory instead (users must call renv::consent
+  # to create this path explicitly)
+  type <- renv_file_type(path, symlinks = FALSE)
+  if (type == "directory")
+    return(path)
+
+  if (renv_once()) {
+    renv_pretty_print(
+      aliased_path(path),
+      "The renv support directory has not yet been created:",
+      c(
+        "A temporary support directory will be used instead.",
+        "Please call `renv::consent()` to allow renv to generate the support directory.",
+        "Please restart the R session after providing consent."
+      ),
+      wrap = FALSE
+    )
+  }
+
+  renv_paths_root_default_tempdir()
+
+}
+
+renv_paths_root_default_impl <- function() {
+
+  # support renv projects created with the old root location
+  oldroot <- switch(
+    Sys.info()[["sysname"]],
+    Darwin  = Sys.getenv("XDG_DATA_HOME", "~/Library/Application Support"),
+    Windows = Sys.getenv("LOCALAPPDATA", Sys.getenv("APPDATA")),
+    Sys.getenv("XDG_DATA_HOME", "~/.local/share")
+  )
+
+  # if we've already initialized renv with the old location, use it
+  oldpath <- file.path(oldroot, "renv")
+  if (file.exists(oldpath))
+    return(oldpath)
+
+  # try using tools to get the user directory
+  tools <- asNamespace("tools")
+  path <- catch(tools$R_user_dir("renv", which = "cache"))
+  if (!inherits(path, "error"))
+    return(path)
+
+  # try using our own backfill for older versions of R
+  renv_paths_root_default_impl_fallback()
+
+}
+
+renv_paths_root_default_impl_fallback <- function() {
+
+  # check for R_USER_CACHE_DIR + XDG_CACHE_HOME overrides
+  envvars <- c("R_USER_CACHE_DIR", "XDG_CACHE_HOME")
+  for (envvar in envvars) {
+    root <- Sys.getenv(envvar, unset = NA)
+    if (!is.na(root)) {
+      path <- file.path(root, "R/renv")
+      return(path)
+    }
+  }
+
+  # use platform-specific default fallbacks
+  if (renv_platform_windows())
+    file.path(Sys.getenv("LOCALAPPDATA"), "R/cache/R/renv")
+  else if (renv_platform_macos())
+    "~/Library/Caches/org.R-project.R/R/renv"
+  else
+    "~/.cache/R/renv"
+
+}
+
+renv_paths_root_default_tempdir <- function() {
+  temp <- file.path(tempdir(), "renv")
+  ensure_directory(temp)
+  return(temp)
+}
+# nocov end
+
+renv_paths_init <- function() {
+  renv_paths_init_envvars()
+}
+
+renv_paths_init_envvars <- function() {
+
+  envvars <- Sys.getenv()
+
+  keys <- grep("^RENV_PATHS_", names(envvars), value = TRUE)
+  keys <- setdiff(keys, c("RENV_PATHS_PREFIX", "RENV_PATHS_PREFIX_AUTO"))
+
+  if (empty(keys))
+    return(character())
+
+  args <- lapply(envvars[keys], normalizePath, winslash = "/", mustWork = FALSE)
+  do.call(Sys.setenv, args)
+
+}
+
+#' Path Customization
+#'
+#' Access the paths that `renv` uses for global state storage.
+#'
+#' By default, `renv` collects state into these folders:
+#'
+#' \tabular{ll}{
+#' **Platform** \tab **Location** \cr
+#' Linux        \tab `~/.local/share/renv` \cr
+#' macOS        \tab `~/Library/Application Support/renv` \cr
+#' Windows      \tab `%LOCALAPPDATA%/renv` \cr
+#' }
+#'
+#' For new installations of `renv` using R (>= 4.0.0), `renv` will use
+#' [tools::R_user_dir()] to resolve the root directory. If an `renv` root
+#' directory has already been created in one of the old locations, that will
+#' still be used. This change was made to comply with the CRAN policy
+#' requirements of \R packages. By default, these paths resolve as:
+#'
+#' \tabular{ll}{
+#' **Platform** \tab **Location** \cr
+#' Linux        \tab `~/.cache/R/renv` \cr
+#' macOS        \tab `~/Library/Caches/org.R-project.R/R/renv` \cr
+#' Windows      \tab `%LOCALAPPDATA%/R/cache/R/renv` \cr
+#' }
+#'
+#' If desired, this path can be customized by setting the `RENV_PATHS_ROOT`
+#' environment variable. This can be useful if you'd like, for example, multiple
+#' users to be able to share a single global cache.
+#'
+#' The various state sub-directories can also be individually adjusted, if so
+#' desired (e.g. you'd prefer to keep the cache of package installations on a
+#' separate volume). The various environment variables that can be set are
+#' enumerated below:
+#'
+#' \tabular{ll}{
+#' \strong{Environment Variable}     \tab \strong{Description} \cr
+#' \code{RENV_PATHS_ROOT}            \tab The root path used for global state storage. \cr
+#' \code{RENV_PATHS_LIBRARY}         \tab The path to the project library. \cr
+#' \code{RENV_PATHS_LIBRARY_ROOT}    \tab The parent path for project libraries. \cr
+#' \code{RENV_PATHS_LIBRARY_STAGING} \tab The parent path used for staged package installs. \cr
+#' \code{RENV_PATHS_LOCAL}           \tab The path containing local package sources. \cr
+#' \code{RENV_PATHS_SOURCE}          \tab The path containing downloaded package sources. \cr
+#' \code{RENV_PATHS_BINARY}          \tab The path containing downloaded package binaries. \cr
+#' \code{RENV_PATHS_CACHE}           \tab The path containing cached package installations. \cr
+#' \code{RENV_PATHS_PREFIX}          \tab An optional prefix to prepend to the constructed library / cache paths. \cr
+#' \code{RENV_PATHS_RTOOLS}          \tab (Windows only) The path to [Rtools](https://cran.r-project.org/bin/windows/Rtools/). \cr
+#' \code{RENV_PATHS_EXTSOFT}         \tab (Windows only) The path containing external software needed for compilation of Windows source packages. \cr
+#' \code{RENV_PATHS_MRAN}            \tab The path containing MRAN-related metadata. See `vignette("mran", package = "renv")` for more details. \cr
+#' }
+#'
+#' Note that `renv` will append platform-specific and version-specific entries
+#' to the set paths as appropriate. For example, if you have set:
+#'
+#' ```
+#' Sys.setenv(RENV_PATHS_CACHE = "/mnt/shared/renv/cache")
+#' ```
+#'
+#' then the directory used for the cache will still depend on the `renv` cache
+#' version (e.g. `v2`), the \R version (e.g. `3.5`) and the platform (e.g.
+#' `x86_64-pc-linux-gnu`). For example:
+#'
+#' ```
+#' /mnt/shared/renv/cache/v2/R-3.5/x86_64-pc-linux-gnu
+#' ```
+#'
+#' This ensures that you can set a single `RENV_PATHS_CACHE` environment variable
+#' globally without worry that it may cause collisions or errors if multiple
+#' versions of \R needed to interact with the same cache.
+#'
+#' If you need to share the same cache with multiple different Linux operating
+#' systems, you may want to set the `RENV_PATHS_PREFIX` environment variable
+#' to help disambiguate the paths used on Linux. For example, setting
+#' `RENV_PATHS_PREFIX = "ubuntu-bionic"` would instruct `renv` to construct a
+#' cache path like:
+#'
+#' ```
+#' /mnt/shared/renv/cache/v2/ubuntu-bionic/R-3.5/x86_64-pc-linux-gnu
+#' ```
+#'
+#' If this is required, it's strongly recommended that this environment
+#' variable is set in your \R installation's `Renviron.site` file, typically
+#' located at `file.path(R.home("etc"), "Renviron.site")`, so that it can be
+#' active for any \R sessions launched on that machine.
+#'
+#' Starting from `renv 0.13.0`, you can also instruct `renv` to auto-generate
+#' an OS-specific component to include as part of library and cache paths,
+#' by setting the environment variable:
+#'
+#' ```
+#' RENV_PATHS_PREFIX_AUTO = TRUE
+#' ```
+#'
+#' The prefix will be constructed based on fields within the system's
+#' `/etc/os-release` file.
+#'
+#' If reproducibility of a project is desired on a particular machine, it is
+#' highly recommended that the `renv` cache of installed packages + binary
+#' packages is backed up and persisted, so that packages can be easily restored
+#' in the future -- installation of packages from source can often be arduous.
+#'
+#' If you want these settings to persist in your project, it is recommended that
+#' you add these to an appropriate \R startup file. For example, these could be
+#' set in:
+#'
+#' - A project-local `.Renviron`;
+#' - The user-level `.Renviron`;
+#' - A file at `file.path(R.home("etc"), "Renviron.site")`.
+#'
+#' Please see ?[Startup] for more details.
+#'
+#' @section Local Sources:
+#'
+#' If your project depends on one or \R packages that are not available in any
+#' remote location, you can still provide a locally-available tarball for `renv`
+#' to use during restore. By default, these packages should be made available in
+#' the folder as specified by the `RENV_PATHS_LOCAL` environment variable. The
+#' package sources should be placed in a file at one of these locations:
+#'
+#' - `${RENV_PATHS_LOCAL}/<package>_<version>.<ext>`
+#' - `${RENV_PATHS_LOCAL}/<package>/<package>_<version>.<ext>`
+#' - `<project>/renv/local/<package>_<version>.<ext>`
+#' - `<project>/renv/local/<package>/<package>_<version>.<ext>`
+#'
+#' where `.<ext>` is `.tar.gz` for source packages, or `.tgz` for binaries on
+#' macOS and `.zip` for binaries on Windows. During a `restore()`, packages
+#' installed from an unknown source will be searched for in this location.
+#'
+#' @section Projects:
+#'
+#' In order to determine whether a package can safely be removed from the cache,
+#' `renv` needs to know which projects are using packages from the cache. Since
+#' packages may be symlinked from the cache, and symlinks are by nature a one-way
+#' link, projects need to also report that they're using the `renv` cache.
+#'
+#' To accomplish this, whenever `renv` is used with a project, it will record
+#' itself as being used within a file located at:
+#'
+#' - `${RENV_PATHS_ROOT}/projects`
+#'
+#' This file is list of projects currently using the `renv` cache. With this,
+#' `renv` can crawl projects registered with `renv` and use that to determine if
+#' any packages within the cache are no longer in use, and can be removed.
+#'
+#' @rdname paths
+#' @name paths
+#'
+#' @export
+#'
+#' @examples
+#' # get the path to the project library
+#' path <- renv::paths$library()
+paths <- list(
+  root     = renv_paths_root,
+  library  = renv_paths_library,
+  lockfile = renv_paths_lockfile,
+  settings = renv_paths_settings,
+  cache    = renv_paths_cache
+)

--- a/R/renv-platform.R
+++ b/R/renv-platform.R
@@ -1,0 +1,52 @@
+
+`_renv_sysinfo` <- NULL
+
+renv_platform_init <- function() {
+  `_renv_sysinfo` <<- Sys.info()
+}
+
+renv_platform_unix <- function() {
+  .Platform$OS.type == "unix"
+}
+
+renv_platform_windows <- function() {
+  .Platform$OS.type == "windows"
+}
+
+renv_platform_macos <- function() {
+  `_renv_sysinfo`[["sysname"]] == "Darwin"
+}
+
+renv_platform_linux <- function() {
+  `_renv_sysinfo`[["sysname"]] == "Linux"
+}
+
+renv_platform_solaris <- function() {
+  `_renv_sysinfo`[["sysname"]] == "SunOS"
+}
+
+renv_platform_wsl <- function() {
+
+  pv <- "/proc/version"
+  if (!file.exists(pv))
+    return(FALSE)
+
+  contents <- catch(readLines(pv, warn = FALSE))
+  if (inherits(contents, "error"))
+    return(FALSE)
+
+  any(grepl("(?:Microsoft|WSL)", contents, ignore.case = TRUE))
+
+}
+
+renv_platform_prefix <- function() {
+  renv_bootstrap_platform_prefix()
+}
+
+renv_platform_os <- function() {
+  renv_bootstrap_platform_os()
+}
+
+renv_platform_machine <- function() {
+  `_renv_sysinfo`[["machine"]]
+}

--- a/R/renv-predicate.R
+++ b/R/renv-predicate.R
@@ -1,0 +1,9 @@
+
+pscalar <- function(x) {
+  length(x) == 1L
+}
+
+pstring <- function(x) {
+  is.character(x) && length(x) == 1L
+}
+

--- a/R/renv-profile.R
+++ b/R/renv-profile.R
@@ -1,0 +1,16 @@
+
+renv_profile_prefix <- function() {
+  renv_bootstrap_profile_prefix()
+}
+
+renv_profile_get <- function() {
+  renv_bootstrap_profile_get()
+}
+
+renv_profile_set <- function(profile) {
+  renv_bootstrap_profile_set(profile)
+}
+
+renv_profile_normalize <- function(profile) {
+  renv_bootstrap_profile_normalize(profile)
+}

--- a/R/renv-progress.R
+++ b/R/renv-progress.R
@@ -1,0 +1,36 @@
+
+# given some function 'f' to be called repeatedly 'max' times,
+# write a small progress counter (using 'emit') if we haven't
+# finished execution after 'wait' seconds. note that we assume
+# that the callback 'f' doesn't also attempt to write output
+# to the same stream used by the progress emitter
+renv_progress <- function(f, max, wait = 1.0, emit = renv_progress_emit) {
+
+  # since we're returning a function need to force all arguments here
+  force(f); force(max); force(wait); force(emit)
+
+  # prepare some state tracking progress
+  count <- 0
+  progress <- ""
+  start <- Sys.time()
+
+  function(...) {
+
+    # check for and print progress
+    count <<- count + 1
+    if (Sys.time() - start > wait) {
+      backspaces <- paste(rep("\b", nchar(progress)), collapse = "")
+      progress <<- sprintf("[%i/%i] ", count, max)
+      emit(paste(backspaces, progress, sep = ""))
+    }
+
+    # invoke callback
+    f(...)
+
+  }
+
+}
+
+renv_progress_emit <- function(...) {
+  cat(..., file = stdout(), sep = "")
+}

--- a/R/renv-project.R
+++ b/R/renv-project.R
@@ -1,0 +1,288 @@
+
+#' Retrieve the Active Project
+#'
+#' Retrieve the path to the active project (if any).
+#'
+#' @param default The value to return when no project is
+#'   currently active. Defaults to `NULL`.
+#'
+#' @export
+#'
+#' @return The active project directory, as a length-one character vector.
+#'
+#' @examples
+#' \dontrun{
+#'
+#' # get the currently-active renv project
+#' renv::project()
+#'
+#' }
+project <- function(default = NULL) {
+  renv_project(default = default)
+}
+
+renv_project <- function(default = getwd()) {
+  project <- Sys.getenv("RENV_PROJECT", unset = NA)
+  if (is.na(project))
+    return(default)
+  project
+}
+
+renv_project_resolve <- function(project = NULL) {
+  project <- project %||% renv_project()
+  normalizePath(project, winslash = "/", mustWork = FALSE)
+}
+
+renv_project_initialized <- function(project) {
+
+  lockfile <- renv_lockfile_path(project)
+  if (file.exists(lockfile))
+    return(TRUE)
+
+  library <- renv_paths_library(project = project)
+  if (file.exists(library))
+    return(TRUE)
+
+  FALSE
+
+}
+
+renv_project_type <- function(path) {
+
+  descpath <- file.path(path, "DESCRIPTION")
+  if (!file.exists(descpath))
+    return("unknown")
+
+  renv_description_type(descpath)
+
+}
+
+renv_project_remotes <- function(project) {
+
+  # if this project has a DESCRIPTION file, use it to provide records
+  descpath <- file.path(project, "DESCRIPTION")
+  if (file.exists(descpath))
+    return(renv_project_remotes_description(project, descpath))
+
+  # otherwise, use the set of (non-base) packages used in the project
+  deps <- dependencies(
+    path     = project,
+    progress = FALSE,
+    errors   = "ignored",
+    dev      = TRUE
+  )
+
+  packages <- sort(unique(deps$Package))
+  setdiff(packages, renv_packages_base())
+
+}
+
+renv_project_remotes_description <- function(project, descpath) {
+
+  # first, parse remotes (if any)
+  remotes <- renv_project_remotes_description_remotes(project, descpath)
+
+  # next, find packages mentioned in the DESCRIPTION file
+  fields <- c("Depends", "Imports", "Suggests", "LinkingTo")
+  deps <- renv_dependencies_discover_description(descpath, fields)
+  if (empty(deps))
+    return(list())
+
+  # split according to package
+  specs <- split(deps, deps$Package)
+
+  # drop ignored specs
+  ignored <- renv_project_ignored_packages(project = project)
+  specs <- specs[setdiff(names(specs), c("R", ignored))]
+
+  # if any Roxygen fields are included,
+  # infer a dependency on roxygen2 and devtools
+  desc <- renv_description_read(descpath)
+  if (any(grepl("^Roxygen", names(desc)))) {
+    for (package in c("devtools", "roxygen2")) {
+      specs[[package]] <-
+        specs[[package]] %||%
+        renv_dependencies_list(descpath, package, dev = TRUE)
+    }
+  }
+
+  # now, try to resolve the packages
+  records <- enumerate(specs, function(package, spec) {
+
+    # use remote if supplied
+    if (!is.null(remotes[[package]]))
+      return(remotes[[package]])
+
+    # check for explicit version requirement
+    explicit <- spec[spec$Require == "==", ]
+    if (nrow(explicit) == 0)
+      return(renv_remotes_resolve(package))
+
+    version <- spec$Version[[1]]
+    if (!nzchar(version))
+      return(renv_remotes_resolve(package))
+
+    entry <- paste(package, version, sep = "@")
+    renv_remotes_resolve(entry)
+
+  })
+
+  # return records
+  records
+
+}
+
+renv_project_remotes_description_remotes <- function(project, descpath) {
+
+  desc <- renv_description_read(descpath)
+
+  remotes <- desc$Remotes
+  if (is.null(desc$Remotes))
+    return(list())
+
+  splat <- strsplit(remotes, "\\s*,\\s*")[[1]]
+  resolved <- lapply(splat, renv_remotes_resolve)
+  names(resolved) <- extract_chr(resolved, "Package")
+  resolved
+
+}
+
+renv_project_ignored_packages <- function(project) {
+
+  # if we don't have a project, nothing to do
+  if (is.null(project))
+    return(character())
+
+  # read base set of ignored packages
+  ignored <- c(
+    settings$ignored.packages(project = project),
+    renv_project_ignored_packages_self(project)
+  )
+
+  # return collected set of ignored packages
+  ignored
+
+}
+
+renv_project_ignored_packages_self <- function(project) {
+
+  # only ignore self in package projects
+  if (renv_project_type(project) != "package")
+    return(NULL)
+
+  # read current package
+  desc <- renv_description_read(project)
+  package <- desc[["Package"]]
+
+  # respect user preference if set
+  ignore <- getOption("renv.snapshot.ignore.self", default = NULL)
+  if (identical(ignore, TRUE))
+    return(package)
+  else if (identical(ignore, FALSE))
+    return(NULL)
+
+  # don't ignore self in golem projets
+  golem <- file.path(project, "inst/golem-config.yml")
+  if (file.exists(golem))
+    return(NULL)
+
+  # hack for renv: don't depend on self
+  if (identical(package, "renv"))
+    return(NULL)
+
+  # return the package name
+  package
+
+}
+
+renv_project_id <- function(project) {
+
+  idpath <- renv_id_path(project = project)
+  if (!file.exists(idpath)) {
+    id <- renv_id_generate()
+    writeLines(id, con = idpath)
+  }
+
+  readLines(idpath, n = 1L, warn = FALSE)
+
+}
+
+renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
+
+  project  <- renv_project_resolve(project)
+  lockfile <- lockfile %||% renv_lockfile_load(project)
+
+  # if there are no packages (other than renv) available in the project library,
+  # but there are multiple packages referenced in the lockfile,
+  # then instruct the user that they may need to run restore
+  libpath <- renv_paths_library(project = project)
+  packages <- list.files(libpath)
+
+  needsrestore <-
+    empty(setdiff(packages, "renv")) &&
+    length(lockfile$Packages) > 1
+
+  if (needsrestore) {
+
+    msg <- lines(
+      "* The project library is out of sync with the lockfile.",
+      "* Use `renv::restore()` to install packages recorded in the lockfile."
+    )
+
+    ewritef(msg)
+    return(FALSE)
+  }
+
+  # perform a lightweight comparison between the project
+  # library and lockfile, and report if there may be
+  # any conflicts
+  library <- renv_libpaths_all()
+
+  # don't validate lockfile state in this scope; just try
+  # to read and use it as-is
+  renv_scope_options(renv.config.snapshot.validate = FALSE)
+
+  # read current state of project library
+  libstate <- snapshot(
+    project  = project,
+    library  = library,
+    lockfile = NULL,
+    type     = "all",
+    force    = TRUE
+  )
+
+  # compare with the current lockfile
+  diff <- renv_lockfile_diff_packages(libstate, lockfile)
+
+  # we only want to report cases where a package version
+  # has changed, or the lockfile references a package that
+  # is not currently installed in the project library
+  diff <- diff[diff != "remove"]
+  if (!empty(diff)) {
+    msg <- "* The project may be out of sync -- use `renv::status()` for more details."
+    ewritef(msg)
+    return(FALSE)
+  }
+
+  TRUE
+
+}
+
+renv_project_find <- function(project = NULL) {
+
+  project <- project %||% getwd()
+
+  resolved <- renv_file_find(project, function(parent) {
+    lockpath <- file.path(parent, "renv/activate.R")
+    if (file.exists(lockpath))
+      return(parent)
+  })
+
+  if (is.null(resolved)) {
+    fmt <- "couldn't resolve renv project associated with path %s"
+    stopf(fmt, renv_path_pretty(project))
+  }
+
+  resolved
+
+}

--- a/R/renv-renvignore.R
+++ b/R/renv-renvignore.R
@@ -1,0 +1,151 @@
+
+# given a path within a project, read all relevant ignore files
+# and generate a pattern that can be used to filter file results
+renv_renvignore_pattern <- function(path = getwd(), root = path) {
+
+  if (is.null(root))
+    return(NULL)
+
+  stopifnot(
+    renv_path_absolute(path),
+    renv_path_absolute(root)
+  )
+
+  # prepare ignores
+  ignores <- stack()
+
+  # read ignore files
+  parent <- path
+  while (parent != dirname(parent)) {
+
+    # attempt to read either .renvignore or .gitignore
+    for (file in c(".renvignore", ".gitignore")) {
+      candidate <- file.path(parent, file)
+      if (file.exists(candidate)) {
+        contents <- readLines(candidate, warn = FALSE)
+        parsed <- renv_renvignore_parse(contents, parent)
+        if (length(parsed))
+          ignores$push(parsed)
+        break
+      }
+    }
+
+    # stop once we've hit the project root
+    if (parent == root)
+      break
+
+    parent <- dirname(parent)
+
+  }
+
+  # collect patterns read
+  patterns <- ignores$data()
+  if (empty(patterns))
+    return(list())
+
+  # separate exclusions, exclusions
+  include <- unlist(extract(patterns, "include"))
+  exclude <- unlist(extract(patterns, "exclude"))
+
+  list(include = include, exclude = exclude)
+
+}
+
+# reads a .gitignore / .renvignore file, and translates the associated
+# entries into PCREs which can be combined and used during directory traversal
+renv_renvignore_parse <- function(contents, prefix = "") {
+
+  # read the ignore entries
+  contents <- grep("^\\s*(?:#|$)", contents, value = TRUE, invert = TRUE)
+  if (empty(contents))
+    return(list())
+
+  # split into inclusion, exclusion patterns
+  negate <- substring(contents, 1L, 1L) == "!"
+  exclude <- contents[!negate]
+  include <- substring(contents[negate], 2L)
+
+  # parse patterns separately
+  list(
+    exclude = renv_renvignore_parse_impl(exclude, prefix),
+    include = renv_renvignore_parse_impl(include, prefix)
+  )
+
+}
+
+renv_renvignore_parse_impl <- function(entries, prefix = "") {
+
+  # check for empty entries list
+  if (empty(entries))
+    return(character())
+
+  # remove trailing whitespace
+  entries <- gsub("\\s+$", "", entries)
+
+  # remove trailing slashes
+  entries <- gsub("/+$", "", entries)
+
+  # entries without a slash should match in whole tree
+  noslash <- grep("/", entries, fixed = TRUE, invert = TRUE)
+  entries[noslash] <- paste("**", entries[noslash], sep = "/")
+
+  # remove a leading slash (avoid double-slashing)
+  entries <- gsub("^/+", "", entries)
+
+  # save any '**' entries seen
+  entries <- gsub("**/",  "\001", entries, fixed = TRUE)
+  entries <- gsub("/**",  "\002", entries, fixed = TRUE)
+
+  # transform '*' and '?'
+  entries <- gsub("*", "\\E[^/]*\\Q", entries, fixed = TRUE)
+  entries <- gsub("?", "\\E[^/]\\Q",  entries, fixed = TRUE)
+
+  # restore '**' entries
+  entries <- gsub("\001", "\\E(?:.*/)?\\Q", entries, fixed = TRUE)
+  entries <- gsub("\002", "/\\E.*\\Q",      entries, fixed = TRUE)
+
+  # enclose in \\Q \\E to ensure e.g. plain '.' are not treated
+  # as regex characters
+  entries <- sprintf("\\Q%s\\E$", entries)
+
+  # prepend prefix
+  entries <- sprintf("^\\Q%s/\\E%s", prefix, entries)
+
+  # remove \\Q\\E
+  entries <- gsub("\\Q\\E", "", entries, fixed = TRUE)
+
+  # all done!
+  entries
+
+}
+
+renv_renvignore_exec <- function(path, root, children) {
+
+  patterns <- renv_renvignore_pattern(path, root)
+  if (empty(patterns) || empty(patterns$exclude))
+    return(children)
+
+  # get the entries that need to be excluded
+  excludes <- logical(length = length(children))
+  for (pattern in patterns$exclude)
+    if (nzchar(pattern))
+      excludes <- excludes | grepl(pattern, children, perl = TRUE)
+
+  if (length(patterns$include)) {
+
+    # check for entries that should be explicitly included
+    # (note that these override any excludes)
+    includes <- logical(length = length(children))
+    for (pattern in patterns$include)
+      if (nzchar(pattern))
+        includes <- includes | grepl(pattern, children, perl = TRUE)
+
+    # unset those excludes
+    excludes[includes] <- FALSE
+
+  }
+
+  # keep paths not explicitly excluded
+  children[!excludes]
+
+}

--- a/R/renv-scope.R
+++ b/R/renv-scope.R
@@ -1,0 +1,380 @@
+
+renv_scope_tempdir <- function(pattern = "renv-tempdir-", .envir = NULL) {
+
+  dir <- tempfile(pattern)
+  ensure_directory(dir)
+  owd <- setwd(dir)
+
+  .envir <- .envir %||% parent.frame()
+
+  defer({
+    setwd(owd)
+    unlink(dir, recursive = TRUE)
+  }, envir = .envir)
+
+}
+
+renv_scope_auth <- function(record, .envir = NULL) {
+
+  package <- record$Package
+  auth <- renv_options_override("renv.auth", package)
+
+  if (empty(auth))
+    return(FALSE)
+
+  envvars <- catch({
+    if (is.function(auth))
+      auth(record)
+    else
+      auth
+  })
+
+  # warn user if auth appears invalid
+  if (inherits(envvars, "error")) {
+    warning(envvars)
+    return(FALSE)
+  }
+
+  if (empty(envvars))
+    return(FALSE)
+
+  .envir <- .envir %||% parent.frame()
+  renv_scope_envvars(.list = as.list(envvars), .envir = .envir)
+  return(TRUE)
+
+}
+
+renv_scope_libpaths <- function(new = .libPaths(), .envir = NULL) {
+  .envir <- .envir %||% parent.frame()
+  old <- renv_libpaths_set(new)
+  defer(renv_libpaths_set(old), envir = .envir)
+}
+
+renv_scope_options <- function(..., .envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  new <- list(...)
+  old <- lapply(names(new), getOption)
+  names(old) <- names(new)
+
+  do.call(base::options, new)
+  defer(do.call(base::options, old), envir = .envir)
+
+}
+
+renv_scope_locale <- function(category = "LC_ALL", locale = "", .envir = NULL) {
+  .envir <- .envir %||% parent.frame()
+  saved <- Sys.getlocale(category)
+  Sys.setlocale(category, locale)
+  defer(Sys.setlocale(category, saved), envir = .envir)
+}
+
+renv_scope_envvars <- function(..., .list = NULL, .envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  dots <- .list %||% list(...)
+  old <- as.list(Sys.getenv(names(dots), unset = NA))
+  names(old) <- names(dots)
+
+  unset <- map_lgl(dots, is.null)
+  Sys.unsetenv(names(dots[unset]))
+  if (length(dots[!unset]))
+    do.call(Sys.setenv, dots[!unset])
+
+  defer({
+    na <- is.na(old)
+    Sys.unsetenv(names(old[na]))
+    if (length(old[!na]))
+      do.call(Sys.setenv, old[!na])
+  }, envir = .envir)
+
+}
+
+renv_scope_sink <- function(file = nullfile(), ..., .envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  # redirect stdout to file, and redirect stderr back to stdout
+  # this ensures that both stdout, stderr are redirected to the same place
+  sink(file = file,     type = "output")
+  sink(file = stdout(), type = "message")
+
+  defer({
+    sink(type = "output")
+    sink(type = "message")
+  }, envir = .envir)
+
+}
+
+renv_scope_error_handler <- function(.envir = NULL) {
+
+  error <- getOption("error")
+  if (!is.null(error))
+    return(FALSE)
+
+  call <- renv_error_handler_call()
+  options(error = call)
+
+  .envir <- .envir %||% parent.frame()
+  defer({
+    if (identical(getOption("error"), call))
+      options(error = error)
+  }, envir = .envir)
+
+  TRUE
+
+}
+
+# used to enforce usage of curl 7.64.1 within the
+# renv_paths_extsoft folder when available on Windows
+
+# nocov start
+renv_scope_downloader <- function(.envir = NULL) {
+
+  if (!renv_platform_windows())
+    return(FALSE)
+
+  if (nzchar(Sys.which("curl")))
+    return(FALSE)
+
+  curlroot <- sprintf("curl-%s-win32-mingw", renv_extsoft_curl_version())
+  curl <- renv_paths_extsoft(curlroot, "bin/curl.exe")
+  if (!file.exists(curl))
+    return(FALSE)
+
+  old <- Sys.getenv("PATH", unset = NA)
+  if (is.na(old))
+    return(FALSE)
+
+  new <- paste(renv_path_normalize(dirname(curl)), old, sep = .Platform$path.sep)
+
+  .envir <- .envir %||% parent.frame()
+  renv_scope_envvars(PATH = new, .envir = .envir)
+
+}
+# nocov end
+
+# nocov start
+renv_scope_rtools <- function(.envir = NULL) {
+
+  if (!renv_platform_windows())
+    return(FALSE)
+
+  # check for Rtools
+  root <- renv_paths_rtools()
+  if (!file.exists(root))
+    return(FALSE)
+
+  # get environment variables appropriate for version of Rtools
+  vars <- renv_rtools_envvars(root)
+
+  # scope envvars in parent
+  .envir <- .envir %||% parent.frame()
+  renv_scope_envvars(.list = vars, .envir = .envir)
+
+}
+# nocov end
+
+# nocov start
+renv_scope_install <- function(.envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  if (renv_platform_macos())
+    renv_scope_install_macos(.envir)
+
+  if (renv_platform_wsl())
+    renv_scope_install_wsl(.envir)
+
+}
+
+renv_scope_install_macos <- function(.envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  # get the current compiler
+  args <- c("CMD", "config", "CC")
+  cc <- system2(R(), args, stdout = TRUE, stderr = TRUE)
+
+  # check to see if we're using the system toolchain
+  # (need to be careful since users might put e.g. ccache or other flags
+  # into the CC variable)
+
+  # helper for creating regex matching compiler bits
+  matches <- function(pattern) {
+    regex <- paste("(?:[[:space:]]|^)", pattern, "(?:[[:space:]]|$)", sep = "")
+    grepl(regex, cc)
+  }
+
+  sysclang <- case(
+    matches("/usr/bin/clang") ~ TRUE,
+    matches("clang")          ~ Sys.which("clang") == "/usr/bin/clang",
+    FALSE
+  )
+
+  # check for an appropriate LLVM toolchain -- if it exists, use it
+  spec <- renv_equip_macos_spec()
+  if (sysclang && !is.null(spec) && file.exists(spec$dst)) {
+    path <- paste(file.path(spec$dst, "bin"), Sys.getenv("PATH"), sep = ":")
+    renv_scope_envvars(PATH = path, .envir = .envir)
+  }
+
+  # generate a custom makevars that should better handle compilation
+  # with the system toolchain (or other toolchains)
+  makevars <- stack()
+
+  # if we don't have an LLVM toolchain available, then try to generate
+  # a Makeconf that shields compilation from usages of '-fopenmp'
+  if (sysclang) {
+
+    makeconf <- readLines(file.path(R.home("etc"), "Makeconf"), warn = FALSE)
+    mplines <- grep(" -fopenmp", makeconf, fixed = TRUE, value = TRUE)
+
+    # read a user makevars (if any)
+    contents <- character()
+    mvsite <- Sys.getenv(
+      "R_MAKEVARS_SITE",
+      unset = file.path(R.home("etc"), "Makevars.site")
+    )
+
+    if (file.exists(mvsite))
+      contents <- readLines(mvsite, warn = FALSE)
+
+    # override usages of '-fopenmp'
+    replaced <- gsub(" -fopenmp", "", mplines, fixed = TRUE)
+    amended <- unique(c(contents, replaced))
+    makevars$push(amended)
+
+  }
+
+  # write makevars to file
+  path <- tempfile("Makevars-")
+  contents <- unlist(makevars$data(), recursive = TRUE, use.names = FALSE)
+  if (length(contents)) {
+    writeLines(contents, con = path)
+    renv_scope_envvars(R_MAKEVARS_SITE = path, .envir = .envir)
+  }
+
+  TRUE
+
+}
+
+renv_scope_install_wsl <- function(.envir = NULL) {
+  .envir <- .envir %||% parent.frame()
+  renv_scope_envvars(R_INSTALL_STAGED = "FALSE")
+}
+# nocov end
+
+renv_scope_restore <- function(..., .envir = NULL) {
+  .envir <- .envir %||% parent.frame()
+  state <- renv_restore_begin(...)
+  defer(renv_restore_end(state), envir = .envir)
+}
+
+renv_scope_git_auth <- function(.envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  # TODO: not yet implemented for Windows
+  if (renv_platform_windows())
+    return(FALSE)
+
+  # use GIT_PAT when provided
+  pat <- Sys.getenv("GIT_PAT", unset = NA)
+  if (!is.na(pat)) {
+    renv_scope_envvars(
+      GIT_USERNAME = pat,
+      GIT_PASSWORD = "x-oauth-basic",
+      .envir = .envir
+    )
+  }
+
+  # only set askpass when GIT_USERNAME + GIT_PASSWORD are set
+  user <-
+    Sys.getenv("GIT_USERNAME", unset = NA) %NA%
+    Sys.getenv("GIT_USER",     unset = NA)
+
+  pass <-
+    Sys.getenv("GIT_PASSWORD", unset = NA) %NA%
+    Sys.getenv("GIT_PASS",     unset = NA)
+
+  if (is.na(user) || is.na(pass))
+    return(FALSE)
+
+  askpass <- system.file("resources/scripts-git-askpass.sh", package = "renv")
+  renv_scope_envvars(GIT_ASKPASS = askpass, .envir = .envir)
+  return(TRUE)
+
+}
+
+renv_scope_bioconductor <- function(.envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  # ensure bioconductor support infrastructure initialized
+  renv_bioconductor_init()
+
+  # activate bioconductor repositories in this context
+  repos <- getOption("repos")
+  biocrepos <- c(renv_bioconductor_repos(), repos)
+  renv_scope_options(repos = renv_vector_unique(biocrepos), .envir = .envir)
+
+}
+
+renv_scope_lock <- function(path = NULL,
+                            ...,
+                            project = NULL) {
+
+  if (!config$locking.enabled())
+    return(TRUE)
+
+  path <- path %||% renv_lock_path(project)
+  ensure_parent_directory(path)
+
+  callback <- renv_lock_create(path)
+  defer(callback(), envir = parent.frame())
+
+}
+
+renv_scope_trace <- function(what, tracer, ..., .envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  call <- sys.call()
+  call[[1L]] <- base::trace
+  call[["print"]] <- FALSE
+  eval(call, envir = parent.frame())
+
+  defer(untrace(substitute(what)), envir = .envir)
+
+}
+
+renv_scope_var <- function(key, value, envir, ..., .envir = NULL) {
+
+  .envir <- .envir %||% parent.frame()
+
+  if (exists(key, envir = envir, inherits = FALSE)) {
+    saved <- get(key, envir = envir, inherits = FALSE)
+    assign(key, value, envir = envir, inherits = FALSE)
+    defer(assign(key, saved, envir = envir, inherits = FALSE), envir = .envir)
+  } else {
+    assign(key, value, envir = envir, inherits = FALSE)
+    defer(rm(list = key, envir = envir, inherits = FALSE), envir = .envir)
+  }
+
+}
+
+renv_scope_tempfile <- function(pattern = "renv-tempfile-",
+                                tmpdir  = tempdir(),
+                                fileext = ".log",
+                                .envir  = NULL)
+{
+  filepath <- tempfile(pattern, tmpdir, fileext)
+
+  .envir <- .envir %||% parent.frame()
+  defer(unlink(filepath, recursive = TRUE, force = TRUE), envir = .envir)
+
+  invisible(filepath)
+}

--- a/R/renv-stack.R
+++ b/R/renv-stack.R
@@ -1,0 +1,49 @@
+
+stack <- function(mode = "list") {
+
+  .data <- list()
+  storage.mode(.data) <- mode
+
+  object <- list(
+
+    push = function(...) {
+      dots <- list(...)
+      for (data in dots) {
+        if (is.null(data))
+          .data[length(.data) + 1] <<- list(NULL)
+        else
+          .data[[length(.data) + 1]] <<- data
+      }
+    },
+
+    pop = function() {
+      item <- .data[[length(.data)]]
+      length(.data) <<- length(.data) - 1
+      item
+    },
+
+    peek = function() {
+      .data[[length(.data)]]
+    },
+
+    contains = function(data) {
+      data %in% .data
+    },
+
+    empty = function() {
+      length(.data) == 0
+    },
+
+    clear = function() {
+      .data <<- list()
+    },
+
+    data = function() {
+      .data
+    }
+
+  )
+
+  object
+
+}

--- a/R/renv-tests.R
+++ b/R/renv-tests.R
@@ -1,0 +1,525 @@
+
+renv_tests_scope <- function(packages = character(), project = NULL) {
+
+  renv_tests_init()
+
+  # ensure that attempts to restart are a no-op
+  options(restart = function(...) TRUE)
+
+  # save local repositories
+  Sys.setenv(RENV_PATHS_LOCAL = file.path(renv_tests_root(), "local"))
+
+  # move to own test directory
+  dir <- project %||% tempfile("renv-test-")
+  ensure_directory(dir)
+  dir <- renv_path_normalize(dir, winslash = "/")
+  owd <- setwd(dir)
+
+  # set as active project
+  Sys.setenv(RENV_PROJECT = dir)
+
+  # create empty renv directory
+  dir.create(file.path(dir, "renv"))
+
+  # create file with dependencies
+  code <- sprintf("library(%s)", packages)
+  writeLines(code, "dependencies.R")
+
+  # use temporary library
+  lib <- tempfile("renv-library-")
+  ensure_directory(lib)
+  libpaths <- .libPaths()
+  .libPaths(lib)
+
+  defer(envir = parent.frame(), {
+    setwd(owd)
+    unlink(lib, recursive = TRUE)
+    .libPaths(libpaths)
+  })
+
+  invisible(dir)
+
+}
+
+renv_tests_root <- function(path = getwd()) {
+  renv_global("tests.root", renv_tests_root_impl(path))
+}
+
+renv_tests_root_impl <- function(path = getwd()) {
+
+  # if we're working in an RStudio project, we can cheat
+  if (exists(".rs.getProjectDirectory")) {
+    projroot <- get(".rs.getProjectDirectory")
+    return(file.path(projroot(), "tests/testthat"))
+  }
+
+  # construct set of paths we'll hunt through
+  slashes <- gregexpr("(?:/|$)", path)[[1]]
+  parts <- substring(path, 1, slashes - 1)
+
+  # begin the search
+  for (part in rev(parts)) {
+
+    # required to find test directory during R CMD check
+    if (file.exists(file.path(part, "testthat.R")))
+      return(file.path(part, "testthat"))
+
+    # required for other general testing
+    anchor <- file.path(part, "DESCRIPTION")
+    if (file.exists(anchor))
+      return(file.path(part, "tests/testthat"))
+
+  }
+
+  stop("could not determine root directory for test files")
+
+}
+
+renv_tests_init_workarounds <- function() {
+
+  if (renv_platform_macos()) {
+
+    if (!nzchar(Sys.getenv("TZ")))
+      Sys.setenv(TZ = "America/Los_Angeles")
+
+  }
+
+}
+
+renv_tests_init_working_dir <- function() {
+  if (exists(".rs.getProjectDirectory")) {
+    home <- get(".rs.getProjectDirectory")
+    setwd(home())
+  }
+}
+
+renv_tests_init_options <- function() {
+  options(
+    renv.config.user.library = FALSE,
+    restart = NULL,
+    warn = 2
+  )
+}
+
+renv_tests_init_repos <- function(repopath = NULL) {
+
+  # find root directory
+  root <- renv_tests_root()
+
+  # generate our dummy repository
+  repopath <- repopath %||% tempfile("renv-repos-")
+  contrib <- file.path(repopath, "src/contrib")
+  ensure_directory(contrib)
+
+  # save current directory
+  owd <- getwd()
+  on.exit(setwd(owd), add = TRUE)
+
+  # copy package stuff to tempdir (because we'll mutate them a bit)
+  source <- file.path(root, "packages")
+  target <- tempfile("renv-packages-")
+  renv_file_copy(source, target)
+  setwd(target)
+
+  # helper function for 'uploading' a package to our test repo
+  upload <- function(path, root, subdir = FALSE) {
+
+    # create package tarball
+    desc <- renv_description_read(path)
+    package <- basename(path)
+    tarball <- sprintf("%s_%s.tar.gz", package, desc$Version)
+    tar(tarball, package, compression = "gzip")
+
+    # copy into repository tree
+    components <- c(root, if (subdir) package, tarball)
+    target <- paste(components, collapse = "/")
+    ensure_parent_directory(target)
+    renv_file_move(tarball, target)
+
+  }
+
+  # just in case?
+  renv_scope_options(renv.config.filebacked.cache = FALSE)
+
+  # copy in packages
+  paths <- list.files(getwd(), full.names = TRUE)
+  subdirs <- file.path(getRversion(), "Recommended")
+  for (path in paths) {
+
+    # upload the 'regular' package
+    upload(path, contrib, subdir = FALSE)
+
+    # upload a subdir (mocking what R does during upgrades)
+    upload(path, file.path(contrib, subdirs), subdir = FALSE)
+
+    # generate an 'old' version of the packages
+    descpath <- file.path(path, "DESCRIPTION")
+    desc <- renv_description_read(descpath)
+    desc$Version <- "0.0.1"
+    write.dcf(desc, file = descpath)
+
+    # place packages at top level (simulating packages with multiple
+    # versions at the top level of the repository)
+    upload(path, contrib, subdir = FALSE)
+
+    # generate an 'old' version of the packages
+    descpath <- file.path(path, "DESCRIPTION")
+    desc <- renv_description_read(descpath)
+    desc$Version <- "0.1.0"
+    write.dcf(desc, file = descpath)
+
+    # place these packages into the archive
+    upload(path, file.path(contrib, "Archive"), subdir = TRUE)
+
+  }
+
+  # update PACKAGES metadata
+  tools::write_PACKAGES(
+    dir = contrib,
+    subdirs = subdirs,
+    type = "source",
+    latestOnly = FALSE
+  )
+
+  # update our repos option
+  fmt <- if (renv_platform_windows()) "file:///%s" else "file://%s"
+  repos <- c(CRAN = sprintf(fmt, repopath))
+
+  options(
+    pkgType             = "source",
+    repos               = repos,
+    renv.tests.repos    = repos,
+    renv.tests.repopath = repopath
+  )
+
+}
+
+renv_tests_init_packages <- function() {
+
+  # don't treat warnings as errors in this scope
+  renv_scope_options(warn = 1)
+
+  # find packages to load
+  packages <- renv_tests_init_packages_find()
+
+  # load those packages
+  envir <- new.env(parent = emptyenv())
+  renv_tests_init_packages_load(packages, envir)
+
+}
+
+renv_tests_init_packages_find <- function() {
+  fields <- c("Depends", "Imports", "Suggests", "LinkingTo")
+  descpath <- system.file("DESCRIPTION", package = "renv")
+  deps <- renv_dependencies_discover_description(descpath, fields = fields)
+  deps[["Package"]]
+}
+
+renv_tests_init_packages_load <- function(packages, envir) {
+  for (package in packages) {
+    tryCatch(
+      renv_tests_init_packages_load_impl(package, envir),
+      error = warning
+    )
+  }
+}
+
+renv_tests_init_packages_load_impl <- function(package, envir) {
+
+  # skip the 'R' package
+  if (identical(package, "R"))
+    return()
+
+  # if we've already tried to load this package, skip it
+  if (visited(package, envir = envir))
+    return()
+
+  # try to load the package
+  if (!package %in% loadedNamespaces())
+    loadNamespace(package)
+
+  # try to find this package
+  pkgpath <- renv_package_find(package)
+  if (!file.exists(pkgpath))
+    return()
+
+  # try to read the package DESCRIPTION and load its dependencies
+  descpath <- file.path(pkgpath, "DESCRIPTION")
+  deps <- renv_dependencies_discover_description(
+    path   = descpath,
+    fields = c("Depends", "Imports", "LinkingTo")
+  )
+
+  map(
+    deps$Package,
+    renv_tests_init_packages_load,
+    envir = envir
+  )
+
+}
+
+renv_tests_init_sandbox <- function() {
+
+  # eagerly load packages that we'll need during tests
+  # (as the sandbox will otherwise 'hide' these packages)
+  testthat <- find.package("testthat")
+  descpath <- file.path(testthat, "DESCRIPTION")
+  deps <- renv_dependencies_discover_description(descpath)
+  for (package in deps$Package)
+    requireNamespace(package, quietly = TRUE)
+
+  # set up a dummy library path
+  dummy <- tempfile("renv-library-")
+  dir.create(dummy)
+  .libPaths(dummy)
+
+  # now sandbox the libpaths
+  renv_sandbox_activate()
+
+}
+
+renv_tests_init_finish <- function() {
+
+  # don't perform transactional installs by default for now
+  # (causes strange CI failures, especially on Windows?)
+  options(renv.config.install.transactional = FALSE)
+
+  # mark tests as running
+  options(renv.tests.running = TRUE)
+
+}
+
+renv_tests_init <- function() {
+
+  if (renv_tests_running())
+    return()
+
+  Sys.unsetenv("RENV_PROFILE")
+  Sys.unsetenv("RENV_PATHS_ROOT")
+  Sys.unsetenv("RENV_PATHS_LIBRARY")
+  Sys.unsetenv("RENV_PATHS_LIBRARY_ROOT")
+  Sys.unsetenv("RENV_CONFIG_CACHE_ENABLED")
+
+  Sys.unsetenv("RENV_PYTHON")
+  Sys.unsetenv("RETICULATE_PYTHON")
+  Sys.unsetenv("RETICULATE_PYTHON_ENV")
+  Sys.unsetenv("RETICULATE_PYTHON_FALLBACK")
+
+  renv_tests_init_workarounds()
+  renv_tests_init_working_dir()
+  renv_tests_init_options()
+  renv_tests_init_repos()
+  renv_tests_init_packages()
+  renv_tests_init_sandbox()
+  renv_tests_init_finish()
+
+}
+
+renv_tests_running <- function() {
+  getOption("renv.tests.running", default = FALSE)
+}
+
+renv_tests_verbose <- function() {
+
+  # if we're not running tests, mark as true
+  running <- renv_tests_running()
+  if (!running)
+    return(TRUE)
+
+  # otherwise, respect option
+  # (we might set this to FALSE to silence output from expected errors)
+  getOption("renv.tests.verbose", default = TRUE)
+
+}
+
+renv_test_code <- function(code, fileext = ".R") {
+
+  file <- tempfile("renv-code-", fileext = fileext)
+  writeLines(deparse(substitute(code)), con = file)
+  file
+
+}
+
+renv_test_retrieve <- function(record) {
+
+  renv_scope_error_handler()
+
+  # avoid using cache
+  renv_scope_envvars(RENV_PATHS_CACHE = tempfile())
+
+  # construct records
+  package <- record$Package
+  records <- list(record)
+  names(records) <- package
+
+  # prepare dummy library
+  templib <- renv_scope_tempfile("renv-library-")
+  ensure_directory(templib)
+  renv_scope_libpaths(c(templib, .libPaths()))
+
+  # attempt a restore into that library
+  renv_scope_restore(
+    project = getwd(),
+    library = templib,
+    records = records,
+    packages = package,
+    recursive = FALSE
+  )
+
+  records <- retrieve(record$Package)
+  renv_install_impl(records)
+
+  descpath <- file.path(templib, package)
+  if (!file.exists(descpath))
+    stopf("failed to retrieve package '%s'", package)
+
+  desc <- renv_description_read(descpath)
+  fields <- grep("^Remote", names(record), value = TRUE)
+
+  testthat::expect_identical(
+    as.list(desc[fields]),
+    as.list(record[fields])
+  )
+
+}
+
+renv_tests_diagnostics <- function() {
+
+  # print library paths
+  renv_pretty_print(
+    paste("-", .libPaths()),
+    "The following R libraries are set:",
+    wrap = FALSE
+  )
+
+  # print repositories
+  repos <- getOption("repos")
+  renv_pretty_print(
+    paste(names(repos), repos, sep = ": "),
+    "The following repositories are set:",
+    wrap = FALSE
+  )
+
+  # print renv root
+  renv_pretty_print(
+    paste("-", paths$root()),
+    "The following renv root directory is being used:",
+    wrap = FALSE
+  )
+
+  # print cache root
+  renv_pretty_print(
+    paste("-", paths$cache()),
+    "The following renv cache directory is being used:",
+    wrap = FALSE
+  )
+
+  writeLines("The following packages are available in the test repositories:")
+
+  dbs <-
+    renv_available_packages(type = "source", quiet = TRUE) %>%
+    map(function(db) {
+      rownames(db) <- NULL
+      db[c("Package", "Version", "Path")]
+    })
+
+  print(dbs)
+
+  path <- Sys.getenv("PATH")
+  splat <- strsplit(path, .Platform$path.sep, fixed = TRUE)[[1]]
+
+  renv_pretty_print(
+    paste("-", splat),
+    "The following PATH is set:",
+    wrap = FALSE
+  )
+
+  envvars <- c(
+    grep("^_R_", names(Sys.getenv()), value = TRUE),
+    "HOME",
+    "R_ARCH", "R_HOME",
+    "R_LIBS", "R_LIBS_SITE", "R_LIBS_USER", "R_USER",
+    "R_ZIPCMD",
+    "TAR", "TEMP", "TMP", "TMPDIR"
+  )
+
+  keys <- format(envvars)
+  vals <- Sys.getenv(envvars, unset = "<NA>")
+  vals[vals != "<NA>"] <- renv_json_quote(vals[vals != "<NA>"])
+
+  renv_pretty_print(
+    paste(keys, vals, sep = " : "),
+    "The following environment variables of interest are set:",
+    wrap = FALSE
+  )
+
+}
+
+renv_tests_report <- function(test, elapsed, expectations) {
+
+  # figure out overall test result
+  status <- "PASS"
+  for (expectation in expectations) {
+
+    errors <- c("expectation_error", "expectation_failure")
+    if (inherits(expectation, errors)) {
+      status <- "FAIL"
+      break
+    }
+
+    if (inherits(expectation, "expectation_skip")) {
+      status <- "SKIP"
+      break
+    }
+
+  }
+
+  # get console width
+  width <- max(getOption("width"), 78L)
+
+  # write out text with line
+  left <- trunc(test, width - 23L)
+
+  # figure out how long tests took to run
+  time <- if (elapsed < 0.1)
+    "<0.1s"
+  else
+    format(renv_difftime_format_short(elapsed), width = 5L, justify = "right")
+
+  # write formatted
+  fmt <- "[%s / %s]"
+  right <- sprintf(fmt, status, time)
+
+  # fill space between with dots
+  dots <- rep.int(".", max(0L, width - nchar(left) - nchar(right) - 4L))
+  all <- paste(left, paste(dots, collapse = ""), right)
+
+  # write it out
+  cli::cat_bullet(all)
+
+}
+
+renv_tests_path <- function(path) {
+  root <- renv_tests_root()
+  file.path(root, path)
+}
+
+renv_tests_supported <- function() {
+
+  # supported when running locally + on CI
+  for (envvar in c("NOT_CRAN", "CI"))
+    if (!is.na(Sys.getenv(envvar, unset = NA)))
+      return(TRUE)
+
+  # disabled on older macOS releases (credentials fails to load)
+  if (renv_platform_macos() && getRversion() < "4.0.0")
+    return(FALSE)
+
+  # disabled on Windows
+  if (renv_platform_windows())
+    return(FALSE)
+
+  # true otherwise
+  TRUE
+
+}

--- a/R/renv-truthy.R
+++ b/R/renv-truthy.R
@@ -1,0 +1,30 @@
+
+renv_truthy_impl <- function(value, values, default) {
+
+  if (is.call(value)) {
+    value <- catch(renv_dependencies_eval(value))
+    if (inherits(value, "error"))
+      return(default)
+  }
+
+  case(
+    is.null(value)      ~ default,
+    is.symbol(value)    ~ as.character(value) %in% values,
+    is.na(value)        ~ default,
+    is.logical(value)   ~ value,
+    is.character(value) ~ value %in% values,
+    is.numeric(value)   ~ value != 0,
+    ~ tryCatch(as.logical(value), error = function(e) default)
+  )
+
+}
+
+truthy <- function(value, default) {
+  values <- c("TRUE", "True", "true", "T", "1")
+  renv_truthy_impl(value, values, default)
+}
+
+falsy <- function(value, default) {
+  values <- c("FALSE", "False", "false", "F", "0")
+  renv_truthy_impl(value, values, default)
+}

--- a/R/renv-utils-format.R
+++ b/R/renv-utils-format.R
@@ -1,0 +1,72 @@
+
+sprintf <- function(fmt, ...) {
+
+  dots <- eval(substitute(alist(...)))
+  if (length(dots) == 0)
+    return(fmt)
+
+  base::sprintf(fmt, ...)
+
+}
+
+stopf <- function(fmt = "", ..., call. = FALSE) {
+  stop(sprintf(fmt, ...), call. = call.)
+}
+
+warningf <- function(fmt = "", ..., call. = FALSE, immediate. = FALSE) {
+  warning(sprintf(fmt, ...), call. = call., immediate. = immediate.)
+}
+
+messagef <- function(fmt = "", ..., appendLF = TRUE) {
+  message(sprintf(fmt, ...), appendLF = appendLF)
+}
+
+vmessagef <- function(fmt = "", ..., appendLF = TRUE) {
+  if (renv_verbose())
+    message(sprintf(fmt, ...), appendLF = appendLF)
+}
+
+
+
+printf <- function(fmt = "", ..., file = stdout()) {
+  if (!is.null(fmt) && renv_tests_verbose())
+    cat(sprintf(fmt, ...), file = file, sep = "")
+}
+
+eprintf <- function(fmt = "", ..., file = stderr()) {
+  if (!is.null(fmt) && renv_tests_verbose())
+    cat(sprintf(fmt, ...), file = file, sep = "")
+}
+
+vprintf <- function(fmt = "", ..., file = stdout()) {
+  if (!is.null(fmt) && renv_verbose())
+    cat(sprintf(fmt, ...), file = file, sep = "")
+}
+
+veprintf <- function(fmt = "", ..., file = stderr()) {
+  if (!is.null(fmt) && renv_verbose())
+    cat(sprintf(fmt, ...), file = file, sep = "")
+}
+
+
+
+writef <- function(fmt = "", ..., con = stdout()) {
+  if (!is.null(fmt) && renv_tests_verbose())
+    writeLines(sprintf(fmt, ...), con = con)
+}
+
+ewritef <- function(fmt = "", ..., con = stderr()) {
+  if (!is.null(fmt) && renv_tests_verbose())
+    writeLines(sprintf(fmt, ...), con = con)
+}
+
+vwritef <- function(fmt = "", ..., con = stdout()) {
+  if (!is.null(fmt) && renv_verbose())
+    writeLines(sprintf(fmt, ...), con = con)
+}
+
+vewritef <- function(fmt = "", ..., con = stderr()) {
+  if (!is.null(fmt) && renv_verbose())
+    writeLines(sprintf(fmt, ...), con = con)
+}
+

--- a/R/renv-utils-map.R
+++ b/R/renv-utils-map.R
@@ -1,0 +1,122 @@
+
+bapply <- function(x, f, ..., index = "Index") {
+  result <- lapply(x, f, ...)
+  bind_list(result, index = index)
+}
+
+enumerate <- function(x, f, ..., FUN.VALUE = NULL) {
+
+  n <- names(x)
+  idx <- named(seq_along(x), n)
+  callback <- function(i) f(n[[i]], x[[i]], ...)
+
+  if (is.null(FUN.VALUE))
+    lapply(idx, callback)
+  else
+    vapply(idx, callback, FUN.VALUE = FUN.VALUE)
+
+}
+
+enum_chr <- function(x, f, ...) {
+  enumerate(x, f, ..., FUN.VALUE = "character")
+}
+
+enum_int <- function(x, f, ...) {
+  enumerate(x, f, ..., FUN.VALUE = "integer")
+}
+
+enum_dbl <- function(x, f, ...) {
+  enumerate(x, f, ..., FUN.VALUE = "double")
+}
+
+enum_lgl <- function(x, f, ...) {
+  enumerate(x, f, ..., FUN.VALUE = "logical")
+}
+
+recurse <- function(object, callback, ...) {
+  recurse_impl(list(), object, callback, ...)
+}
+
+recurse_impl <- function(stack, object, callback, ...) {
+
+  # ignore missing values
+  if (missing(object) || identical(object, quote(expr = )))
+    return()
+
+  # push node on to stack
+  stack[[length(stack) + 1]] <- object
+
+  # invoke callback
+
+  result <- callback(object, stack, ...)
+  if (is.call(result))
+    object <- result
+
+  # recurse
+  if (is.recursive(object))
+    for (i in seq_along(object))
+      recurse_impl(stack, object[[i]], callback, ...)
+
+}
+
+
+uapply <- function(x, f, ...) {
+  f <- match.fun(f)
+  unlist(lapply(x, f, ...), recursive = FALSE)
+}
+
+filter <- function(x, f, ...) {
+  f <- match.fun(f)
+  x[map_lgl(x, f, ...)]
+}
+
+reject <- function(x, f, ...) {
+  f <- match.fun(f)
+  x[!map_lgl(x, f, ...)]
+}
+
+map <- function(x, f, ...) {
+  f <- match.fun(f)
+  lapply(x, f, ...)
+}
+
+map_chr <- function(x, f, ...) {
+  f <- match.fun(f)
+  vapply(x, f, ..., FUN.VALUE = character(1))
+}
+
+map_dbl <- function(x, f, ...) {
+  f <- match.fun(f)
+  vapply(x, f, ..., FUN.VALUE = numeric(1))
+}
+
+map_int <- function(x, f, ...) {
+  f <- match.fun(f)
+  vapply(x, f, ..., FUN.VALUE = integer(1))
+}
+
+map_lgl <- function(x, f, ...) {
+  f <- match.fun(f)
+  vapply(x, f, ..., FUN.VALUE = logical(1))
+}
+
+
+extract <- function(x, ...) {
+  lapply(x, `[[`, ...)
+}
+
+extract_chr <- function(x, ...) {
+  vapply(x, `[[`, ..., FUN.VALUE = character(1))
+}
+
+extract_dbl <- function(x, ...) {
+  vapply(x, `[[`, ..., FUN.VALUE = numeric(1))
+}
+
+extract_int <- function(x, ...) {
+  vapply(x, `[[`, ..., FUN.VALUE = integer(1))
+}
+
+extract_lgl <- function(x, ...) {
+  vapply(x, `[[`, ..., FUN.VALUE = logical(1))
+}

--- a/R/renv-utils.R
+++ b/R/renv-utils.R
@@ -1,0 +1,412 @@
+
+`%>%` <- function(...) {
+
+  dots <- eval(substitute(alist(...)))
+  if (length(dots) != 2L)
+    stopf("`%>%` called with invalid number of arguments")
+
+  lhs <- dots[[1L]]; rhs <- dots[[2L]]
+  if (!is.call(rhs))
+    stopf("right-hand side of rhs is not a call")
+
+  data <- c(rhs[[1L]], lhs, as.list(rhs[-1L]))
+  call <- as.call(data)
+
+  nm <- names(rhs)
+  if (length(nm))
+    names(call) <- c("", "", nm[-1L])
+
+  eval(call, envir = parent.frame())
+
+}
+
+`%||%` <- function(x, y) {
+  if (length(x) || is.environment(x)) x else y
+}
+
+`%""%` <- function(x, y) {
+  if (length(x) && nzchar(x)) x else y
+}
+
+`%NA%` <- function(x, y) {
+  if (length(x) && is.na(x)) y else x
+}
+
+`%NULL%` <- function(x, y) {
+  if (is.null(x)) y else x
+}
+
+`%&&%` <- function(x, y) {
+  if (length(x)) y
+}
+
+
+lines <- function(...) {
+  paste(..., sep = "\n")
+}
+
+is_named <- function(x) {
+  nm <- names(x)
+  !is.null(nm) && all(nzchar(nm))
+}
+
+named <- function(object, names = object) {
+  names(object) <- names
+  object
+}
+
+empty <- function(x) {
+  length(x) == 0
+}
+
+aliased_path <- function(path) {
+
+  home <-
+    Sys.getenv("HOME") %""%
+    Sys.getenv("R_USER")
+
+  if (!nzchar(home))
+    return(path)
+
+  home <- gsub("\\", "/", home, fixed = TRUE)
+  path <- gsub("\\", "/", path, fixed = TRUE)
+
+  match <- regexpr(home, path, fixed = TRUE, useBytes = TRUE)
+  path[match == 1] <- file.path("~", substring(path[match == 1], nchar(home) + 2L))
+
+  path
+
+}
+
+trimws <- function(x) {
+  gsub("^\\s+|\\s+$", "", x)
+}
+
+bind_list <- function(data, names = NULL, index = "Index") {
+
+  # keep only non-empty data
+  filtered <- Filter(NROW, data)
+  if (!length(filtered))
+    return(NULL)
+
+  # ensure all datasets have the same column names
+  # try to preserve the ordering of names if possible
+  # (try to find one dataset which has all column relevant column names)
+  nms <- character()
+  for (i in seq_along(filtered)) {
+    nmsi <- names(filtered[[i]])
+    if (empty(setdiff(nms, nmsi)))
+      nms <- nmsi
+  }
+
+  # check now if we've caught all relevant names; if we didn't,
+  # just fall back to a "dumb" union
+  allnms <- unique(unlist(lapply(filtered, names)))
+  if (!setequal(nms, allnms))
+    nms <- allnms
+
+  # we've collected all names; now fill with NAs as necessary
+  filled <- map(filtered, function(datum) {
+    datum[setdiff(nms, names(datum))] <- NA
+    datum[nms]
+  })
+
+  # we've collected and ordered each data.frame, now merge them
+  rhs <- .mapply(c, filled, list(use.names = FALSE))
+  names(rhs) <- names(filled[[1]])
+
+  if (is.null(names(data))) {
+    names(rhs) <- names(rhs) %||% names
+    return(as.data.frame(rhs, stringsAsFactors = FALSE))
+  }
+
+  if (index %in% names(rhs)) {
+    fmt <- "name collision: bound list already contains column called '%s'"
+    stopf(fmt, index)
+  }
+
+  lhs <- list()
+  rows <- function(item) nrow(item) %||% length(item[[1]])
+  lhs[[index]] <- rep.int(names(filled), times = map_dbl(filled, rows))
+
+  cbind(
+    as.data.frame(lhs, stringsAsFactors = FALSE),
+    as.data.frame(rhs, stringsAsFactors = FALSE)
+  )
+
+}
+
+case <- function(...) {
+
+  dots <- list(...)
+  for (dot in dots) {
+
+    if (!inherits(dot, "formula"))
+      return(dot)
+
+    else if (length(dot) == 2) {
+      expr <- dot[[2]]
+      return(eval(expr, envir = environment(dot)))
+    }
+
+    else {
+
+      cond <- dot[[2]]
+      expr <- dot[[3]]
+      if (eval(cond, envir = environment(dot)))
+        return(eval(expr, envir = environment(dot)))
+
+    }
+  }
+
+  NULL
+
+}
+
+catch <- function(expr) {
+  tryCatch(
+    withCallingHandlers(expr, error = renv_error_capture),
+    error = renv_error_tag
+  )
+}
+
+catchall <- function(expr) {
+  tryCatch(
+    withCallingHandlers(expr, condition = renv_error_capture),
+    condition = renv_error_tag
+  )
+}
+
+# nocov start
+
+ask <- function(question, default = FALSE) {
+
+  if (renv_tests_running())
+    return(TRUE)
+
+  if (!interactive())
+    return(default)
+
+  initializing <- Sys.getenv("RENV_R_INITIALIZING", unset = NA)
+  if (identical(initializing, "true"))
+    return(default)
+
+  selection <- if (default) "[Y/n]" else "[y/N]"
+  prompt <- sprintf("%s %s: ", question, selection)
+  response <- tolower(trimws(readline(prompt)))
+  if (!nzchar(response))
+    return(default)
+
+  substring(response, 1L, 1L) == "y"
+
+}
+
+proceed <- function(default = FALSE) {
+  ask("Do you want to proceed?", default = default)
+}
+
+# nocov end
+
+inject <- function(contents,
+                   pattern,
+                   replacement,
+                   anchor = NULL)
+{
+  # first, check to see if the pattern matches a line
+  index <- grep(pattern, contents)
+  if (length(index)) {
+    contents[index] <- replacement
+    return(contents)
+  }
+
+  # otherwise, check for the anchor, and insert after
+  index <- if (!is.null(anchor)) grep(anchor, contents)
+  if (length(index)) {
+    contents <- c(
+      head(contents, n = index),
+      replacement,
+      tail(contents, n = -index)
+    )
+    return(contents)
+  }
+
+  # otherwise, just append the new line
+  c(contents, replacement)
+}
+
+env <- function(...) {
+  list2env(list(...), envir = new.env(parent = emptyenv()))
+}
+
+deparsed <- function(value, width = 60L) {
+  paste(deparse(value, width.cutoff = width), collapse = "\n")
+}
+
+read <- function(file) {
+  contents <- readLines(file, warn = FALSE)
+  paste(contents, collapse = "\n")
+}
+
+plural <- function(word, n) {
+  if (n == 1) word else paste(word, "s", sep = "")
+}
+
+trunc <- function(text, n = 78) {
+  long <- nchar(text) > n
+  text[long] <- sprintf("%s <...>", substring(text[long], 1, n - 6))
+  text
+}
+
+startswith <- function(string, prefix) {
+  substring(string, 1, nchar(prefix)) == prefix
+}
+
+endswith <- function(string, suffix) {
+  substring(string, nchar(string) - nchar(suffix) + 1) == suffix
+}
+
+# like tools::file_ext, but includes leading '.', and preserves
+# '.tar.gz', '.tar.bz' and so on
+fileext <- function(path, default = "") {
+  indices <- regexpr("[.]((?:tar[.])?[[:alnum:]]+)$", path)
+  ifelse(indices > -1L, substring(path, indices), default)
+}
+
+git <- function() {
+
+  gitpath <- Sys.which("git")
+  if (!nzchar(gitpath))
+    stop("failed to find git executable on the PATH")
+
+  gitpath
+
+}
+
+visited <- function(name, envir) {
+
+  if (exists(name, envir = envir))
+    return(TRUE)
+
+  envir[[name]] <- TRUE
+  FALSE
+
+}
+
+rowapply <- function(X, FUN, ...) {
+  lapply(seq_len(NROW(X)), function(I) {
+    FUN(X[I, ], ...)
+  })
+}
+
+comspec <- function() {
+  Sys.getenv("COMSPEC", unset = Sys.which("cmd.exe"))
+}
+
+nullfile <- function() {
+  if (renv_platform_windows()) "NUL" else "/dev/null"
+}
+
+quietly <- function(expr, sink = TRUE) {
+
+  if (sink) {
+    sink(file = nullfile())
+    on.exit(sink(NULL), add = TRUE)
+  }
+
+  withCallingHandlers(
+    expr,
+    warning               = function(c) invokeRestart("muffleWarning"),
+    message               = function(c) invokeRestart("muffleMessage"),
+    packageStartupMessage = function(c) invokeRestart("muffleMessage")
+  )
+
+}
+
+convert <- function(x, type) {
+  storage.mode(x) <- type
+  x
+}
+
+remap <- function(x, map) {
+
+  # TODO: use match?
+  remapped <- x
+  enumerate(map, function(key, val) {
+    remapped[remapped == key] <<- val
+  })
+  remapped
+
+}
+
+header <- function(label,
+                   prefix = "#",
+                   suffix = "=",
+                   n = 38L)
+{
+  n <- n - nchar(label) - nchar(prefix) - 2L
+  if (n <= 0)
+    return(paste(prefix, label))
+
+  tail <- paste(rep.int(suffix, n), collapse = "")
+  paste(prefix, label, tail)
+
+}
+
+keep <- function(x, keys) {
+  x[intersect(keys, names(x))]
+}
+
+drop <- function(x, keys) {
+  x[setdiff(names(x), keys)]
+}
+
+invoke <- function(f, ...) {
+  f(...)
+}
+
+dequote <- function(strings) {
+
+  for (quote in c("'", '"')) {
+
+    # find strings matching pattern
+    pattern <- paste0(quote, "(.*)", quote)
+    matches <- grep(pattern, strings)
+    if (empty(matches))
+      next
+
+    # remove outer quotes
+    strings[matches] <- gsub(pattern, "\\1", strings[matches])
+
+    # un-escape inner quotes
+    pattern <- paste0("\\", quote)
+    strings[matches] <- gsub(pattern, quote, strings[matches], fixed = TRUE)
+  }
+
+  strings
+
+}
+
+memoize <- function(key, expr, envir) {
+  value <- envir[[key]] %||% expr
+  envir[[key]] <- value
+  value
+}
+
+nth <- function(x, i) {
+  x[[i]]
+}
+
+heredoc <- function(text) {
+
+  # remove leading, trailing whitespace
+  trimmed <- gsub("^\\s*\\n|\\n\\s*$", "", text)
+
+  # split into lines
+  lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]
+
+  # compute common indent
+  indent <- regexpr("[^[:space:]]", lines)
+  common <- min(setdiff(indent, -1L))
+  paste(substring(lines, common), collapse = "\n")
+
+}

--- a/R/renv-verbose.R
+++ b/R/renv-verbose.R
@@ -1,0 +1,14 @@
+
+renv_verbose <- function() {
+
+  verbose <- getOption("renv.verbose")
+  if (!is.null(verbose))
+    return(as.logical(verbose))
+
+  verbose <- Sys.getenv("RENV_VERBOSE", unset = NA)
+  if (!is.na(verbose))
+    return(as.logical(verbose))
+
+  interactive() || !renv_tests_running()
+
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,9 @@
 .onLoad <- function(libname, pkgname) {
 
+  renv_platform_init()
+  renv_methods_init()
+  renv_paths_init()
+
   mappings <- list(
     "R_PACKRAT_DEFAULT_LIBPATHS" = .libPaths(),
     "R_PACKRAT_SYSTEM_LIBRARY"   = .Library,
@@ -10,5 +14,4 @@
     if (is.na(Sys.getenv(key, unset = NA)))
       setenv(key, val)
   })
-
 }


### PR DESCRIPTION
Incomplete in its current form. This was enough to prove that we can use the renv dependency analysis and avoid the problems identified in https://github.com/rstudio/packrat/issues/644.

Files copied from renv commit https://github.com/rstudio/renv/commit/56bf09bd2ad3abf5b0d28ba6abc7f5a7b9a88f01 (0.14.0-10)