### PR TITLE
Use internal tar in untar only when TAR is not set

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -177,7 +177,7 @@ unbundle <- function(bundle, where, ..., restore = TRUE) {
 
   whereFiles <- list.files()
   message("- Untarring '", basename(bundle), "' in directory '", where, "'...")
-  untar(bundle, exdir = where, tar = "internal", ...)
+  untar(bundle, exdir = where, tar = Sys.getenv("TAR", "internal"), ...)
   dirName <- normalizePath(setdiff(list.files(), whereFiles), winslash = "/", mustWork = TRUE)
 
   if (restore) {

--- a/R/cranlike-repositories.R
+++ b/R/cranlike-repositories.R
@@ -177,7 +177,7 @@ uploadPackageTarball <- function(package, repoName, repoPath, ...) {
 
   # Annotate the package DESCRIPTION with the repository
   tmpTarballPath <- file.path(tempdir(), "packrat-tarball-upload")
-  untar(package, exdir = tmpTarballPath, tar = "internal")
+  untar(package, exdir = tmpTarballPath, tar = Sys.getenv("TAR", "internal"))
   pkgName <- sub("_.*", "", basename(package))
   untarredPath <- file.path(tmpTarballPath, pkgName)
   setRepositoryField(

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -456,7 +456,7 @@ getSourcePackageInfoImpl <- function(path) {
   ## For tarballs, we unzip them to a temporary directory and then read from there
   tempdir <- file.path(tempdir(), "packrat", path)
   if (endswith(path, "tar.gz")) {
-    untar(path, exdir = tempdir, tar = "internal")
+    untar(path, exdir = tempdir, tar = Sys.getenv("TAR", "internal"))
     folderName <- list.files(tempdir, full.names = TRUE)[[1]]
   } else {
     folderName <- path

--- a/R/restore.R
+++ b/R/restore.R
@@ -135,7 +135,7 @@ getSourceForPkgRecord <- function(pkgRecord,
         setwd(file.path(pkgRecord$source_path, ".."))
 
         tar(file.path(pkgSrcDir, pkgSrcFile), files = pkgRecord$name,
-            compression = "gzip", tar = "internal")
+            compression = "gzip", tar = Sys.getenv("TAR", "internal"))
       }
     })
     type <- "local"
@@ -290,7 +290,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       })
       # untar can emit noisy warnings (e.g. "skipping pax global extended
       # headers"); hide those
-      suppressWarnings(untar(srczip, exdir = scratchDir, tar = "internal"))
+      suppressWarnings(untar(srczip, exdir = scratchDir, tar = Sys.getenv("TAR", "internal")))
       # Find the base directory
       basedir <- if (length(dir(scratchDir)) == 1)
         file.path(scratchDir, dir(scratchDir))
@@ -388,7 +388,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       })
       # untar can emit noisy warnings (e.g. "skipping pax global extended
       # headers"); hide those
-      suppressWarnings(untar(srczip, exdir = scratchDir, tar = "internal"))
+      suppressWarnings(untar(srczip, exdir = scratchDir, tar = Sys.getenv("TAR", "internal")))
       # Find the base directory
       basedir <- if (length(dir(scratchDir)) == 1)
         file.path(scratchDir, dir(scratchDir))
@@ -478,7 +478,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       })
       # untar can emit noisy warnings (e.g. "skipping pax global extended
       # headers"); hide those
-      suppressWarnings(untar(srczip, exdir = scratchDir, tar = "internal"))
+      suppressWarnings(untar(srczip, exdir = scratchDir, tar = Sys.getenv("TAR", "internal")))
       # Find the base directory
       basedir <- if (length(dir(scratchDir)) == 1)
         file.path(scratchDir, dir(scratchDir))

--- a/R/testthat-helpers.R
+++ b/R/testthat-helpers.R
@@ -197,7 +197,7 @@ bundle_test <- function(bundler, checker, ...) {
   setwd("packrat-test-bundle")
   suppressWarnings(packrat::init(enter = FALSE))
   bundler(file = "test-bundle.tar.gz", ...)
-  utils::untar("test-bundle.tar.gz", exdir = "untarred", tar = "internal")
+  utils::untar("test-bundle.tar.gz", exdir = "untarred", tar = Sys.getenv("TAR", "internal"))
 
   # run checker
   checker()


### PR DESCRIPTION
The TAR variables is set by R process if tar binary is available. I can imagine that in some system TAR will not be discover property but then standard `internal` will be used.  

It's better to use system tar that internal R tar in case where tar files are not compatible with internal R tar (#648).

This pr is changing only untar param to default behavior where `tar = Sys.getenv("TAR", "internal")`.

Reported long time ago in #648 