### PR TITLE
Add environment masking to Packrat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Packrat 0.9.0 (UNRELEASED)
 
+- Packrat now masks environment variables commonly used for Git service account
+  authentication from subprocesses used to install packages. This behavior can
+  be disabled by setting the option `packrat.unmask.git.service.vars` to `TRUE`.
+- Users can now mask arbitrary environment variables from the subprocess that
+  run package installation tasks, by setting the option `packrat.masked.envvars`
+  to a character vector of variable names to mask.
 
 # Packrat 0.8.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,10 @@
 
 - Packrat now masks environment variables commonly used for Git service account
   authentication from subprocesses used to install packages. This behavior can
-  be disabled by setting the option `packrat.unmask.git.service.vars` to `TRUE`.
-- Users can now mask arbitrary environment variables from the subprocess that
+  be disabled by setting the option `packrat.mask.git.service.envvars` to `FALSE`.
+- Users can mask additional arbitrary environment variables from the subprocess that
   run package installation tasks, by setting the option `packrat.masked.envvars`
-  to a character vector of variable names to mask.
+  to a character vector of variable names to mask. These variables are masked whether or not `packrat.mask.git.service.envvars` has been set to `FALSE`.
 
 # Packrat 0.8.1
 

--- a/R/install.R
+++ b/R/install.R
@@ -116,7 +116,7 @@ build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
 
 R.path <- function() file.path(R.home("bin"), "R")
 
