### PR TITLE
stop using devtools::github_pat, as it is no longer available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Stop using `devtools::github_pat` to obtain an (optional) `GITHUB_PAT`
   environment variable value. The `github_pat` function was removed in
-  devtools-2.4.3. (#651)
+  `devtools-2.4.3`. (#651)
 
 - Use authenticated downloaders for GitHub, GitLab, and Bitbucket when the
   `httr` package is installed and the appropriate credentials are available.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Packrat 0.8.0 (UNRELEASED)
 
+- Stop using `devtools::github_pat` to obtain an (optional) `GITHUB_PAT`
+  environment variable value. The `github_pat` function was removed in
+  devtools-2.4.3.
+
+- Use authenticated downloaders for GitHub, GitLab, and Bitbucket when the
+  `httr` package is installed and the appropriate credentials are available.
+
+- Provide more information about authenticated download failures.
+
 
 # Packrat 0.7.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Stop using `devtools::github_pat` to obtain an (optional) `GITHUB_PAT`
   environment variable value. The `github_pat` function was removed in
-  devtools-2.4.3.
+  devtools-2.4.3. (#651)
 
 - Use authenticated downloaders for GitHub, GitLab, and Bitbucket when the
   `httr` package is installed and the appropriate credentials are available.

--- a/R/bitbucket.R
+++ b/R/bitbucket.R
@@ -3,8 +3,8 @@ isBitbucketURL <- function(url) {
 }
 
 canUseBitbucketDownloader <- function() {
-  (all(packageVersionInstalled(httr = "1.0.0")) &
-     !is.null(bitbucket_user(quiet = TRUE)) &
+  (all(packageVersionInstalled(httr = "1.0.0")) &&
+     !is.null(bitbucket_user(quiet = TRUE)) &&
      !is.null(bitbucket_pwd(quiet = TRUE)))
 }
 
@@ -12,7 +12,7 @@ bitbucketDownload <- function(url, destfile, ...) {
   tryCatch(
     bitbucketDownloadImpl(url, destfile, ...),
     error = function(e) {
-      stop(sprintf("Bitbucket request failed with %s", e), call. = FALSE)
+      stop(sprintf("Bitbucket request failed: %s", e), call. = FALSE)
     })
 }
 
@@ -33,7 +33,7 @@ bitbucketDownloadImpl <- function(url, destfile, ...) {
   if (result$status != 200) {
     stop(
       sprintf(
-        "Unable to download package from Bitbucket; check the BITBICKET_USERNAME and BITBUCKET_PASSWORD environment variables: %s",
+        "Unable to download package from Bitbucket; check the BITBUCKET_USERNAME and BITBUCKET_PASSWORD environment variables: %s",
         httr::http_status(result)$message))
   }
   writeBin(content(result, "raw"), destfile)

--- a/R/downloader.R
+++ b/R/downloader.R
@@ -52,29 +52,6 @@ download <- function(url,
 }
 
 downloadImpl <- function(url, method, ...) {
-
-  # If this is a path to a GitHub URL, attempt to download with authentication,
-  # so that private GitHub repositories can be handled.
-  if (isGitHubURL(url) && canUseGitHubDownloader()) {
-    result <- try(githubDownload(url, ...), silent = TRUE)
-    if (!inherits(result, "try-error"))
-      return(result)
-  }
-
-  # If this is a path to a Bitbucket URL, attempt to download.
-  if (isBitbucketURL(url) && canUseBitbucketDownloader()) {
-    result <- try(bitbucketDownload(url, ...), silent = TRUE)
-    if (!inherits(result, "try-error"))
-      return(result)
-  }
-
-  # If this is a path to a Gitlab URL, attempt to download.
-  if (isGitlabURL(url) && canUseGitlabDownloader()) {
-    result <- try(gitlabDownload(url, ...), silent = TRUE)
-    if (!inherits(result, "try-error"))
-      return(result)
-  }
-
   # When on Windows using an 'internal' method, we need to call
   # 'setInternet2' to set some appropriate state.
   if (is.windows() && method == "internal") {

--- a/R/github.R
+++ b/R/github.R
@@ -3,23 +3,51 @@ isGitHubURL <- function(url) {
 }
 
 canUseGitHubDownloader <- function() {
-  all(packageVersionInstalled(devtools = "1.9.1", httr = "1.0.0"))
+  all(packageVersionInstalled(httr = "1.0.0")) & (!is.null(github_pat()))
+}
+
+github_pat <- function(quiet = TRUE) {
+  pat <- Sys.getenv("GITHUB_PAT")
+  if (nzchar(pat)) {
+    if (!quiet) {
+      message("Using GitHub username from envvar GITHUB_PAT")
+    }
+    return(pat)
+  }
+  return(NULL)
 }
 
 githubDownload <- function(url, destfile, ...) {
-  onError(1, {
-    github_pat      <- yoink("devtools", "github_pat")
-    authenticate    <- yoink("httr", "authenticate")
-    GET             <- yoink("httr", "GET")
-    content         <- yoink("httr", "content")
+  tryCatch(
+    githubDownloadImpl(url, destfile, ...),
+    error = function(e) {
+      stop(sprintf("GitHub request failed with %s", e), call. = FALSE)
+    })
+}
 
-    token <- github_pat(quiet = TRUE)
-    auth <- if (!is.null(token))
-      authenticate(token, "x-oauth-basic", "basic")
-    else
-      list()
-    request <- GET(url, auth)
-    writeBin(content(request, "raw"), destfile)
-    if (file.exists(destfile)) 0 else 1
-  })
+githubDownloadImpl <- function(url, destfile, ...) {
+  authenticate    <- yoink("httr", "authenticate")
+  GET             <- yoink("httr", "GET")
+  content         <- yoink("httr", "content")
+
+  token <- github_pat(quiet = TRUE)
+  auth <- if (!is.null(token)) {
+    authenticate(token, "x-oauth-basic", "basic")
+  } else {
+    list()
+  }
+
+  result <- GET(url, auth)
+  if (result$status != 200) {
+    stop(
+      sprintf(
+        "Unable to download package from GitHub; check the GITHUB_PAT environment variable: %s",
+        httr::http_status(result)$message), call. = FALSE)
+  }
+  writeBin(content(result, "raw"), destfile)
+  if (!file.exists(destfile)) {
+    stop("No data received.", call. = FALSE)
+  }
+  # Success!
+  return(TRUE)
 }

--- a/R/github.R
+++ b/R/github.R
@@ -3,14 +3,15 @@ isGitHubURL <- function(url) {
 }
 
 canUseGitHubDownloader <- function() {
-  all(packageVersionInstalled(httr = "1.0.0")) & (!is.null(github_pat()))
+  (all(packageVersionInstalled(httr = "1.0.0")) &&
+     !is.null(github_pat()))
 }
 
 github_pat <- function(quiet = TRUE) {
   pat <- Sys.getenv("GITHUB_PAT")
   if (nzchar(pat)) {
     if (!quiet) {
-      message("Using GitHub username from envvar GITHUB_PAT")
+      message("Using GitHub PAT from envvar GITHUB_PAT")
     }
     return(pat)
   }
@@ -21,7 +22,7 @@ githubDownload <- function(url, destfile, ...) {
   tryCatch(
     githubDownloadImpl(url, destfile, ...),
     error = function(e) {
-      stop(sprintf("GitHub request failed with %s", e), call. = FALSE)
+      stop(sprintf("GitHub request failed: %s", e), call. = FALSE)
     })
 }
 

--- a/R/gitlab.R
+++ b/R/gitlab.R
@@ -3,11 +3,17 @@ isGitlabURL <- function(url) {
 }
 
 canUseGitlabDownloader <- function() {
-  all(packageVersionInstalled(devtools = "1.9.1", httr = "1.0.0"))
+  (all(packageVersionInstalled(httr = "1.0.0")) &
+     !is.null(gitlab_user(quiet = TRUE)) &
+     !is.null(gitlab_pwd(quiet = TRUE)))
 }
 
 gitlabDownload <- function(url, destfile, ...) {
-  onError(1, gitlabDownloadImpl(url, destfile, ...))
+  tryCatch(
+    gitlabDownloadImpl(url, destfile, ...),
+    error = function(e) {
+      stop(sprintf("GitLab request failed with %s", e), call. = FALSE)
+    })
 }
 
 gitlabDownloadImpl <- function(url, destfile, ...) {
@@ -24,15 +30,18 @@ gitlabDownloadImpl <- function(url, destfile, ...) {
   }
 
   request <- GET(url, auth)
-  if (request$status == 401) {
-    warning("Failed to download package from GitLab: not authorized. ",
-            "Did you set GITLAB_USERNAME and GITLAB_PASSWORD env vars?",
-            call. = FALSE)
-    return(1)
+  if (result$status != 200) {
+    stop(
+      sprintf(
+        "Unable to download package from GitLab; check the GITLAB_USERNAME and GITLAB_PASSWORD environment variables: %s",
+        httr::http_status(result)$message), call. = FALSE)
   }
-
-  if (request$status == 200) writeBin(content(request, "raw"), destfile)
-  if (file.exists(destfile)) 0 else 1
+  writeBin(content(result, "raw"), destfile)
+  if (!file.exists(destfile)) {
+    stop("No data received.", call. = FALSE)
+  }
+  # Success!
+  return(TRUE)
 }
 
 #' Retrieve GitLab user.

--- a/R/gitlab.R
+++ b/R/gitlab.R
@@ -3,8 +3,8 @@ isGitlabURL <- function(url) {
 }
 
 canUseGitlabDownloader <- function() {
-  (all(packageVersionInstalled(httr = "1.0.0")) &
-     !is.null(gitlab_user(quiet = TRUE)) &
+  (all(packageVersionInstalled(httr = "1.0.0")) &&
+     !is.null(gitlab_user(quiet = TRUE)) &&
      !is.null(gitlab_pwd(quiet = TRUE)))
 }
 
@@ -12,7 +12,7 @@ gitlabDownload <- function(url, destfile, ...) {
   tryCatch(
     gitlabDownloadImpl(url, destfile, ...),
     error = function(e) {
-      stop(sprintf("GitLab request failed with %s", e), call. = FALSE)
+      stop(sprintf("GitLab request failed: %s", e), call. = FALSE)
     })
 }
 


### PR DESCRIPTION
We have started seeing errors when folks are using packrat to install private GitHub packages. This is rooted in the fact that `devtools` has removed the `github_pat` function in its 2.4.3 release.

* use authenticated downloaders when httr is installed and
  authentication is available.
* err in github/gitlab/bitbucket downloaders, which provides
  more information on failure to restore.
* remove github/gitlab/bitbucket download calls from downloadImpl,
  as all downloadWithRetries calls are prefaced by repo-specific
  download calls.
* err on all non-200 HTTP statuses for github/gitlab/bitbucket.
  previously, whatever content we downloaded would be used,
  which could be empty, or a JSON error document, or whatever.


R errors such as the lack of `devtools::github_pat` would now appear like:

```
Error in value[[3L]](cond) : Failed to download package from URL:
- 'https://api.github.com/repos/rstudio/academyapi/tarball/6e3b86420e053359774468b364fe7f73c53f3f1b'
- Reason: Error: GitHub request failed with Error in get(name, envir = asNamespace(pkg), inherits = FALSE): object 'github_pat' not found
```

HTTP errors would now appear like:

```
Error in value[[3L]](cond) : Failed to download package from URL:
- 'https://api.github.com/repos/rstudio/academyapi/tarball/6e3b86420e053359774468b364fe7f73c53f3f1b'
- Reason: Error: GitHub request failed with Error: Unable to download package from GitHub; check the GITHUB_PAT environment variable: Client error: (404) Not Found
```

Fixes #651