### PR TITLE
Fix gitlab url for subgroups

### DIFF
--- a/R/gitlab.R
+++ b/R/gitlab.R
@@ -71,7 +71,7 @@ gitlabArchiveUrl <- function(pkgRecord) {
   archiveUrl <- sprintf(fmt,
                         pkgRecord$remote_host,
                         pkgRecord$remote_username,
-                        pkgRecord$remote_repo,
+                        sub("/", "%2F", pkgRecord$remote_repo),
                         pkgRecord$remote_sha)
 
   protocol <- if (identical(method, "internal")) "http" else "https"


### PR DESCRIPTION
Another gitlab bug to fix cc: @aronatkins.

This change allow install packages from subgroups. 

Example:
https://gitlab.com/main518/child/skeleton

Minimal reproduce example:
```r
# remotes::install_gitlab("main518/child/skeleton")

library(shiny)
library(skeleton)

ui <- fluidPage(

)

server <- function(input, output) {

}

shinyApp(ui = ui, server = server)

```

The `/` needs to be replace with `%2F` for RemoteRepo.
```r
> packageDescription("skeleton")
Package: skeleton
Title: A skeleton R package.
Version: 1.0.1
Author: Kevin Ushey
Description: Doesn't really do anything.
Depends: R (>= 3.0.1)
License: GPL (>= 2)
Encoding: UTF-8
LazyData: true
RemoteType: gitlab
RemoteHost: gitlab.com
RemoteRepo: child/skeleton
RemoteUsername: main518
RemoteRef: HEAD
RemoteSha: 958296dbbbf7f1d82f7f5dd1b121c7558604809f
NeedsCompilation: no
Packaged: 2023-01-09 13:25:41 UTC; forysa
Built: R 4.0.5; ; 2023-01-09 13:25:41 UTC; unix

-- File: /Library/Frameworks/R.framework/Versions/4.0/Resources/library/skeleton/Meta/package.rds 
```