-R <- function(options, path = tempdir(), env_vars = NULL, ...) {
+R <- function(options, path = tempdir(), env_vars = NULL, env_mask = c("") ...) {
   options <- paste("--vanilla", options)
   r_path <- file.path(R.home("bin"), "R")
 
@@ -125,6 +125,10 @@ R <- function(options, path = tempdir(), env_vars = NULL, ...) {
     old <- add_path(get_rtools_path(), 0)
     on.exit(set_path(old))
   }
+
+  getOption("packrat.masked.envvars")
+  # OR
+  get_opts("environment_masking")
 
   in_dir(path, system_check(r_path, options, c(r_env_vars(), env_vars), ...))
 }

--- a/R/install.R
+++ b/R/install.R
@@ -212,6 +212,14 @@ set_libpaths <- function(paths) {
 
 with_libpaths <- with_something(set_libpaths)
 
+# Modifies environment variables, executes the code in `code` and then restores
+# the environment variables to their prior values.
+# - `new` should be a named character vector of values for environment variables
+#   to take during execution. Variables can be temporarily unset with an `NA`
+#   value.
+# - `action` can be "prefix" or "suffix" to combine `new` with existing
+#   variables instead of replacing.
+# See `set_envvar` for more details.
 with_envvar <- function(new, code, action = "replace") {
   old <- set_envvar(new, action)
   on.exit(set_envvar(old, "replace"))
@@ -677,6 +685,14 @@ wrap_command <- function(x) {
   paste(lines, continue, collapse = "\n")
 }
 
+# `set_envvar` takes a named character vector and sets its contents to update
+# environment variables. It returns the old value of the modified envvars.
+# - All non-NA entries in the list will be written to the environment. The
+#   default action overwrites the environment variables, but "prefix" and
+#   "suffix" combine the new value with the existing value.
+# - Any names in the list with NA values will be unset using `Sys.unsetenv`
+# `with_envvar` uses this function to temporarily replace environment variables
+# for execution of a code block.
 set_envvar <- function(envs, action = "replace") {
   stopifnot(all.named(envs))
   stopifnot(is.character(action), length(action) == 1)

--- a/R/install.R
+++ b/R/install.R
@@ -153,7 +153,7 @@ r_env_vars <- function() {
 
 envvar_mask <- function() {
   # Mask tokens unless told not to.
-  git_token_vars <- if (!getOption("packrat.unmask.git.service.vars", FALSE)) {
+  git_token_vars <- if (!getOption("packrat.mask.git.service.envvars", TRUE)) {
     c(
       "GITHUB_PAT",
       "GITLAB_PAT",

--- a/R/install.R
+++ b/R/install.R
@@ -617,13 +617,10 @@ system_check <- function(cmd, args = character(), env = character(),
   if (!is.null(masked_envvars_option)) {
     add_to_env <- as.character(rep(NA, length(masked_envvars_option)))
     names(add_to_env) <- masked_envvars_option
-    print(add_to_env)
     env <- c(env, add_to_env)
   }
 
-  print(env)
-
-  if (!quiet) {
+  if (!quiet && !return_output) {
     message(wrap_command(full))
     message()
   }

--- a/R/install.R
+++ b/R/install.R
@@ -116,7 +116,7 @@ build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
 
 R.path <- function() file.path(R.home("bin"), "R")
 
-R <- function(options, path = tempdir(), env_vars = NULL, ...) {
+R <- function(options, path = tempdir(), ...) {
   options <- paste("--vanilla", options)
   r_path <- file.path(R.home("bin"), "R")
 
@@ -131,7 +131,7 @@ R <- function(options, path = tempdir(), env_vars = NULL, ...) {
     system_check(
       cmd = r_path,
       args = options,
-      env = c(r_env_vars(), env_vars, envvar_mask()),
+      env = c(r_env_vars(), envvar_mask()),
       ...
     )
   )

--- a/R/install.R
+++ b/R/install.R
@@ -127,7 +127,7 @@ R <- function(options, path = tempdir(), env_vars = NULL, ...) {
   }
 
   # Mask Git service tokens unless told not to.
-  git_token_vars <- if (!getOption("packrat.unmask.git.service.tokens", FALSE)) {
+  git_token_vars <- if (!getOption("packrat.unmask.git.service.vars", FALSE)) {
     c(
       "GITHUB_PAT" = NA,
       "GITLAB_PAT" = NA,

--- a/R/install.R
+++ b/R/install.R
@@ -153,7 +153,7 @@ r_env_vars <- function() {
 
 envvar_mask <- function() {
   # Mask tokens unless told not to.
-  git_token_vars <- if (!getOption("packrat.mask.git.service.envvars", TRUE)) {
+  git_token_vars <- if (getOption("packrat.mask.git.service.envvars", TRUE)) {
     c(
       "GITHUB_PAT",
       "GITLAB_PAT",

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -41,7 +41,7 @@ test_that("Git service token variables are masked from subprocesses by default",
   )
   set_envvar(git_token_vars)
 
-  unmask_option <- options("packrat.unmask.git.service.tokens" = NULL)
+  unmask_option <- options("packrat.unmask.git.service.vars" = NULL)
   on.exit(options(unmask_option), add = TRUE)
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
@@ -95,7 +95,7 @@ test_that("Git service token variable masking can be disabled", {
   )
   set_envvar(git_token_vars)
 
-  unmask_option <- options("packrat.unmask.git.service.tokens" = TRUE)
+  unmask_option <- options("packrat.unmask.git.service.vars" = TRUE)
   on.exit(options(unmask_option), add = TRUE)
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -14,12 +14,12 @@ test_that("Git service token variables are masked from subprocesses by default",
     "GITLAB_USER",
     "GITLAB_PASSWORD",
     "GITLAB_PASS"
-  ))
+  ), unset = NA)
   for (varname in names(prior_envvars)) {
-    if (is.na(varname)) {
-      on.exit(Sys.unsetenv(varname), add = TRUE)
+    if (is.na(prior_envvars[varname])) {
+      on.exit(Sys.unsetenv(varname), add = TRUE, after = FALSE)
     } else {
-      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE)
+      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE, after = FALSE)
     }
   }
 
@@ -42,7 +42,7 @@ test_that("Git service token variables are masked from subprocesses by default",
   set_envvar(git_token_vars)
 
   unmask_option <- options("packrat.unmask.git.service.vars" = NULL)
-  on.exit(options(unmask_option), add = TRUE)
+  on.exit(options(unmask_option), add = TRUE, after = FALSE)
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
 
@@ -67,12 +67,12 @@ test_that("Git service token variable masking can be disabled", {
     "GITLAB_USER",
     "GITLAB_PASSWORD",
     "GITLAB_PASS"
-  ))
+  ), unset = NA)
   for (varname in names(prior_envvars)) {
-    if (is.na(varname)) {
-      on.exit(Sys.unsetenv(varname), add = TRUE)
+    if (is.na(prior_envvars[varname])) {
+      on.exit(Sys.unsetenv(varname), add = TRUE, after = FALSE)
     } else {
-      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE)
+      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE, after = FALSE)
     }
   }
 
@@ -96,7 +96,7 @@ test_that("Git service token variable masking can be disabled", {
   set_envvar(git_token_vars)
 
   unmask_option <- options("packrat.unmask.git.service.vars" = TRUE)
-  on.exit(options(unmask_option), add = TRUE)
+  on.exit(options(unmask_option), add = TRUE, after = FALSE)
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
 
@@ -111,12 +111,12 @@ test_that("Other environment variables can be masked via the new option", {
     "MEAT_EATERS_OPTION" = "beef_patty"
   )
 
-  prior_envvars <- Sys.getenv(names(envvars))
+  prior_envvars <- Sys.getenv(names(envvars), unset = NA)
   for (varname in names(prior_envvars)) {
-    if (is.na(varname)) {
-      on.exit(Sys.unsetenv(varname), add = TRUE)
+    if (is.na(prior_envvars[varname])) {
+      on.exit(Sys.unsetenv(varname), add = TRUE, after = FALSE)
     } else {
-      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE)
+      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE, after = FALSE)
     }
   }
   set_envvar(envvars)
@@ -129,7 +129,7 @@ test_that("Other environment variables can be masked via the new option", {
 
 
   unmask_option <- options("packrat.masked.envvars" = names(envvars))
-  on.exit(options(unmask_option), add = TRUE)
+  on.exit(options(unmask_option), add = TRUE, after = FALSE)
 
   # Now that they are named in the option, they should be absent from this output
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -27,7 +27,7 @@ test_that("The default list of environment variables is masked correctly", {
   found_in_output <- sapply(names(new_envvars), function(x) any(grepl(x, subprocess_output)))
 
   # Read `any(found_in_output)` as "Are any of the outputs TRUE?"
-  expect_false(any(found_in_output))
+  expect_false(any(found_in_output), info = print(subprocess_output))
 })
 
 test_that("The default list of masked environment variables can be disabled", {
@@ -57,7 +57,7 @@ test_that("The default list of masked environment variables can be disabled", {
 
   # Check to see if the masked envvar names appear in the subprocess output.
   found_in_output <- sapply(names(new_envvars), function(x) any(grepl(x, subprocess_output)))
-  expect_true(all(found_in_output))
+  expect_true(all(found_in_output), info = print(subprocess_output))
 })
 
 test_that("Environment variables appear in an R subprocess", {
@@ -73,7 +73,7 @@ test_that("Environment variables appear in an R subprocess", {
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
   found_in_output <- sapply(names(new_envvars), function(x) any(grepl(x, subprocess_output)))
-  expect_true(all(found_in_output))
+  expect_true(all(found_in_output), info = print(subprocess_output))
 })
 
 test_that("User-specified masked envvars do not appear in an R subprocess", {
@@ -91,7 +91,7 @@ test_that("User-specified masked envvars do not appear in an R subprocess", {
   found_in_output <- sapply(names(new_envvars), function(x) any(grepl(x, subprocess_output)))
 
   # Read `any(found_in_output)` as "Are any of the outputs TRUE?"
-  expect_false(any(found_in_output))
+  expect_false(any(found_in_output), info = print(subprocess_output))
 })
 
 test_that("Git and user-specified variables can be masked while other variables still appear", {
@@ -128,8 +128,8 @@ test_that("Git and user-specified variables can be masked while other variables 
 
   # Check masked vars
   not_expected <- sapply(masked_names, function(x) any(grepl(x, subprocess_output)))
-  expect_false(any(not_expected)) # expect_false("Are any of the outputs TRUE?")
+  expect_false(any(not_expected), info = print(subprocess_output)) # expect_false("Are any of the outputs TRUE?")
 
   # Check unmasked var
-  expect_true(any(grepl(unmasked_name, subprocess_output)))
+  expect_true(any(grepl(unmasked_name, subprocess_output)), info = print(subprocess_output))
 })

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -113,6 +113,9 @@ test_that("Git and user-specified variables can be masked while other variables 
     "PLANT_BASED" = "veggie_patty",
     "MEAT_EATERS_OPTION" = "beef_patty"
   )
+  prior_envvars <- set_envvar(new_envvars, "replace")
+  on.exit(set_envvar(new_envvars, "replace"), add = TRUE, after = FALSE)
+
 
   git_mask_option <- options("packrat.mask.git.service.envvars" = NULL)
   on.exit(options(git_mask_option), add = TRUE, after = FALSE)
@@ -128,7 +131,7 @@ test_that("Git and user-specified variables can be masked while other variables 
 
   # Check masked vars
   not_expected <- sapply(masked_names, function(x) any(grepl(x, subprocess_output)))
-  expect_false(any(not_expected), info = print(subprocess_output)) # expect_false("Are any of the outputs TRUE?")
+  expect_false(any(not_expected), info = print(not_expected)) # expect_false("Are any of the outputs TRUE?")
 
   # Check unmasked var
   expect_true(any(grepl(unmasked_name, subprocess_output)), info = print(subprocess_output))

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,6 +1,6 @@
 test_that("The default list of environment variables is masked correctly", {
+    # We won't check GITHUB_PAT because it's always present in process on CI.
   new_envvars <- c(
-    # "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
     "BITBUCKET_USERNAME" = "secret",
     "BITBUCKET_USER" = "secret",
@@ -32,7 +32,6 @@ test_that("The default list of environment variables is masked correctly", {
 
 test_that("The default list of masked environment variables can be disabled", {
   new_envvars <- c(
-    # "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
     "BITBUCKET_USERNAME" = "secret",
     "BITBUCKET_USER" = "secret",
@@ -96,7 +95,6 @@ test_that("User-specified masked envvars do not appear in an R subprocess", {
 
 test_that("Git and user-specified variables can be masked while other variables still appear", {
   new_envvars <- c(
-    # "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
     "BITBUCKET_USERNAME" = "secret",
     "BITBUCKET_USER" = "secret",
@@ -114,7 +112,7 @@ test_that("Git and user-specified variables can be masked while other variables 
     "MEAT_EATERS_OPTION" = "beef_patty"
   )
   prior_envvars <- set_envvar(new_envvars, "replace")
-  on.exit(set_envvar(new_envvars, "replace"), add = TRUE, after = FALSE)
+  on.exit(set_envvar(prior_envvars, "replace"), add = TRUE, after = FALSE)
 
 
   git_mask_option <- options("packrat.mask.git.service.envvars" = NULL)
@@ -131,7 +129,7 @@ test_that("Git and user-specified variables can be masked while other variables 
 
   # Check masked vars
   not_expected <- sapply(masked_names, function(x) any(grepl(x, subprocess_output)))
-  expect_false(any(not_expected), info = print(not_expected)) # expect_false("Are any of the outputs TRUE?")
+  expect_false(any(not_expected), info = print(subprocess_output)) # expect_false("Are any of the outputs TRUE?")
 
   # Check unmasked var
   expect_true(any(grepl(unmasked_name, subprocess_output)), info = print(subprocess_output))

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,28 +1,4 @@
 test_that("Git service token variables are masked from subprocesses by default", {
-  prior_envvars <- Sys.getenv(c(
-    "GITHUB_PAT",
-    "GITLAB_PAT",
-    "BITBUCKET_USERNAME",
-    "BITBUCKET_USER",
-    "BITBUCKET_PASSWORD",
-    "BITBUCKET_PASS",
-    "GITHUB_USERNAME",
-    "GITHUB_USER",
-    "GITHUB_PASSWORD",
-    "GITHUB_PASS",
-    "GITLAB_USERNAME",
-    "GITLAB_USER",
-    "GITLAB_PASSWORD",
-    "GITLAB_PASS"
-  ), unset = NA)
-  for (varname in names(prior_envvars)) {
-    if (is.na(prior_envvars[varname])) {
-      on.exit(Sys.unsetenv(varname), add = TRUE, after = FALSE)
-    } else {
-      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE, after = FALSE)
-    }
-  }
-
   git_token_vars <- c(
     "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
@@ -39,7 +15,8 @@ test_that("Git service token variables are masked from subprocesses by default",
     "GITLAB_PASSWORD" = "secret",
     "GITLAB_PASS" = "secret"
   )
-  set_envvar(git_token_vars)
+  prior_envvars <- set_envvar(git_token_vars, "replace")
+  on.exit(set_envvar(prior_envvars, "replace"))
 
   unmask_option <- options("packrat.unmask.git.service.vars" = NULL)
   on.exit(options(unmask_option), add = TRUE, after = FALSE)
@@ -52,30 +29,6 @@ test_that("Git service token variables are masked from subprocesses by default",
 })
 
 test_that("Git service token variable masking can be disabled", {
-  prior_envvars <- Sys.getenv(c(
-    "GITHUB_PAT",
-    "GITLAB_PAT",
-    "BITBUCKET_USERNAME",
-    "BITBUCKET_USER",
-    "BITBUCKET_PASSWORD",
-    "BITBUCKET_PASS",
-    "GITHUB_USERNAME",
-    "GITHUB_USER",
-    "GITHUB_PASSWORD",
-    "GITHUB_PASS",
-    "GITLAB_USERNAME",
-    "GITLAB_USER",
-    "GITLAB_PASSWORD",
-    "GITLAB_PASS"
-  ), unset = NA)
-  for (varname in names(prior_envvars)) {
-    if (is.na(prior_envvars[varname])) {
-      on.exit(Sys.unsetenv(varname), add = TRUE, after = FALSE)
-    } else {
-      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE, after = FALSE)
-    }
-  }
-
   git_token_vars <- c(
     "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
@@ -83,7 +36,6 @@ test_that("Git service token variable masking can be disabled", {
     "BITBUCKET_USER" = "secret",
     "BITBUCKET_PASSWORD" = "secret",
     "BITBUCKET_PASS" = "secret",
-    # Varnames that may have been used previously
     "GITHUB_USERNAME" = "secret",
     "GITHUB_USER" = "secret",
     "GITHUB_PASSWORD" = "secret",
@@ -93,7 +45,8 @@ test_that("Git service token variable masking can be disabled", {
     "GITLAB_PASSWORD" = "secret",
     "GITLAB_PASS" = "secret"
   )
-  set_envvar(git_token_vars)
+  prior_envvars <- set_envvar(git_token_vars, "replace")
+  on.exit(set_envvar(prior_envvars, "replace"))
 
   unmask_option <- options("packrat.unmask.git.service.vars" = TRUE)
   on.exit(options(unmask_option), add = TRUE, after = FALSE)
@@ -110,16 +63,8 @@ test_that("Other environment variables can be masked via the new option", {
     "MY_SPECIAL_PAT" = "veggie_patty",
     "MEAT_EATERS_OPTION" = "beef_patty"
   )
-
-  prior_envvars <- Sys.getenv(names(envvars), unset = NA)
-  for (varname in names(prior_envvars)) {
-    if (is.na(prior_envvars[varname])) {
-      on.exit(Sys.unsetenv(varname), add = TRUE, after = FALSE)
-    } else {
-      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE, after = FALSE)
-    }
-  }
-  set_envvar(envvars)
+  prior_envvars <- set_envvar(envvars, "replace")
+  on.exit(set_envvar(envvars, "replace"), add = TRUE, after = FALSE)
 
   # First, we should check that our environment variables appear in the subprocess
   # environment when they aren't masked.

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,6 +1,6 @@
 test_that("The default list of environment variables is masked correctly", {
   new_envvars <- c(
-    "GITHUB_PAT" = "secret",
+    # "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
     "BITBUCKET_USERNAME" = "secret",
     "BITBUCKET_USER" = "secret",
@@ -32,7 +32,7 @@ test_that("The default list of environment variables is masked correctly", {
 
 test_that("The default list of masked environment variables can be disabled", {
   new_envvars <- c(
-    "GITHUB_PAT" = "secret",
+    # "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
     "BITBUCKET_USERNAME" = "secret",
     "BITBUCKET_USER" = "secret",
@@ -96,7 +96,7 @@ test_that("User-specified masked envvars do not appear in an R subprocess", {
 
 test_that("Git and user-specified variables can be masked while other variables still appear", {
   new_envvars <- c(
-    "GITHUB_PAT" = "secret",
+    # "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
     "BITBUCKET_USERNAME" = "secret",
     "BITBUCKET_USER" = "secret",

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -18,13 +18,15 @@ test_that("The default list of environment variables is masked correctly", {
   prior_envvars <- set_envvar(new_envvars, "replace")
   on.exit(set_envvar(prior_envvars, "replace"))
 
-  unmask_option <- options("packrat.mask.git.service.envvars" = NULL)
-  on.exit(options(unmask_option), add = TRUE, after = FALSE)
+  git_mask_option <- options("packrat.mask.git.service.envvars" = NULL)
+  on.exit(options(git_mask_option), add = TRUE, after = FALSE)
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
 
-  # Check to see if the supposedly_masked vars appear in the subprocess output.
-  found_in_output <- sapply(new_envvars, function(x) any(grepl(x, subprocess_output)))
+  # Check to see if the masked envvar names appear in the subprocess output.
+  found_in_output <- sapply(names(new_envvars), function(x) any(grepl(x, subprocess_output)))
+
+  # Read `any(found_in_output)` as "Are any of the outputs TRUE?"
   expect_false(any(found_in_output))
 })
 
@@ -48,36 +50,86 @@ test_that("The default list of masked environment variables can be disabled", {
   prior_envvars <- set_envvar(new_envvars, "replace")
   on.exit(set_envvar(prior_envvars, "replace"))
 
-  unmask_option <- options("packrat.mask.git.service.envvars" = FALSE)
-  on.exit(options(unmask_option), add = TRUE, after = FALSE)
+  git_mask_option <- options("packrat.mask.git.service.envvars" = FALSE)
+  on.exit(options(git_mask_option), add = TRUE, after = FALSE)
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
 
-  # Check to see if the supposedly_masked vars appear in the subprocess output.
-  found_in_output <- sapply(new_envvars, function(x) any(grepl(x, subprocess_output)))
+  # Check to see if the masked envvar names appear in the subprocess output.
+  found_in_output <- sapply(names(new_envvars), function(x) any(grepl(x, subprocess_output)))
   expect_true(all(found_in_output))
 })
 
-test_that("User-specified environment variables are masked from an R subprocess", {
+test_that("Environment variables appear in an R subprocess", {
   new_envvars <- c(
-    "MY_SPECIAL_PAT" = "veggie_patty",
+    "PLANT_BASED" = "veggie_patty",
     "MEAT_EATERS_OPTION" = "beef_patty"
   )
   prior_envvars <- set_envvar(new_envvars, "replace")
   on.exit(set_envvar(new_envvars, "replace"), add = TRUE, after = FALSE)
 
-  # First, we should check that our environment variables appear in the subprocess
-  # environment when they aren't masked.
+  user_mask <- options("packrat.masked.envvars" = NULL)
+  on.exit(options(user_mask), add = TRUE, after = FALSE)
+
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
-  found_in_output <- sapply(new_envvars, function(x) any(grepl(x, subprocess_output)))
+  found_in_output <- sapply(names(new_envvars), function(x) any(grepl(x, subprocess_output)))
   expect_true(all(found_in_output))
+})
 
+test_that("User-specified masked envvars do not appear in an R subprocess", {
+  new_envvars <- c(
+    "PLANT_BASED" = "veggie_patty",
+    "MEAT_EATERS_OPTION" = "beef_patty"
+  )
+  prior_envvars <- set_envvar(new_envvars, "replace")
+  on.exit(set_envvar(new_envvars, "replace"), add = TRUE, after = FALSE)
 
-  unmask_option <- options("packrat.masked.envvars" = names(new_envvars))
-  on.exit(options(unmask_option), add = TRUE, after = FALSE)
+  user_mask <- options("packrat.masked.envvars" = names(new_envvars))
+  on.exit(options(user_mask), add = TRUE, after = FALSE)
 
-  # Now that they are named in the option, they should be absent from this output
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
-  found_in_output <- sapply(new_envvars, function(x) any(grepl(x, subprocess_output)))
+  found_in_output <- sapply(names(new_envvars), function(x) any(grepl(x, subprocess_output)))
+
+  # Read `any(found_in_output)` as "Are any of the outputs TRUE?"
   expect_false(any(found_in_output))
+})
+
+test_that("Git and user-specified variables can be masked while other variables still appear", {
+  new_envvars <- c(
+    "GITHUB_PAT" = "secret",
+    "GITLAB_PAT" = "secret",
+    "BITBUCKET_USERNAME" = "secret",
+    "BITBUCKET_USER" = "secret",
+    "BITBUCKET_PASSWORD" = "secret",
+    "BITBUCKET_PASS" = "secret",
+    "GITHUB_USERNAME" = "secret",
+    "GITHUB_USER" = "secret",
+    "GITHUB_PASSWORD" = "secret",
+    "GITHUB_PASS" = "secret",
+    "GITLAB_USERNAME" = "secret",
+    "GITLAB_USER" = "secret",
+    "GITLAB_PASSWORD" = "secret",
+    "GITLAB_PASS" = "secret",
+    "PLANT_BASED" = "veggie_patty",
+    "MEAT_EATERS_OPTION" = "beef_patty"
+  )
+
+  git_mask_option <- options("packrat.mask.git.service.envvars" = NULL)
+  on.exit(options(git_mask_option), add = TRUE, after = FALSE)
+
+  user_mask_option <- options("packrat.masked.envvars" = "PLANT_BASED")
+  on.exit(options(user_mask_option), add = TRUE, after = FALSE)
+
+  # We're expecting everything but the last item to be masked.
+  masked_names <- names(new_envvars)[1:length(new_envvars) - 1]
+  unmasked_name <- names(new_envvars)[length(new_envvars)]
+
+  subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
+
+  # Check masked vars
+  not_expected <- sapply(masked_names, function(x) any(grepl(x, subprocess_output)))
+  expect_false(any(not_expected)) # expect_false("Are any of the outputs TRUE?")
+
+  # Check unmasked var
+  expect_true(any(grepl(unmasked_name, subprocess_output)))
 })

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -18,7 +18,7 @@ test_that("The default list of environment variables is masked correctly", {
   prior_envvars <- set_envvar(new_envvars, "replace")
   on.exit(set_envvar(prior_envvars, "replace"))
 
-  unmask_option <- options("packrat.unmask.git.service.vars" = NULL)
+  unmask_option <- options("packrat.mask.git.service.envvars" = NULL)
   on.exit(options(unmask_option), add = TRUE, after = FALSE)
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
@@ -48,7 +48,7 @@ test_that("The default list of masked environment variables can be disabled", {
   prior_envvars <- set_envvar(new_envvars, "replace")
   on.exit(set_envvar(prior_envvars, "replace"))
 
-  unmask_option <- options("packrat.unmask.git.service.vars" = TRUE)
+  unmask_option <- options("packrat.mask.git.service.envvars" = FALSE)
   on.exit(options(unmask_option), add = TRUE, after = FALSE)
 
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,5 +1,5 @@
-test_that("Git service token variables are masked from subprocesses by default", {
-  git_token_vars <- c(
+test_that("The default list of environment variables is masked correctly", {
+  new_envvars <- c(
     "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
     "BITBUCKET_USERNAME" = "secret",
@@ -15,7 +15,7 @@ test_that("Git service token variables are masked from subprocesses by default",
     "GITLAB_PASSWORD" = "secret",
     "GITLAB_PASS" = "secret"
   )
-  prior_envvars <- set_envvar(git_token_vars, "replace")
+  prior_envvars <- set_envvar(new_envvars, "replace")
   on.exit(set_envvar(prior_envvars, "replace"))
 
   unmask_option <- options("packrat.unmask.git.service.vars" = NULL)
@@ -24,12 +24,12 @@ test_that("Git service token variables are masked from subprocesses by default",
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
 
   # Check to see if the supposedly_masked vars appear in the subprocess output.
-  found_in_output <- sapply(git_token_vars, function(x) any(grepl(x, subprocess_output)))
+  found_in_output <- sapply(new_envvars, function(x) any(grepl(x, subprocess_output)))
   expect_false(any(found_in_output))
 })
 
-test_that("Git service token variable masking can be disabled", {
-  git_token_vars <- c(
+test_that("The default list of masked environment variables can be disabled", {
+  new_envvars <- c(
     "GITHUB_PAT" = "secret",
     "GITLAB_PAT" = "secret",
     "BITBUCKET_USERNAME" = "secret",
@@ -45,7 +45,7 @@ test_that("Git service token variable masking can be disabled", {
     "GITLAB_PASSWORD" = "secret",
     "GITLAB_PASS" = "secret"
   )
-  prior_envvars <- set_envvar(git_token_vars, "replace")
+  prior_envvars <- set_envvar(new_envvars, "replace")
   on.exit(set_envvar(prior_envvars, "replace"))
 
   unmask_option <- options("packrat.unmask.git.service.vars" = TRUE)
@@ -54,30 +54,30 @@ test_that("Git service token variable masking can be disabled", {
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
 
   # Check to see if the supposedly_masked vars appear in the subprocess output.
-  found_in_output <- sapply(git_token_vars, function(x) any(grepl(x, subprocess_output)))
+  found_in_output <- sapply(new_envvars, function(x) any(grepl(x, subprocess_output)))
   expect_true(all(found_in_output))
 })
 
-test_that("Other environment variables can be masked via the new option", {
-  envvars <- c(
+test_that("User-specified environment variables are masked from an R subprocess", {
+  new_envvars <- c(
     "MY_SPECIAL_PAT" = "veggie_patty",
     "MEAT_EATERS_OPTION" = "beef_patty"
   )
-  prior_envvars <- set_envvar(envvars, "replace")
-  on.exit(set_envvar(envvars, "replace"), add = TRUE, after = FALSE)
+  prior_envvars <- set_envvar(new_envvars, "replace")
+  on.exit(set_envvar(new_envvars, "replace"), add = TRUE, after = FALSE)
 
   # First, we should check that our environment variables appear in the subprocess
   # environment when they aren't masked.
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
-  found_in_output <- sapply(envvars, function(x) any(grepl(x, subprocess_output)))
+  found_in_output <- sapply(new_envvars, function(x) any(grepl(x, subprocess_output)))
   expect_true(all(found_in_output))
 
 
-  unmask_option <- options("packrat.masked.envvars" = names(envvars))
+  unmask_option <- options("packrat.masked.envvars" = names(new_envvars))
   on.exit(options(unmask_option), add = TRUE, after = FALSE)
 
   # Now that they are named in the option, they should be absent from this output
   subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
-  found_in_output <- sapply(envvars, function(x) any(grepl(x, subprocess_output)))
+  found_in_output <- sapply(new_envvars, function(x) any(grepl(x, subprocess_output)))
   expect_false(any(found_in_output))
 })

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,0 +1,138 @@
+test_that("Git service token variables are masked from subprocesses by default", {
+  prior_envvars <- Sys.getenv(c(
+    "GITHUB_PAT",
+    "GITLAB_PAT",
+    "BITBUCKET_USERNAME",
+    "BITBUCKET_USER",
+    "BITBUCKET_PASSWORD",
+    "BITBUCKET_PASS",
+    "GITHUB_USERNAME",
+    "GITHUB_USER",
+    "GITHUB_PASSWORD",
+    "GITHUB_PASS",
+    "GITLAB_USERNAME",
+    "GITLAB_USER",
+    "GITLAB_PASSWORD",
+    "GITLAB_PASS"
+  ))
+  for (varname in names(prior_envvars)) {
+    if (is.na(varname)) {
+      on.exit(Sys.unsetenv(varname), add = TRUE)
+    } else {
+      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE)
+    }
+  }
+
+  git_token_vars <- c(
+    "GITHUB_PAT" = "secret",
+    "GITLAB_PAT" = "secret",
+    "BITBUCKET_USERNAME" = "secret",
+    "BITBUCKET_USER" = "secret",
+    "BITBUCKET_PASSWORD" = "secret",
+    "BITBUCKET_PASS" = "secret",
+    "GITHUB_USERNAME" = "secret",
+    "GITHUB_USER" = "secret",
+    "GITHUB_PASSWORD" = "secret",
+    "GITHUB_PASS" = "secret",
+    "GITLAB_USERNAME" = "secret",
+    "GITLAB_USER" = "secret",
+    "GITLAB_PASSWORD" = "secret",
+    "GITLAB_PASS" = "secret"
+  )
+  set_envvar(git_token_vars)
+
+  unmask_option <- options("packrat.unmask.git.service.tokens" = NULL)
+  on.exit(options(unmask_option), add = TRUE)
+
+  subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
+
+  # Check to see if the supposedly_masked vars appear in the subprocess output.
+  found_in_output <- sapply(git_token_vars, function(x) any(grepl(x, subprocess_output)))
+  expect_false(any(found_in_output))
+})
+
+test_that("Git service token variable masking can be disabled", {
+  prior_envvars <- Sys.getenv(c(
+    "GITHUB_PAT",
+    "GITLAB_PAT",
+    "BITBUCKET_USERNAME",
+    "BITBUCKET_USER",
+    "BITBUCKET_PASSWORD",
+    "BITBUCKET_PASS",
+    "GITHUB_USERNAME",
+    "GITHUB_USER",
+    "GITHUB_PASSWORD",
+    "GITHUB_PASS",
+    "GITLAB_USERNAME",
+    "GITLAB_USER",
+    "GITLAB_PASSWORD",
+    "GITLAB_PASS"
+  ))
+  for (varname in names(prior_envvars)) {
+    if (is.na(varname)) {
+      on.exit(Sys.unsetenv(varname), add = TRUE)
+    } else {
+      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE)
+    }
+  }
+
+  git_token_vars <- c(
+    "GITHUB_PAT" = "secret",
+    "GITLAB_PAT" = "secret",
+    "BITBUCKET_USERNAME" = "secret",
+    "BITBUCKET_USER" = "secret",
+    "BITBUCKET_PASSWORD" = "secret",
+    "BITBUCKET_PASS" = "secret",
+    # Varnames that may have been used previously
+    "GITHUB_USERNAME" = "secret",
+    "GITHUB_USER" = "secret",
+    "GITHUB_PASSWORD" = "secret",
+    "GITHUB_PASS" = "secret",
+    "GITLAB_USERNAME" = "secret",
+    "GITLAB_USER" = "secret",
+    "GITLAB_PASSWORD" = "secret",
+    "GITLAB_PASS" = "secret"
+  )
+  set_envvar(git_token_vars)
+
+  unmask_option <- options("packrat.unmask.git.service.tokens" = TRUE)
+  on.exit(options(unmask_option), add = TRUE)
+
+  subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
+
+  # Check to see if the supposedly_masked vars appear in the subprocess output.
+  found_in_output <- sapply(git_token_vars, function(x) any(grepl(x, subprocess_output)))
+  expect_true(all(found_in_output))
+})
+
+test_that("Other environment variables can be masked via the new option", {
+  envvars <- c(
+    "MY_SPECIAL_PAT" = "veggie_patty",
+    "MEAT_EATERS_OPTION" = "beef_patty"
+  )
+
+  prior_envvars <- Sys.getenv(names(envvars))
+  for (varname in names(prior_envvars)) {
+    if (is.na(varname)) {
+      on.exit(Sys.unsetenv(varname), add = TRUE)
+    } else {
+      on.exit(Sys.setenv(varname = prior_envvars[varname]), add = TRUE)
+    }
+  }
+  set_envvar(envvars)
+
+  # First, we should check that our environment variables appear in the subprocess
+  # environment when they aren't masked.
+  subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
+  found_in_output <- sapply(envvars, function(x) any(grepl(x, subprocess_output)))
+  expect_true(all(found_in_output))
+
+
+  unmask_option <- options("packrat.masked.envvars" = names(envvars))
+  on.exit(options(unmask_option), add = TRUE)
+
+  # Now that they are named in the option, they should be absent from this output
+  subprocess_output <- R("-e 'Sys.getenv()'", return_output = TRUE)
+  found_in_output <- sapply(envvars, function(x) any(grepl(x, subprocess_output)))
+  expect_false(any(found_in_output))
+})


### PR DESCRIPTION
### Intent

Mask certain environment variables from subprocesses launched by Packrat.

### Approach

There are two ways an environment variable can be added to the list of environment variables to mask:
- A predefined list of variables is built-in. This can be disabled by setting the option `packrat.mask.git.service.envvars` to `FALSE`.
- Users can define a character vector of additional variable names to mask in the option `packrat.masked.envvars`.

These are compiled in a function called `envvar_mask()`, which returns a named character vector of NAs with the names of variables to mask. This is used in the `R()` function that launches R subprocesses.

Other changes:
- A change was made to `system_check()` to add the argument `return_output = FALSE`, which captures and returns the output of the command, rather than returning `TRUE` upon success. This is used to facilitate tests that launch subprocesses and make assertions about the output.
- Renamed `is.named()`, which checks that all elements of a vector are named, to `all.named()`.

#### Open question

- Maybe the envvar mask should be loaded in `system_check()`. This is lower-level and can launch any process, whereas `R()` is for launching R processes. In practice, they are completely coupled.

### Automated Tests

Tests work one level out from the `envvar_mask()` function, launching an R process to run `R -e 'Sys.getenv()'` to examine the resulting environment. There are three tests:
- Test that the default list of variables is masked with the option unset
- Test that the default list of variables is ignored when the appropriate option is set
- Test that other variables can be masked

I wrote these tests before I moved the code to its own `envvar_mask()` function. It would be possible to test that inner code, but this outer test will fail if the inner code does not function.

### QA Notes

Install the test version of the package.

We're going to examine our environment with `Sys.getenv()`, and then run an R subprocess via Packrat and look at the environment seen by that subprocess. This will confirm that the new variable masking options are working correctly.

#### 1. Git service account variables are masked by default, but can be unmasked with an option.

In an R session, set an environment variable named `GITHUB_PAT`. The second line here should print out the result.

```r
Sys.setenv(GITHUB_PAT = "very_secret")
Sys.getenv("GITHUB_PAT")
```
```
[1] "very_secret"
```

Next, we'll see if it appears in a subprocess. This will print out a fair amount of text, including the R startup text. The result here is truncated. The important part is that the variable `very_secret` should not appear below the line where our function call is printed out.

```r
packrat:::R("-e 'Sys.getenv(\"GITHUB_PAT\")'", return_output = TRUE)
```
```
[20] "> Sys.getenv(\"GITHUB_PAT\")"                                 
[21] "[1] \"\""                                                     
```

Next, we'll turn off Git variable masking and see if the variable does appear.

```r
options(packrat.mask.git.service.envvars = FALSE)
packrat:::R("-e 'Sys.getenv(\"GITHUB_PAT\")'", return_output = TRUE)
```
```
[20] "> Sys.getenv(\"GITHUB_PAT\")"                                 
[21] "[1] \"very_secret\""                                          
```

#### 2. Arbitrary environment variables we provide can be masked with an option.

Set two variables and examine them locally.

```r
Sys.setenv(PLANT_BASED_PAT = "veggie_patty")
Sys.setenv(MEAT_EATERS_OPTION = "beef_patty")
Sys.getenv(c("PLANT_BASED_PAT", "MEAT_EATERS_OPTION"))
```
```
   PLANT_BASED_PAT MEAT_EATERS_OPTION 
    "veggie_patty"       "beef_patty" 
```

Check them in a subprocess.

```r
packrat:::R("-e 'Sys.getenv(c(\"PLANT_BASED_PAT\", \"MEAT_EATERS_OPTION\"))'", return_output = TRUE)
```
```
[20] "> Sys.getenv(c(\"PLANT_BASED_PAT\", \"MEAT_EATERS_OPTION\"))" 
[21] "   PLANT_BASED_PAT MEAT_EATERS_OPTION "                       
[22] "    \"veggie_patty\"       \"beef_patty\" "                   
```

Set new Packrat option and check that they are absent from the subprocess output.

```r
options(packrat.masked.envvars = c("PLANT_BASED_PAT", "MEAT_EATERS_OPTION"))
packrat:::R("-e 'Sys.getenv(c(\"PLANT_BASED_PAT\", \"MEAT_EATERS_OPTION\"))'", return_output = TRUE)
```
```
[20] "> Sys.getenv(c(\"PLANT_BASED_PAT\", \"MEAT_EATERS_OPTION\"))" 
[21] "   PLANT_BASED_PAT MEAT_EATERS_OPTION "                       
[22] "                \"\"                 \"\" "                   
```

#### 3. Verify that these options work together

Turn Git variable masking back on. Change the user mask option to only specify one of the variables. Confirm that all our variables still exist.

```r
options(packrat.mask.git.service.envvars = NULL)
options(packrat.masked.envvars = "PLANT_BASED_PAT")
Sys.getenv(c("GITHUB_PAT", "PLANT_BASED_PAT", "MEAT_EATERS_OPTION"))
```
```
        GITHUB_PAT    PLANT_BASED_PAT MEAT_EATERS_OPTION 
     "very_secret"     "veggie_patty"       "beef_patty" 
```

Check these variables in a subprocess. Only `MEAT_EATERS_OPTION` should be there.

```r
packrat:::R("-e 'Sys.getenv(c(\"GITHUB_PAT\", \"PLANT_BASED_PAT\", \"MEAT_EATERS_OPTION\"))'", return_output = TRUE)
```
```
[20] "> Sys.getenv(c(\"GITHUB_PAT\", \"PLANT_BASED_PAT\", \"MEAT_EATERS_OPTION\"))"
[21] "        GITHUB_PAT    PLANT_BASED_PAT MEAT_EATERS_OPTION "                   
[22] "                \"\"                 \"\"       \"beef_patty\" "             
```