### PR TITLE
Fix issue adjusting `DESCRIPTION` files for SCM-backed packages in subdirectories of remote repos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Packrat 0.9.1 (UNRELEASED)
 
+- Fix an issue where Packrat would fail to restore packages installed from
+  subdirectories of SCM repositories (GitHub, GitLab, Bitbucket). (#704)
+
 # Packrat 0.9.0
 
 - Packrat now supports restoring packages hosted in private repositories on

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -344,7 +344,8 @@ inferPackageRecord <- function(df, available = availablePackages()) {
       c(remote_repo = as.character(df$RemoteRepo)),
       c(remote_username = as.character(df$RemoteUsername)),
       c(remote_ref = as.character(df$RemoteRef)),
-      c(remote_sha = as.character(df$RemoteSha))
+      c(remote_sha = as.character(df$RemoteSha)),
+      c(remote_subdir = as.character(df$RemoteSubdir))
     ), class = c('packageRecord', 'github')))
   } else if (hasRemoteType(df, "bitbucket")) {
     # It's Bitbucket!

--- a/R/remote-info.R
+++ b/R/remote-info.R
@@ -1,32 +1,34 @@
 getRemoteInfo <- function(pkgRecord) {
   if (pkgRecord$source == "github") {
-    remote_info <- as.data.frame(
-      c(
-        list(
-          RemoteType     = pkgRecord$source,
-          GithubRepo     = pkgRecord$gh_repo,
-          GithubUsername = pkgRecord$gh_username,
-          GithubRef      = pkgRecord$gh_ref,
-          GithubSHA1     = pkgRecord$gh_sha1
-        ),
-        c(GithubSubdir   = pkgRecord$gh_subdir)
-      ),
-      stringsAsFactors = FALSE
+    return(
+      as.data.frame(
+        c(
+          list(
+            RemoteType     = pkgRecord$source,
+            GithubRepo     = pkgRecord$gh_repo,
+            GithubUsername = pkgRecord$gh_username,
+            GithubRef      = pkgRecord$gh_ref,
+            GithubSHA1     = pkgRecord$gh_sha1
+          ),
+          c(GithubSubdir   = pkgRecord$gh_subdir)
+        ), stringsAsFactors = FALSE
+      )
     )
   } else {
-    remote_info <- as.data.frame(
-    c(
-      list(
-        RemoteType     = pkgRecord$source,
-        RemoteHost     = pkgRecord$remote_host,
-        RemoteRepo     = pkgRecord$remote_repo,
-        RemoteUsername = pkgRecord$remote_username,
-        RemoteRef      = pkgRecord$remote_ref,
-        RemoteSha      = pkgRecord$remote_sha
-      ),
-      c(RemoteSubdir = pkgRecord$remote_subdir)
-    ),
-    stringsAsFactors = FALSE
+    return(
+      as.data.frame(
+        c(
+          list(
+            RemoteType     = pkgRecord$source,
+            RemoteHost     = pkgRecord$remote_host,
+            RemoteRepo     = pkgRecord$remote_repo,
+            RemoteUsername = pkgRecord$remote_username,
+            RemoteRef      = pkgRecord$remote_ref,
+            RemoteSha      = pkgRecord$remote_sha
+          ),
+          c(RemoteSubdir = pkgRecord$remote_subdir)
+        ), stringsAsFactors = FALSE
+      )
     )
   }
 }

--- a/R/remote-info.R
+++ b/R/remote-info.R
@@ -10,34 +10,26 @@
 getRemoteInfo <- function(pkgRecord) {
   if (pkgRecord$source == "github") {
     return(
-      as.data.frame(
-        c(
-          list(
-            RemoteType     = pkgRecord$source,
-            GithubRepo     = pkgRecord$gh_repo,
-            GithubUsername = pkgRecord$gh_username,
-            GithubRef      = pkgRecord$gh_ref,
-            GithubSHA1     = pkgRecord$gh_sha1
-          ),
-          c(GithubSubdir   = pkgRecord$gh_subdir)
-        ), stringsAsFactors = FALSE
-      )
+      as.data.frame(as.list(c(
+        RemoteType     = pkgRecord$source,
+        GithubRepo     = pkgRecord$gh_repo,
+        GithubUsername = pkgRecord$gh_username,
+        GithubRef      = pkgRecord$gh_ref,
+        GithubSHA1     = pkgRecord$gh_sha1,
+        GithubSubdir = pkgRecord$gh_subdir
+      )), stringsAsFactors = FALSE)
     )
   } else {
     return(
-      as.data.frame(
-        c(
-          list(
-            RemoteType     = pkgRecord$source,
-            RemoteHost     = pkgRecord$remote_host,
-            RemoteRepo     = pkgRecord$remote_repo,
-            RemoteUsername = pkgRecord$remote_username,
-            RemoteRef      = pkgRecord$remote_ref,
-            RemoteSha      = pkgRecord$remote_sha
-          ),
-          c(RemoteSubdir = pkgRecord$remote_subdir)
-        ), stringsAsFactors = FALSE
-      )
+      as.data.frame(as.list(c(
+        RemoteType     = pkgRecord$source,
+        RemoteHost     = pkgRecord$remote_host,
+        RemoteRepo     = pkgRecord$remote_repo,
+        RemoteUsername = pkgRecord$remote_username,
+        RemoteRef      = pkgRecord$remote_ref,
+        RemoteSha      = pkgRecord$remote_sha,
+        RemoteSubdir = pkgRecord$remote_subdir
+      )), stringsAsFactors = FALSE)
     )
   }
 }

--- a/R/remote-info.R
+++ b/R/remote-info.R
@@ -1,3 +1,12 @@
+# This code is difficult to read and has caused problems in the past. Heed my
+# warning. This so that as.data.frame() is given a list. The *_subdir fields are
+# missing in most cases. If they were included in the main list() calls, list()
+# would include a field with that name with a NULL value.
+#
+# Creating a list and then concatenating the possibly-NULL subdir fields means
+# that they are NULL, they will not appear at all in the resulting list at all.
+# The resulting data frame is later appended to the DESCRIPTION file, so this is
+# desirable.
 getRemoteInfo <- function(pkgRecord) {
   if (pkgRecord$source == "github") {
     return(

--- a/R/remote-info.R
+++ b/R/remote-info.R
@@ -1,0 +1,32 @@
+getRemoteInfo <- function(pkgRecord) {
+  if (pkgRecord$source == "github") {
+    remote_info <- as.data.frame(
+      c(
+        list(
+          RemoteType     = pkgRecord$source,
+          GithubRepo     = pkgRecord$gh_repo,
+          GithubUsername = pkgRecord$gh_username,
+          GithubRef      = pkgRecord$gh_ref,
+          GithubSHA1     = pkgRecord$gh_sha1
+        ),
+        c(GithubSubdir   = pkgRecord$gh_subdir)
+      ),
+      stringsAsFactors = FALSE
+    )
+  } else {
+    remote_info <- as.data.frame(
+    c(
+      list(
+        RemoteType     = pkgRecord$source,
+        RemoteHost     = pkgRecord$remote_host,
+        RemoteRepo     = pkgRecord$remote_repo,
+        RemoteUsername = pkgRecord$remote_username,
+        RemoteRef      = pkgRecord$remote_ref,
+        RemoteSha      = pkgRecord$remote_sha
+      ),
+      c(RemoteSubdir = pkgRecord$remote_subdir)
+    ),
+    stringsAsFactors = FALSE
+    )
+  }
+}

--- a/R/restore.R
+++ b/R/restore.R
@@ -242,17 +242,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       stop(e)
     })
 
-    remote_info <- as.data.frame(
-      list(
-        RemoteType     = pkgRecord$source,
-        GithubRepo     = pkgRecord$gh_repo,
-        GithubUsername = pkgRecord$gh_username,
-        GithubRef      = pkgRecord$gh_ref,
-        GithubSHA1     = pkgRecord$gh_sha1
-      ),
-      c(GithubSubdir   = pkgRecord$gh_subdir),
-      stringsAsFactors = FALSE
-    )
+    remote_info <- getRemoteInfo(pkgRecord)
 
     dest <- normalizePath(file.path(pkgSrcDir, pkgSrcFile), winslash = "/", mustWork = FALSE)
 
@@ -287,19 +277,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       stop(e)
     })
 
-    # Modify remote info, move modified package to new location
-    remote_info <- as.data.frame(
-      list(
-        RemoteType = pkgRecord$source,
-        RemoteHost = pkgRecord$remote_host,
-        RemoteRepo = pkgRecord$remote_repo,
-        RemoteUsername = pkgRecord$remote_username,
-        RemoteRef = pkgRecord$remote_ref,
-        RemoteSha = pkgRecord$remote_sha
-      ),
-      c(RemoteSubdir = pkgRecord$remote_subdir),
-      stringsAsFactors = FALSE
-    )
+    remote_info <- getRemoteInfo(pkgRecord)
 
     dest <- normalizePath(file.path(pkgSrcDir, pkgSrcFile), winslash = "/", mustWork = FALSE)
 
@@ -335,19 +313,7 @@ getSourceForPkgRecord <- function(pkgRecord,
       stop(e)
     })
 
-    # Modify remote info, move modified package to new location
-    remote_info <- as.data.frame(
-      list(
-        RemoteType = pkgRecord$source,
-        RemoteHost = pkgRecord$remote_host,
-        RemoteRepo = pkgRecord$remote_repo,
-        RemoteUsername = pkgRecord$remote_username,
-        RemoteRef = pkgRecord$remote_ref,
-        RemoteSha = pkgRecord$remote_sha
-      ),
-      c(RemoteSubdir = pkgRecord$remote_subdir),
-      stringsAsFactors = FALSE
-    )
+    remote_info <- getRemoteInfo(pkgRecord)
 
     dest <- normalizePath(file.path(pkgSrcDir, pkgSrcFile), winslash = "/", mustWork = FALSE)
 

--- a/tests/testthat/_snaps/pkg.md
+++ b/tests/testthat/_snaps/pkg.md
@@ -1,0 +1,161 @@
+# inferPackageRecord preserves fields: GitHub
+
+    Code
+      inferPackageRecord(df)
+    Output
+      $name
+      [1] "pkg"
+      
+      $source
+      [1] "github"
+      
+      $version
+      [1] "0.1.0"
+      
+      $gh_repo
+      [1] "plain_ol_pkg"
+      
+      $gh_username
+      [1] "my-github-username"
+      
+      $gh_ref
+      [1] "HEAD"
+      
+      $gh_sha1
+      [1] "abc123"
+      
+      $remote_host
+      [1] "api.github.com"
+      
+      $remote_repo
+      [1] "plain_ol_pkg"
+      
+      $remote_username
+      [1] "my-github-username"
+      
+      $remote_ref
+      [1] "HEAD"
+      
+      $remote_sha
+      [1] "abc123"
+      
+      attr(,"class")
+      [1] "packageRecord" "github"       
+
+# inferPackageRecord preserves fields: GitHub, pkg in subdir
+
+    Code
+      inferPackageRecord(df)
+    Output
+      $name
+      [1] "pkginsubdir"
+      
+      $source
+      [1] "github"
+      
+      $version
+      [1] "0.1.0"
+      
+      $gh_repo
+      [1] "pkg_in_subdir"
+      
+      $gh_username
+      [1] "my-github-username"
+      
+      $gh_ref
+      [1] "HEAD"
+      
+      $gh_sha1
+      [1] "abc123"
+      
+      $gh_subdir
+      [1] "pkginsubdir"
+      
+      $remote_host
+      [1] "api.github.com"
+      
+      $remote_repo
+      [1] "pkg_in_subdir"
+      
+      $remote_username
+      [1] "my-github-username"
+      
+      $remote_ref
+      [1] "HEAD"
+      
+      $remote_sha
+      [1] "abc123"
+      
+      $remote_subdir
+      [1] "pkginsubdir"
+      
+      attr(,"class")
+      [1] "packageRecord" "github"       
+
+# inferPackageRecord preserves fields: GitLab
+
+    Code
+      inferPackageRecord(df)
+    Output
+      $name
+      [1] "pkg"
+      
+      $source
+      [1] "gitlab"
+      
+      $version
+      [1] "0.1.0"
+      
+      $remote_repo
+      [1] "plain_ol_pkg"
+      
+      $remote_username
+      [1] "my-gitlab-username"
+      
+      $remote_ref
+      [1] "HEAD"
+      
+      $remote_sha
+      [1] "abc123"
+      
+      $remote_host
+      [1] "gitlab.com"
+      
+      attr(,"class")
+      [1] "packageRecord" "gitlab"       
+
+# inferPackageRecord preserves fields: GitLab, pkg in subdir
+
+    Code
+      inferPackageRecord(df)
+    Output
+      $name
+      [1] "pkginsubdir"
+      
+      $source
+      [1] "gitlab"
+      
+      $version
+      [1] "0.1.0"
+      
+      $remote_repo
+      [1] "pkg_in_subdir"
+      
+      $remote_username
+      [1] "my-gitlab-username"
+      
+      $remote_ref
+      [1] "HEAD"
+      
+      $remote_sha
+      [1] "abc123"
+      
+      $remote_host
+      [1] "gitlab.com"
+      
+      $remote_subdir
+      [1] "pkginsubdir"
+      
+      attr(,"class")
+      [1] "packageRecord" "gitlab"       
+

--- a/tests/testthat/resources/descriptions/github
+++ b/tests/testthat/resources/descriptions/github
@@ -1,0 +1,23 @@
+Package: pkg
+Type: Package
+Title: Plain Old Package
+Version: 0.1.0
+Author: Toph Allen <toph.allen@gmail.com>
+Maintainer: Toph Allen <toph.allen@gmail.com>
+Description: This package is at the top level of its directory structure
+License: MIT
+Encoding: UTF-8
+RoxygenNote: 7.1.2
+RemoteType: github
+RemoteHost: api.github.com
+RemoteRepo: plain_ol_pkg
+RemoteUsername: my-github-username
+RemoteRef: HEAD
+RemoteSha: abc123
+GithubRepo: plain_ol_pkg
+GithubUsername: my-github-username
+GithubRef: HEAD
+GithubSHA1: abc123
+NeedsCompilation: no
+Packaged: 2023-02-22 17:15:10 UTC; root
+Built: R 4.2.1; ; 2023-02-22 17:15:10 UTC; unix

--- a/tests/testthat/resources/descriptions/github_subdir
+++ b/tests/testthat/resources/descriptions/github_subdir
@@ -1,0 +1,25 @@
+Package: pkginsubdir
+Type: Package
+Title: Package In Subdirectory
+Version: 0.1.0
+Author: Toph Allen <toph.allen@gmail.com>
+Maintainer: Toph Allen <toph.allen@gmail.com>
+Description: This package lives in a subdirectory
+License: MIT
+Encoding: UTF-8
+RoxygenNote: 7.1.2
+RemoteType: github
+RemoteHost: api.github.com
+RemoteRepo: pkg_in_subdir
+RemoteUsername: my-github-username
+RemoteRef: HEAD
+RemoteSha: abc123
+RemoteSubdir: pkginsubdir
+GithubRepo: pkg_in_subdir
+GithubUsername: my-github-username
+GithubRef: HEAD
+GithubSHA1: abc123
+GithubSubdir: pkginsubdir
+NeedsCompilation: no
+Packaged: 2023-02-22 17:15:10 UTC; root
+Built: R 4.2.1; ; 2023-02-22 17:15:10 UTC; unix

--- a/tests/testthat/resources/descriptions/gitlab
+++ b/tests/testthat/resources/descriptions/gitlab
@@ -1,0 +1,19 @@
+Package: pkg
+Type: Package
+Title: Plain Old Package
+Version: 0.1.0
+Author: Toph Allen <toph.allen@gmail.com>
+Maintainer: Toph Allen <toph.allen@gmail.com>
+Description: This package is at the top level of its directory structure
+License: MIT
+Encoding: UTF-8
+RoxygenNote: 7.1.2
+RemoteType: gitlab
+RemoteHost: gitlab.com
+RemoteRepo: plain_ol_pkg
+RemoteUsername: my-gitlab-username
+RemoteRef: HEAD
+RemoteSha: abc123
+NeedsCompilation: no
+Packaged: 2023-02-22 17:15:10 UTC; root
+Built: R 4.2.1; ; 2023-02-22 17:15:10 UTC; unix

--- a/tests/testthat/resources/descriptions/gitlab_subdir
+++ b/tests/testthat/resources/descriptions/gitlab_subdir
@@ -1,0 +1,20 @@
+Package: pkginsubdir
+Type: Package
+Title: Package In Subdirectory
+Version: 0.1.0
+Author: Toph Allen <toph.allen@gmail.com>
+Maintainer: Toph Allen <toph.allen@gmail.com>
+Description: This package lives in a subdirectory
+License: MIT
+Encoding: UTF-8
+RoxygenNote: 7.1.2
+RemoteType: gitlab
+RemoteHost: gitlab.com
+RemoteRepo: pkg_in_subdir
+RemoteUsername: my-gitlab-username
+RemoteRef: HEAD
+RemoteSha: abc123
+RemoteSubdir: pkginsubdir
+NeedsCompilation: no
+Packaged: 2023-02-22 17:15:10 UTC; root
+Built: R 4.2.1; ; 2023-02-22 17:15:10 UTC; unix

--- a/tests/testthat/test-pkg.R
+++ b/tests/testthat/test-pkg.R
@@ -21,4 +21,3 @@ test_that("inferPackageRecord preserves fields: GitLab, pkg in subdir", {
   df <- as.data.frame(readDcf(test_path("resources/descriptions/gitlab_subdir")))
   expect_snapshot(inferPackageRecord(df))
 })
-

--- a/tests/testthat/test-pkg.R
+++ b/tests/testthat/test-pkg.R
@@ -1,0 +1,24 @@
+test_that("inferPackageRecord preserves fields: GitHub", {
+  # GitHub with no subdir.
+  df <- as.data.frame(readDcf(test_path("resources/descriptions/github")))
+  expect_snapshot(inferPackageRecord(df))
+})
+
+test_that("inferPackageRecord preserves fields: GitHub, pkg in subdir", {
+  # GitHub with subdir.
+  df <- as.data.frame(readDcf(test_path("resources/descriptions/github_subdir")))
+  expect_snapshot(inferPackageRecord(df))
+})
+
+test_that("inferPackageRecord preserves fields: GitLab", {
+  # GitLab with no subdir.
+  df <- as.data.frame(readDcf(test_path("resources/descriptions/gitlab")))
+  expect_snapshot(inferPackageRecord(df))
+})
+
+test_that("inferPackageRecord preserves fields: GitLab, pkg in subdir", {
+  # GitLab with subdir.
+  df <- as.data.frame(readDcf(test_path("resources/descriptions/gitlab_subdir")))
+  expect_snapshot(inferPackageRecord(df))
+})
+

--- a/tests/testthat/test-remote-info.R
+++ b/tests/testthat/test-remote-info.R
@@ -52,7 +52,7 @@ test_that("remote_info is correctly generated from a GitLab pkgRecord", {
     remote_repo = 'adder',
     remote_username = 'my-username',
     remote_ref = 'HEAD',
-    remote_sha1 = 'abc123'
+    remote_sha = 'abc123'
   )
   expected <- data.frame(
     RemoteType = "gitlab",
@@ -75,7 +75,7 @@ test_that("remote_info is correctly generated from a GitLab pkgRecord with a sub
     remote_repo = 'sub_adder',
     remote_username = 'my-username',
     remote_ref = 'HEAD',
-    remote_sha1 = 'abc123',
+    remote_sha = 'abc123',
     remote_subdir = 'subadder'
   )
   expected <- data.frame(

--- a/tests/testthat/test-remote-info.R
+++ b/tests/testthat/test-remote-info.R
@@ -1,0 +1,92 @@
+test_that("remote_info is correctly generated from a GitHub pkgRecord", {
+  pkgRecordGithub <- list(
+    name = 'adder',
+    source = 'github',
+    version = '0.9.3.1',
+    gh_repo = 'adder',
+    gh_username = 'my-username',
+    gh_ref = 'HEAD',
+    gh_sha1 = 'abc123'
+  )
+  expected <- data.frame(
+    RemoteType = "github",
+    GithubRepo = "adder",
+    GithubUsername = "my-username",
+    GithubRef = "HEAD",
+    GithubSHA1 = "abc123",
+    stringsAsFactors = FALSE
+  )
+  expect_identical(getRemoteInfo(pkgRecordGithub), expected)
+})
+
+test_that("remote_info is correctly generated from a GitHub pkgRecord with a subdirectory", {
+  pkgRecordGithubSubdir <- list(
+    name = 'subadder',
+    source = 'github',
+    version = '0.9.3.1',
+    gh_repo = 'sub_adder',
+    gh_username = 'my-username',
+    gh_ref = 'HEAD',
+    gh_sha1 = 'abc123',
+    gh_subdir = 'subadder'
+  )
+  expected <- data.frame(
+    RemoteType     = "github",
+    GithubRepo     = "sub_adder",
+    GithubUsername = "my-username",
+    GithubRef      = "HEAD",
+    GithubSHA1     = "abc123",
+    GithubSubdir   = "subadder",
+    stringsAsFactors = FALSE
+  )
+  expect_identical(getRemoteInfo(pkgRecordGithubSubdir), expected)
+})
+
+# GitLab package records will work for Bitbucket too
+test_that("remote_info is correctly generated from a GitLab pkgRecord", {
+  pkgRecordGitlab <- list(
+    name = 'adder',
+    source = 'gitlab',
+    version = '0.9.3.1',
+    remote_host = 'gitlab.com',
+    remote_repo = 'adder',
+    remote_username = 'my-username',
+    remote_ref = 'HEAD',
+    remote_sha1 = 'abc123'
+  )
+  expected <- data.frame(
+    RemoteType = "gitlab",
+    RemoteHost = "gitlab.com",
+    RemoteRepo = "adder",
+    RemoteUsername = "my-username",
+    RemoteRef = "HEAD",
+    RemoteSha = "abc123",
+    stringsAsFactors = FALSE
+  )
+  expect_identical(getRemoteInfo(pkgRecordGitlab), expected)
+})
+
+test_that("remote_info is correctly generated from a GitLab pkgRecord with a subdirectory", {
+  pkgRecordGitlabSubdir <- list(
+    name = 'subadder',
+    source = 'gitlab',
+    version = '0.9.3.1',
+    remote_host = 'gitlab.com',
+    remote_repo = 'sub_adder',
+    remote_username = 'my-username',
+    remote_ref = 'HEAD',
+    remote_sha1 = 'abc123',
+    remote_subdir = 'subadder'
+  )
+  expected <- data.frame(
+    RemoteType = "gitlab",
+    RemoteHost = "gitlab.com",
+    RemoteRepo = "sub_adder",
+    RemoteUsername = "my-username",
+    RemoteRef = "HEAD",
+    RemoteSha = "abc123",
+    RemoteSubdir = "subadder",
+    stringsAsFactors = FALSE
+  )
+  expect_identical(getRemoteInfo(pkgRecordGitlabSubdir), expected)
+})


### PR DESCRIPTION
### Intent

Fix an issue where Packrat would fail to restore packages from subdirectories of repositories.

### Approach

There were a few complex nested calls to `as.data.frame()`, `c()`, and `list()` spread across `getSourceForPkgRecord()` that I attempted to simplify in an earlier update. I simplified them incorrectly, causing `subdir` properties to be dropped.

Because we don't have end-to-end tests set up, and this transformation was part of a long function, no tests caught the issue. I moved the transformations into their own function and added unit tests.

Stepping back, this problem stems from the overall complexity of Packrat's workflows. This solution does not directly address the complexity. It adds a bit of indirection to make the outer-level workflow clearer, but it doesn't reduce the overall complexity of the data flows in the restore process.

### QA Notes

End-to-end validation should involve restoring a Packrat environment that contains a package in a subdirectory. I have already tested that myself, and I'll walk through it with the package's maintainers before this merges.