### PR TITLE
renv unscoped settings & test splitting

### DIFF
--- a/inst/resources/renv.R
+++ b/inst/resources/renv.R
@@ -5453,7 +5453,7 @@ renv_dependencies_discover_description_fields <- function() {
 
   # all else fails, use the active project
   project <- project %||% renv_project()
-  renv::settings$package.dependency.fields(project = project)
+  settings$package.dependency.fields(project = project)
 
 }
 

--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -1,16 +1,17 @@
+test_that("Shiny examples have a shiny dependency", {
+  skip_on_cran()
+  skip_if_not_installed("shiny")
+  
+  # Confirm packrat believes all example shiny apps are, in fact, shiny apps
+  examplesPath <- system.file("examples", package = "shiny")
+  apps <- list.files(examplesPath, full.names = TRUE)
+  for (app in apps) {
+    expect_true("shiny" %in% packrat:::appDependencies(app), app)
+  }
+})
+
 test_that("projects which use shiny implicitly are detected", {
   skip_on_cran()
-
-  # Try checking to see if packrat believes all example shiny apps
-  # are, in fact, shiny apps
-  options(repos = c(CRAN = "https://cran.rstudio.org"))
-  if ("shiny" %in% rownames(installed.packages())) {
-    examplesPath <- system.file("examples", package = "shiny")
-    apps <- list.files(examplesPath, full.names = TRUE)
-    for (app in apps) {
-      expect_true("shiny" %in% packrat:::appDependencies(app))
-    }
-  }
 
   # Check that 'shiny' is listed as a dependency for an
   # R Markdown document with 'runtime: shiny'


### PR DESCRIPTION
This change to the embedded renv needs to be back-ported before we take the next update.