### PR TITLE
Update how `tar` binaries are discovered

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,6 +48,7 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          cache: false
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,6 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-          cache: false
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Suggests:
     devtools,
     httr,
     knitr,
+    mockery,
     rmarkdown
 URL: https://github.com/rstudio/packrat/
 BugReports: https://github.com/rstudio/packrat/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Packrat 0.9.0 (UNRELEASED)
 
+- Change how Packrat selects a `tar` binary. Previously, Packrat would force the
+  use of R's internal `tar` implementation, which cannot handle long filepaths.
+  Now, if a `TAR` environment variable exists, Packrat will use that. Otherwise,
+  it will either look for a `tar` binary on the `PATH` on Unix, or look for the
+  system `tar` on Windows. If no binary is found in those locations, it will use
+  R's internal `tar` implementation. (#648)
 
 # Packrat 0.8.1
 

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -177,7 +177,7 @@ unbundle <- function(bundle, where, ..., restore = TRUE) {
 
   whereFiles <- list.files()
   message("- Untarring '", basename(bundle), "' in directory '", where, "'...")
-  untar(bundle, exdir = where, tar = "internal", ...)
+  untar(bundle, exdir = where, tar = tar_binary(), ...)
   dirName <- normalizePath(setdiff(list.files(), whereFiles), winslash = "/", mustWork = TRUE)
 
   if (restore) {

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -126,7 +126,7 @@ bundle <- function(project = NULL,
     tarfile = file,
     files = basename(project),
     compression = "gzip",
-    tar = "internal",
+    tar = tar_binary(),
     ...
   )
 

--- a/R/cranlike-repositories.R
+++ b/R/cranlike-repositories.R
@@ -193,7 +193,7 @@ uploadPackageTarball <- function(package, repoName, repoPath, ...) {
     basename(package),
     files = pkgName,
     compression = "gzip",
-    tar = "internal"
+    tar = tar_binary()
   )
 
   if (success != 0)

--- a/R/cranlike-repositories.R
+++ b/R/cranlike-repositories.R
@@ -177,7 +177,7 @@ uploadPackageTarball <- function(package, repoName, repoPath, ...) {
 
   # Annotate the package DESCRIPTION with the repository
   tmpTarballPath <- file.path(tempdir(), "packrat-tarball-upload")
-  untar(package, exdir = tmpTarballPath, tar = "internal")
+  untar(package, exdir = tmpTarballPath, tar = tar_binary())
   pkgName <- sub("_.*", "", basename(package))
   untarredPath <- file.path(tmpTarballPath, pkgName)
   setRepositoryField(

--- a/R/env.R
+++ b/R/env.R
@@ -1,4 +1,36 @@
-# Tools for storing state in environment variables.
+# Tools for getting info about the execution environment
+
+tar_binary() <- function() {
+  # If TAR is specified in the environment, use that.
+  tar <- Sys.getenv("TAR", unset = NA)
+  if (!is.na(tar)) {
+    return(tar)
+  }
+
+  # If we're on Unix, look for a tar binary on the PATH.
+  if (is.unix()) {
+    return(Sys.which("tar"))
+  }
+
+  # If we're on Windows, look for the system tar binary.
+  if (is.windows()) {
+    root <- Sys.getenv("SystemRoot", unset = NA)
+    if (is.na(root)) {
+      root <- "C:/Windows"
+    }
+    tar <- file.path(root, "System32/tar.exe")
+    if (file.exists(tar)) {
+      return(tar)
+    }
+  }
+
+  # Return internal only as a fallback with a warning.
+  warning("No external tar binary found. Using R's internal TAR, which may cause failures with long filenames.")
+  return("internal")
+}
+
+
+# Tools for storing state in environment variables. Possibly unused.
 getenv <- function(x) {
   strsplit(Sys.getenv(x, unset = ""), .Platform$path.sep, fixed = TRUE)[[1]]
 }

--- a/R/env.R
+++ b/R/env.R
@@ -1,6 +1,6 @@
 # Tools for getting info about the execution environment
 
-tar_binary() <- function() {
+tar_binary <- function() {
   # If TAR is specified in the environment, use that.
   tar <- Sys.getenv("TAR", unset = NA)
   if (!is.na(tar)) {

--- a/R/env.R
+++ b/R/env.R
@@ -9,7 +9,10 @@ tar_binary <- function() {
 
   # If we're on Unix, look for a tar binary on the PATH.
   if (is.unix()) {
-    return(Sys.which("tar"))
+    tar <- file.path(Sys.which("tar"))
+    if (file.exists(tar)) {
+      return(tar)
+    }
   }
 
   # If we're on Windows, look for the system tar binary.
@@ -28,7 +31,6 @@ tar_binary <- function() {
   warning("No external tar binary found. Using R's internal TAR, which may cause failures with long filenames.")
   return("internal")
 }
-
 
 # Tools for storing state in environment variables. Possibly unused.
 getenv <- function(x) {

--- a/R/install.R
+++ b/R/install.R
@@ -139,17 +139,8 @@ r_env_vars <- function() {
     # the R subprocesses. Unsetting it here avoids those problems.
     "R_TESTS" = "",
     "NOT_CRAN" = "true",
-    "TAR" = auto_tar()
+    "TAR" = tar_binary()
   )
-}
-
-auto_tar <- function() {
-  tar <- Sys.getenv("TAR", unset = NA)
-  if (!is.na(tar)) return(tar)
-
-  windows <- .Platform$OS.type == "windows"
-  no_rtools <- is.null(get_rtools_path())
-  if (windows && no_rtools) "internal" else ""
 }
 
 with_something <- function(set) {
@@ -254,27 +245,21 @@ decompress <- function(src, target = tempdir()) {
 decompressImpl <- function(src, target = tempdir()) {
   stopifnot(file.exists(src))
 
-  # force internal tar (otherwise bad things can happen on Windows if
-  # unexpected versions of tar.exe are on the PATH)
-  TAR <- Sys.getenv("TAR")
-  Sys.setenv(TAR = "internal")
-  on.exit(Sys.setenv(TAR = TAR), add = TRUE)
-
   if (grepl("\\.zip$", src)) {
     unzip(src, exdir = target, unzip = getOption("unzip"))
     outdir <- getrootdir(as.vector(unzip(src, list = TRUE)$Name))
 
   } else if (grepl("\\.tar$", src)) {
-    untar(src, exdir = target)
-    outdir <- getrootdir(untar(src, list = TRUE))
+    untar(src, exdir = target, tar = tar_binary())
+    outdir <- getrootdir(untar(src, list = TRUE, tar = tar_binary()))
 
   } else if (grepl("\\.(tar\\.gz|tgz)$", src)) {
-    untar(src, exdir = target, compressed = "gzip")
-    outdir <- getrootdir(untar(src, compressed = "gzip", list = TRUE))
+    untar(src, exdir = target, compressed = "gzip", tar = tar_binary())
+    outdir <- getrootdir(untar(src, compressed = "gzip", list = TRUE, tar = tar_binary()))
 
   } else if (grepl("\\.(tar\\.bz2|tbz)$", src)) {
-    untar(src, exdir = target, compressed = "bzip2")
-    outdir <- getrootdir(untar(src, compressed = "bzip2", list = TRUE))
+    untar(src, exdir = target, compressed = "bzip2", tar = tar_binary())
+    outdir <- getrootdir(untar(src, compressed = "bzip2", list = TRUE, tar = tar_binary()))
 
   } else {
     ext <- gsub("^[^.]*\\.", "", src)

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -456,7 +456,7 @@ getSourcePackageInfoImpl <- function(path) {
   ## For tarballs, we unzip them to a temporary directory and then read from there
   tempdir <- file.path(tempdir(), "packrat", path)
   if (endswith(path, "tar.gz")) {
-    untar(path, exdir = tempdir, tar = "internal")
+    untar(path, exdir = tempdir, tar = tar_binary())
     folderName <- list.files(tempdir, full.names = TRUE)[[1]]
   } else {
     folderName <- path

--- a/R/platform.R
+++ b/R/platform.R
@@ -1,5 +1,9 @@
 is.windows <- function() {
-  Sys.info()["sysname"] == "Windows"
+  .Platform$OS.type == "windows"
+}
+
+is.unix <- function() {
+  .Platform$OS.type == "unix"
 }
 
 is.mac <- function() {

--- a/R/restore.R
+++ b/R/restore.R
@@ -135,7 +135,7 @@ getSourceForPkgRecord <- function(pkgRecord,
         setwd(file.path(pkgRecord$source_path, ".."))
 
         tar(file.path(pkgSrcDir, pkgSrcFile), files = pkgRecord$name,
-            compression = "gzip", tar = "internal")
+            compression = "gzip", tar = tar_binary())
       }
     })
     type <- "local"
@@ -290,7 +290,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       })
       # untar can emit noisy warnings (e.g. "skipping pax global extended
       # headers"); hide those
-      suppressWarnings(untar(srczip, exdir = scratchDir, tar = "internal"))
+      suppressWarnings(untar(srczip, exdir = scratchDir, tar = tar_binary()))
       # Find the base directory
       basedir <- if (length(dir(scratchDir)) == 1)
         file.path(scratchDir, dir(scratchDir))
@@ -388,7 +388,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       })
       # untar can emit noisy warnings (e.g. "skipping pax global extended
       # headers"); hide those
-      suppressWarnings(untar(srczip, exdir = scratchDir, tar = "internal"))
+      suppressWarnings(untar(srczip, exdir = scratchDir, tar = tar_binary()))
       # Find the base directory
       basedir <- if (length(dir(scratchDir)) == 1)
         file.path(scratchDir, dir(scratchDir))
@@ -478,7 +478,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       })
       # untar can emit noisy warnings (e.g. "skipping pax global extended
       # headers"); hide those
-      suppressWarnings(untar(srczip, exdir = scratchDir, tar = "internal"))
+      suppressWarnings(untar(srczip, exdir = scratchDir, tar = tar_binary()))
       # Find the base directory
       basedir <- if (length(dir(scratchDir)) == 1)
         file.path(scratchDir, dir(scratchDir))

--- a/R/testthat-helpers.R
+++ b/R/testthat-helpers.R
@@ -56,7 +56,7 @@ rebuildTestRepo <- function(testroot = getwd()) {
     descfile <- as.data.frame(read.dcf(file.path(source, pkg, "DESCRIPTION")))
     tarball <- paste(pkg, "_", as.character(descfile$Version), ".tar.gz",
                      sep = "")
-    tar(tarball, pkg, compression = "gzip", tar = "internal")
+    tar(tarball, pkg, compression = "gzip", tar = tar_binary())
     dir.create(file.path(target, pkg))
     file.rename(file.path(source, tarball), file.path(target, pkg, tarball))
   }

--- a/R/testthat-helpers.R
+++ b/R/testthat-helpers.R
@@ -197,7 +197,7 @@ bundle_test <- function(bundler, checker, ...) {
   setwd("packrat-test-bundle")
   suppressWarnings(packrat::init(enter = FALSE))
   bundler(file = "test-bundle.tar.gz", ...)
-  utils::untar("test-bundle.tar.gz", exdir = "untarred", tar = "internal")
+  utils::untar("test-bundle.tar.gz", exdir = "untarred", tar = tar_binary())
 
   # run checker
   checker()

--- a/R/utils.R
+++ b/R/utils.R
@@ -618,22 +618,6 @@ defer <- function(expr, envir = parent.frame()) {
   do.call(base::on.exit, list(substitute(call), add = TRUE), envir = envir)
 }
 
-isUsingExternalTar <- function() {
-
-  TAR <- Sys.getenv("TAR")
-
-  if (!nzchar(TAR))
-    return(FALSE)
-
-  if (!nzchar(Sys.which(TAR)))
-    return(FALSE)
-
-  if (identical(TAR, "internal"))
-    return(FALSE)
-
-  TRUE
-}
-
 join <- function(..., sep = "", collapse = NULL) {
   paste(..., sep = sep, collapse = collapse)
 }

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -8,12 +8,13 @@ test_that("TAR environment variable is respected", {
     on.exit(Sys.setenv("TAR" = TAR))
   }
 
-  Sys.setenv(TAR = "foo/bar/tar")
+  Sys.setenv(TAR = "/foo/bar/tar")
 
-  expect_equal(tar_binary(), "foo/bar/tar")
+  expect_equal(tar_binary(), "/foo/bar/tar")
 })
 
-test_that("With no TAR variable set, on Unix, we look for tar with Sys.which", {
+test_that("On Unix, use tar on the path if it exists, otherwise internal", {
+  skip_on_os("windows")
   TAR <- Sys.getenv("TAR")
   if (is.na(TAR)) {
     on.exit(Sys.unsetenv("TAR"))
@@ -23,8 +24,35 @@ test_that("With no TAR variable set, on Unix, we look for tar with Sys.which", {
 
   Sys.unsetenv("TAR")
 
-  stub(is.unix, "tar_binary", TRUE)
-  stub(base::Sys.which, "tar_binary", "foo/bar/tar")
+  which_tar <- file.path(Sys.which("tar"))
 
-  expect_equal(tar_binary(), "foo/bar/tar")
+  if (file.exists(which_tar)) {
+    expect_equal(tar_binary(), which_tar)
+  } else {
+    expect_equal(tar_binary(), "internal")
+  }
+})
+
+test_that("On Windows, use the system tar if it exists, otherwise internal", {
+  skip_on_os(c("mac", "linux", "solaris"))
+  TAR <- Sys.getenv("TAR")
+  if (is.na(TAR)) {
+    on.exit(Sys.unsetenv("TAR"))
+  } else {
+    on.exit(Sys.setenv("TAR" = TAR))
+  }
+
+  Sys.unsetenv("TAR")
+
+  root <- Sys.getenv("SystemRoot", unset = NA)
+  if (is.na(root)) {
+    root <- "C:/Windows"
+  }
+  tar <- file.path(root, "System32/tar.exe")
+
+  if (file.exists(tar)) {
+    expect_equal(tar_binary(), tar)
+  } else {
+    expect_equal(tar_binary(), "internal")
+  }
 })

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -1,0 +1,30 @@
+library(mockery)
+
+test_that("TAR environment variable is respected", {
+  TAR <- Sys.getenv("TAR")
+  if (is.na(TAR)) {
+    on.exit(Sys.unsetenv("TAR"))
+  } else {
+    on.exit(Sys.setenv("TAR" = TAR))
+  }
+
+  Sys.setenv(TAR = "foo/bar/tar")
+
+  expect_equal(tar_binary(), "foo/bar/tar")
+})
+
+test_that("With no TAR variable set, on Unix, we look for tar with Sys.which", {
+  TAR <- Sys.getenv("TAR")
+  if (is.na(TAR)) {
+    on.exit(Sys.unsetenv("TAR"))
+  } else {
+    on.exit(Sys.setenv("TAR" = TAR))
+  }
+
+  Sys.unsetenv("TAR")
+
+  stub(is.unix, "tar_binary", TRUE)
+  stub(base::Sys.which, "tar_binary", "foo/bar/tar")
+
+  expect_equal(tar_binary(), "foo/bar/tar")
+})


### PR DESCRIPTION
This PR incorporates #678, but goes further, so will supersede that PR.

Fixes #648 

### Intent

Packrat has previously forced the use of R's internal tar implementation. This is buggy in a number of situations, including any repository with a slug > 16 characters.

Note: The code is ready for review, but QA notes are incomplete.

### Approach

Influenced by the approach taken in `renv`, we now define a function `tar_binary()` to encapsulate slightly more complex logic:

- If `TAR` is set, respect that;
- If on Unix, look for `tar` on the `PATH`;
- If on Windows, look for the system `tar` and use that if it exists (see [`renv` implementation](https://github.com/rstudio/renv/blob/2bea5cef7cb6c57e43580cf0a182cbe59ef3536a/R/tar.R#L14-L21))
- Otherwise, return `"internal"` and maybe emit a warning about long filenames.

I put the function in `env.R`, because it gathers information about the environment.

There were a number of locations where `tar()` or `untar()` were called with `internal`, and this PR changes all of them.

### Automated Tests

This PR adds automated tests. Note that it adds a dependency on `mockery` for the tests; I'm not sure if we're ok with this.

There are five test functions that test the logical flow of the function in the following cases:

- A `TAR` variable is defined returns the contents of that variable
- We're on Unix and we can find a `tar` binary on the `PATH` returns that binary
- We're on Unix and we can't find a `tar` binary on the `PATH` returns `"internal"`
- We're on Windows and we find system `tar` returns the system `tar`
- We're on Windows and we can't find system `tar` returns `"internal"`

### QA Notes

You can validate that `packrat::restore()` still works by installing the the version of the package from this branch and running `packrat::restore()` in an R session in the top level directory extracted from this .zip file: [simple-rmd.zip](https://github.com/rstudio/packrat/files/9253334/simple-rmd.zip)

This will perform a Packrat restore. I'm not sure if there's a way to validate that the download path has been exercised from `restore()` though.

You can also run `packrat:::tar_binary()` and see that it prints the expected path for your environment. For me, this looks like:

```r
> packrat:::tar_binary()
[1] "/usr/bin/tar"
```