### PR TITLE
Remove reference to unassigned variable from error message

### DIFF
--- a/R/restore.R
+++ b/R/restore.R
@@ -988,7 +988,7 @@ appendRemoteInfoToDescription <- function(src, dest, remote_info) {
   }
 
   if (!file.exists(file.path(basedir, "DESCRIPTION"))) {
-    stop("No DESCRIPTION file was found in the archive for ", pkgRecord$name)
+    stop("Could not locate DESCRIPTION file in package archive.")
   }
 
   # Do what we came here to do.


### PR DESCRIPTION
Previously, an error message in `appendRemoteInfoToDescription` referenced a variable that was out of scope. This small change removes that reference.

The variable was used to add the package reference to the error message. However, this function is only ever called in contexts that already add the package name to the error message, so I didn't think it was necessary to pass in an extra object to obtain that name for the error message.

Fixes #691 

### QA Notes

None needed.