### PR TITLE
Document TAR handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,6 @@ Suggests:
     rmarkdown
 URL: https://github.com/rstudio/packrat/
 BugReports: https://github.com/rstudio/packrat/issues
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Encoding: UTF-8
 Config/testthat/edition: 3

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -6,6 +6,8 @@
 #' be unbundled either with \code{packrat::\link{unbundle}} (which
 #' restores the project as well), \R's own \code{utils::\link{untar}}, or
 #' through most system \code{tar} implementations.
+#' 
+#' The tar binary is selected using the same heuristic as \code{\link{restore}}.
 #'
 #' @param project The project directory. Defaults to the currently activate
 #'  project. By default, the current project active under \code{packratMode}

--- a/R/packrat.R
+++ b/R/packrat.R
@@ -14,7 +14,8 @@
 #' packages your project depends on.
 #' \item \strong{Reproducible}: Packrat records the exact package versions you
 #' depend on, and ensures those exact versions are the ones that get installed
-#' wherever you go.}
+#' wherever you go.
+#' }
 #'
 #' Use \code{\link{init}} to create a new packrat project,
 #' \code{\link{snapshot}} to record changes to your project's library, and
@@ -269,14 +270,12 @@ initImpl <- function(project = getwd(),
 #'
 #' There are three common use cases for \code{restore}:
 #' \itemize{
-#'   \item \strong{Hydrate}: Use \code{restore} after copying a project to a new
-#' machine to populate the library on that machine.
-#'
-#'   \item \strong{Sync}: Use \code{restore} to apply library changes made by a
+#' \item \strong{Hydrate}: Use \code{restore} after copying a project to a new machine
+#' to populate the library on that machine.
+#' \item \strong{Sync}: Use \code{restore} to apply library changes made by a
 #' collaborator to your own library. (In general, you want to run \code{restore}
 #' whenever you pick up a change to \code{packrat.lock})
-#'
-#'   \item \strong{Rollback}: Use \code{restore} to undo accidental changes made
+#' \item \strong{Rollback}: Use \code{restore} to undo accidental changes made
 #' to the library since the last snapshot.
 #' }
 #'
@@ -284,13 +283,12 @@ initImpl <- function(project = getwd(),
 #' changes are necessary to currently loaded packages, you will need to restart
 #' \R to apply the changes (\code{restore} will let you know when this is
 #' necessary). It is recommended that you do this as soon as possible, because
-#' any library changes made between running \code{restore} and restarting \R will
-#' be lost.
+#' any library changes made between running \code{restore} and restarting \R
+#' will be lost.
 #'
-#' @note
-#' \code{restore} can be destructive; it will remove packages that were not in
-#' the snapshot, and it will replace newer packages with older versions if
-#' that's what the snapshot indicates. \code{restore} will warn you before
+#' @note \code{restore} can be destructive; it will remove packages that were
+#' not in the snapshot, and it will replace newer packages with older versions
+#' if that's what the snapshot indicates. \code{restore} will warn you before
 #' attempting to remove or downgrade a package (if \code{prompt} is
 #' \code{TRUE}), but will always perform upgrades and new installations without
 #' prompting.
@@ -298,9 +296,16 @@ initImpl <- function(project = getwd(),
 #' \code{restore} works only on the private package library created by packrat;
 #' if you have other libraries on your path, they will be unaffected.
 #'
-#' The \code{restart} parameter will only result in a restart of R when the
-#' R environment packrat is running within makes available a restart function
-#' via \code{getOption("restart")}.
+#' The \code{restart} parameter will only result in a restart of R when the R
+#' environment packrat is running within makes available a restart function via
+#' \code{getOption("restart")}.
+#'
+#' Packrat selects a \code{tar} binary with the following heuristic: If a \code{TAR}
+#' environment variable exists, Packrat will use that. Otherwise, it will either
+#' look for a \code{tar} binary on the \code{PATH} on Unix, or look for the
+#' system \code{tar} on Windows. If no binary is found in those locations, it
+#' will use R's internal \code{tar} implementation, which may cause errors with
+#' long filenames.
 #'
 #' @param project The project directory. When in packrat mode, if this is \code{NULL},
 #' then the directory associated with the current packrat project is used. Otherwise,

--- a/man/bundle.Rd
+++ b/man/bundle.Rd
@@ -53,4 +53,6 @@ The project is bundled as a gzipped tarball (\code{.tar.gz}), which can
 be unbundled either with \code{packrat::\link{unbundle}} (which
 restores the project as well), \R's own \code{utils::\link{untar}}, or
 through most system \code{tar} implementations.
+
+The tar binary is selected using the same heuristic as \code{\link{restore}}.
 }

--- a/man/packrat.Rd
+++ b/man/packrat.Rd
@@ -20,7 +20,8 @@ another, even across different platforms. Packrat makes it easy to install the
 packages your project depends on.
 \item \strong{Reproducible}: Packrat records the exact package versions you
 depend on, and ensures those exact versions are the ones that get installed
-wherever you go.}
+wherever you go.
+}
 
 Use \code{\link{init}} to create a new packrat project,
 \code{\link{snapshot}} to record changes to your project's library, and

