### PR TITLE
Fix Bitbucket and GitLab download calls in `getSourceForPkgRecord()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Packrat 0.9.0 (UNRELEASED)
 
+- Fixed a bug preventing successful downloads of private GitLab and Bitbucket
+  archives during restore. (#671)
 
 # Packrat 0.8.0
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -364,19 +364,19 @@ getSourceForPkgRecord <- function(pkgRecord,
         unlink(srczip, recursive = TRUE)
     }, add = TRUE)
 
-    if (canUseBitbucketDownloader()) {
-      success <- bitbucketDownload(archiveUrl, srczip)
-      if (!success) {
-        message("FAILED")
-        stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
+    tryCatch({
+      success <- if (canUseBitbucketDownloader()) {
+        bitbucketDownload(archiveUrl, srczip)
+      } else {
+        downloadWithRetries(archiveUrl, destfile = srczip, quiet = TRUE, mode = "wb")
       }
-    } else {
-      success <- downloadWithRetries(archiveUrl, destfile = srczip, quiet = TRUE, mode = "wb")
       if (!success) {
-        message("FAILED")
-        stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
+        stop("Download failure.")
       }
-    }
+    }, error = function(e) {
+      message("FAILED")
+      stop(sprintf("Failed to download package from URL:\n- '%s'\n- Reason: %s", archiveUrl, e))
+    })
 
 
 
@@ -456,19 +456,19 @@ getSourceForPkgRecord <- function(pkgRecord,
         unlink(srczip, recursive = TRUE)
     }, add = TRUE)
 
-    if (canUseGitlabDownloader()) {
-      success <- gitlabDownload(archiveUrl, srczip)
-      if (!success) {
-        message("FAILED")
-        stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
+    tryCatch({
+      success <- if (canUseGitlabDownloader()) {
+        gitlabDownload(archiveUrl, srczip)
+      } else {
+        downloadWithRetries(archiveUrl, destfile = srczip, quiet = TRUE, mode = "wb")
       }
-    } else {
-      success <- downloadWithRetries(archiveUrl, destfile = srczip, quiet = TRUE, mode = "wb")
       if (!success) {
-        message("FAILED")
-        stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
+        stop("Download failure.")
       }
-    }
+    }, error = function(e) {
+      message("FAILED")
+      stop(sprintf("Failed to download package from URL:\n- '%s'\n- Reason: %s", archiveUrl, e))
+    })
 
     local({
       scratchDir <- tempfile()

--- a/R/restore.R
+++ b/R/restore.R
@@ -365,8 +365,8 @@ getSourceForPkgRecord <- function(pkgRecord,
     }, add = TRUE)
 
     if (canUseBitbucketDownloader()) {
-      status <- bitbucketDownload(archiveUrl, srczip)
-      if (status) {
+      success <- bitbucketDownload(archiveUrl, srczip)
+      if (!success) {
         message("FAILED")
         stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
       }
@@ -457,8 +457,8 @@ getSourceForPkgRecord <- function(pkgRecord,
     }, add = TRUE)
 
     if (canUseGitlabDownloader()) {
-      status <- gitlabDownload(archiveUrl, srczip)
-      if (status) {
+      success <- gitlabDownload(archiveUrl, srczip)
+      if (!success) {
         message("FAILED")
         stop("Failed to download package from URL:\n- ", shQuote(archiveUrl))
       }

--- a/packrat.Rproj
+++ b/packrat.Rproj
@@ -17,7 +17,6 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source --install-tests
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace,vignette


### PR DESCRIPTION
## Intent

Fix archive downloads for Bitbucket and GitLab source archives when they're called in `getSourceForPkgRecord()`.

Fixes #671

## Approach

At first, I just flipped the polarity of the conditional evaluating the `bitbucketDownload()` and `gitlabDownload()` functions' output. But then I saw that the GitHub download workflow had been updated, so I modified Bitbucket and GitLab's download flow to follow GitHub's.

## QA Notes

Still thinking about this.

## Checklist

- [x] Added NEWS entry