### PR TITLE
ignore packages when recursively enumerating dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
 - The `packrat::set_opts` function and `packrat::opts` single-option setter no
   longer overwrite previously written in-memory state. (#655)
 
+- The 'packrat::opts$ignored.packages()' project option ignores recursive
+  package dependencies in addition to direct package dependencies. (#654)
+
+
 # Packrat 0.7.0
 
 - Fixed an issue where Packrat could inadvertently execute non-R code chunks

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -53,6 +53,8 @@ appDependencies <- function(project = NULL,
     .packrat_mutables$origLibPaths
   )
 
+  ignores <- packrat::opts$ignored.packages()
+
   ## For R packages, we only use the DESCRIPTION file
   if (isRPackage(project)) {
 
@@ -61,20 +63,22 @@ appDependencies <- function(project = NULL,
       pkgDescriptionDependencies(file.path(project, "DESCRIPTION"))$Package
 
     # Strip out any dependencies the user has requested we do not track.
-    parentDeps <- setdiff(parentDeps, packrat::opts$ignored.packages())
+    parentDeps <- setdiff(parentDeps, ignores)
 
     ## For downstream dependencies, we don't grab their Suggests:
     ## Presumedly, we can build child dependencies without vignettes, and hence
     ## do not need suggests -- for the package itself, we should make sure
     ## we grab suggests, however
     childDeps <- recursivePackageDependencies(parentDeps,
+                                              ignores,
                                               libPaths,
                                               available.packages,
                                               fields)
   } else {
     parentDeps <- setdiff(unique(c(dirDependencies(project))), "packrat")
-    parentDeps <- setdiff(parentDeps, packrat::opts$ignored.packages())
+    parentDeps <- setdiff(parentDeps, ignores)
     childDeps <- recursivePackageDependencies(parentDeps,
+                                              ignores,
                                               libPaths,
                                               available.packages,
                                               fields)

--- a/R/library-support.R
+++ b/R/library-support.R
@@ -132,6 +132,7 @@ symlinkExternalPackages <- function(project = NULL) {
   lib.loc <- getDefaultLibPaths()
   pkgDeps <- recursivePackageDependencies(
     external.packages,
+    ignores = NULL,
     lib.loc = lib.loc,
     available.packages = NULL
   )

--- a/R/recursive-package-dependencies.R
+++ b/R/recursive-package-dependencies.R
@@ -127,15 +127,21 @@ dropSystemPackages <- function(packages) {
   packages
 }
 
-recursivePackageDependencies <- function(pkgs, lib.loc,
-                                         available.packages = availablePackages(),
-                                         fields = c("Depends", "Imports", "LinkingTo")) {
+recursivePackageDependencies <- function(
+    pkgs,
+    ignores,
+    lib.loc,
+    available.packages = availablePackages(),
+    fields = c("Depends", "Imports", "LinkingTo")) {
 
   if (!length(pkgs)) return(NULL)
+
   deps <- getPackageDependencies(pkgs, lib.loc, available.packages, fields)
+  deps <- setdiff(deps, ignores)
   depsToCheck <- setdiff(deps, pkgs)
   while (length(depsToCheck)) {
     newDeps <- getPackageDependencies(depsToCheck, lib.loc, available.packages, fields)
+    newDeps <- setdiff(newDeps, ignores)
     depsToCheck <- setdiff(newDeps, deps)
     deps <- sort_c(unique(c(deps, newDeps)))
   }

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -120,3 +120,38 @@ test_that("knitr doesn't warn about unknown engines in dependency discovery", {
   expect_equal(deps, "rmarkdown")
 
 })
+
+withTestContext({
+  test_that("project dependencies are detected", {
+    skip_on_cran()
+
+    packrat:::set_opts(local.repos = "packages", persist = FALSE)
+    on.exit(packrat:::set_opts(local.repos = NULL, persist = FALSE), add = TRUE)
+
+    projRoot <- cloneTestProject("sated")
+    deps <- packrat:::appDependencies(projRoot)
+    expect_equal(deps, c("bread", "breakfast", "oatmeal", "packrat", "toast"))
+  })
+
+  test_that("project dependencies can ignore top-level dependencies", {
+    skip_on_cran()
+
+    packrat:::set_opts(ignored.packages = c("bread"), local.repos = "packages", persist = FALSE)
+    on.exit(packrat:::set_opts(ignored.packages = NULL, local.repos = NULL, persist = FALSE), add = TRUE)
+
+    projRoot <- cloneTestProject("smallbreakfast")
+    deps <- packrat:::appDependencies(projRoot)
+    expect_equal(deps, c("oatmeal", "packrat")) # bread is ignored.
+  })
+
+  test_that("project dependencies can ignore lower-level dependencies", {
+    skip_on_cran()
+
+    packrat:::set_opts(ignored.packages = c("toast"), local.repos = "packages", persist = FALSE)
+    on.exit(packrat:::set_opts(ignored.packages = NULL, local.repos = NULL, persist = FALSE), add = TRUE)
+
+    projRoot <- cloneTestProject("sated")
+    deps <- packrat:::appDependencies(projRoot)
+    expect_equal(deps, c("breakfast", "oatmeal", "packrat")) # toast and bread are ignored
+  })
+})


### PR DESCRIPTION
previously, we ignored only direct dependencies

Given a Shiny application having:

```r
library(shiny)
library(emo) # hadley/emo

ui <- fluidPage("So much", emo::ji("dancing"))
server <- function(input, output) {}
shinyApp(ui = ui, server = server)
```

The default set of dependencies:

```
> packrat:::appDependencies(".")
 [1] "R6"          "Rcpp"        "assertthat"  "base64enc"   "bslib"       "cachem"      "commonmark" 
 [8] "crayon"      "digest"      "ellipsis"    "emo"         "fastmap"     "fontawesome" "fs"         
[15] "generics"    "glue"        "htmltools"   "httpuv"      "jquerylib"   "jsonlite"    "later"      
[22] "lifecycle"   "lubridate"   "magrittr"    "mime"        "packrat"     "promises"    "purrr"      
[29] "rappdirs"    "rlang"       "sass"        "shiny"       "sourcetools" "stringi"     "stringr"    
[36] "withr"       "xtable"     
```

Prior to this change, with "emo" and "Rcpp" as ignores, only the top-level "emo" is ignored:

```
> packrat::set_opts(ignored.packages = c("emo","Rcpp"), persist = FALSE)
> packrat:::appDependencies(".")
 [1] "R6"          "Rcpp"        "base64enc"   "bslib"       "cachem"      "commonmark"  "crayon"     
 [8] "digest"      "ellipsis"    "fastmap"     "fontawesome" "fs"          "glue"        "htmltools"  
[15] "httpuv"      "jquerylib"   "jsonlite"    "later"       "lifecycle"   "magrittr"    "mime"       
[22] "packrat"     "promises"    "rappdirs"    "rlang"       "sass"        "shiny"       "sourcetools"
[29] "withr"       "xtable"     
```

After this change, both "emo" and "Rcpp" are ignored:

```
> packrat::set_opts(ignored.packages = c("emo","Rcpp"), persist = FALSE)
> packrat:::appDependencies(".")
 [1] "R6"          "base64enc"   "bslib"       "cachem"      "commonmark"  "crayon"      "digest"     
 [8] "ellipsis"    "fastmap"     "fontawesome" "fs"          "glue"        "htmltools"   "httpuv"     
[15] "jquerylib"   "jsonlite"    "later"       "lifecycle"   "magrittr"    "mime"        "packrat"    
[22] "promises"    "rappdirs"    "rlang"       "sass"        "shiny"       "sourcetools" "withr"      
[29] "xtable"     
```

If we were to choose a dependency with substantial dependencies, we'll see those dependencies disappear, as well; notice that "stringi" is not included as a result of ignoring "stringr"; neither of these are direct project dependencies:

```
> packrat::set_opts(ignored.packages = c("stringr"), persist = FALSE)
> packrat:::appDependencies(".")
 [1] "R6"          "Rcpp"        "assertthat"  "base64enc"   "bslib"       "cachem"      "commonmark" 
 [8] "crayon"      "digest"      "ellipsis"    "emo"         "fastmap"     "fontawesome" "fs"         
[15] "generics"    "glue"        "htmltools"   "httpuv"      "jquerylib"   "jsonlite"    "later"      
[22] "lifecycle"   "lubridate"   "magrittr"    "mime"        "packrat"     "promises"    "purrr"      
[29] "rappdirs"    "rlang"       "sass"        "shiny"       "sourcetools" "withr"       "xtable"     
```