### PR TITLE
Adds RemoteSubdir for gitlab.

### DIFF
--- a/R/pkg.R
+++ b/R/pkg.R
@@ -369,7 +369,8 @@ inferPackageRecord <- function(df, available = availablePackages()) {
       remote_username = as.character(df$RemoteUsername),
       remote_ref = as.character(df$RemoteRef),
       remote_sha = as.character(df$RemoteSha)),
-      c(remote_host = as.character(df$RemoteHost))
+      c(remote_host = as.character(df$RemoteHost)),
+      c(remote_subdir = as.character(df$RemoteSubdir))
     ), class = c('packageRecord', 'gitlab')))
   } else if (identical(as.character(df$Priority), 'base')) {
     # It's a base package!


### PR DESCRIPTION
Gitlab is missing getting RemoteSubdir.

RStudio Connect is throwing error during deployment.

```
Error in (function() {: No DESCRIPTION file was found in the archive for packageName
```