--- a/man/restore.Rd
+++ b/man/restore.Rd
@@ -40,14 +40,12 @@ set of installed packages and their versions matches the snapshot exactly.
 
 There are three common use cases for \code{restore}:
 \itemize{
-  \item \strong{Hydrate}: Use \code{restore} after copying a project to a new
-machine to populate the library on that machine.
-
-  \item \strong{Sync}: Use \code{restore} to apply library changes made by a
+\item \strong{Hydrate}: Use \code{restore} after copying a project to a new machine
+to populate the library on that machine.
+\item \strong{Sync}: Use \code{restore} to apply library changes made by a
 collaborator to your own library. (In general, you want to run \code{restore}
 whenever you pick up a change to \code{packrat.lock})
-
-  \item \strong{Rollback}: Use \code{restore} to undo accidental changes made
+\item \strong{Rollback}: Use \code{restore} to undo accidental changes made
 to the library since the last snapshot.
 }
 
@@ -55,13 +53,13 @@ to the library since the last snapshot.
 changes are necessary to currently loaded packages, you will need to restart
 \R to apply the changes (\code{restore} will let you know when this is
 necessary). It is recommended that you do this as soon as possible, because
-any library changes made between running \code{restore} and restarting \R will
-be lost.
+any library changes made between running \code{restore} and restarting \R
+will be lost.
 }
 \note{
-\code{restore} can be destructive; it will remove packages that were not in
-the snapshot, and it will replace newer packages with older versions if
-that's what the snapshot indicates. \code{restore} will warn you before
+\code{restore} can be destructive; it will remove packages that were
+not in the snapshot, and it will replace newer packages with older versions
+if that's what the snapshot indicates. \code{restore} will warn you before
 attempting to remove or downgrade a package (if \code{prompt} is
 \code{TRUE}), but will always perform upgrades and new installations without
 prompting.
@@ -69,9 +67,16 @@ prompting.
 \code{restore} works only on the private package library created by packrat;
 if you have other libraries on your path, they will be unaffected.
 
-The \code{restart} parameter will only result in a restart of R when the
-R environment packrat is running within makes available a restart function
-via \code{getOption("restart")}.
+The \code{restart} parameter will only result in a restart of R when the R
+environment packrat is running within makes available a restart function via
+\code{getOption("restart")}.
+
+Packrat selects a \code{tar} binary with the following heuristic: If a \code{TAR}
+environment variable exists, Packrat will use that. Otherwise, it will either
+look for a \code{tar} binary on the \code{PATH} on Unix, or look for the
+system \code{tar} on Windows. If no binary is found in those locations, it
+will use R's internal \code{tar} implementation, which may cause errors with
+long filenames.
 }
 \seealso{
 \code{\link{snapshot}}, the command that creates the snapshots applied with


### PR DESCRIPTION
### Intent

Better document TAR binary discovery heuristic.

### Approach

Added a new paragraph to the `?restore` docs describing the heuristic. Link to `?restore` from the `?bundle` documentation. From a scan of the code, these were the two documented functions that wind up tarring or untarring things — some but not all of which happened automatically when calling `devtools::document()`.

Some reflowing of roxygen comments.