### PR TITLE
Immediately warn about differing R version

### DIFF
--- a/R/packrat.R
+++ b/R/packrat.R
@@ -386,8 +386,10 @@ restore <- function(project = NULL,
   packages <- lockInfo(project)
   r_version <- lockInfo(project, 'r_version')
   if (!identical(as.character(getRversion()), r_version)) {
-    warning('The most recent snapshot was generated using R version ',
-            r_version)
+    warning(
+      'The most recent snapshot was generated using R version ', r_version,
+      immediate. = TRUE
+    )
   }
 
   # See if any of the packages that are currently in the library are dirty.


### PR DESCRIPTION
This ensures that the warning message doesn't print after the error if restore fails. Currently the connect log looks like this:

```
Error in (function (..., row.names = NULL, check.rows = FALSE, check.names = TRUE, : arguments imply differing number of rows: 1, 0

Unable to fully restore the R packages associated with this deployment.
Please review the preceding messages to determine which package
encountered installation difficulty and the cause of the failure.
Warning message:
In packrat::restore(overwrite.dirty = TRUE, prompt = FALSE, restart = FALSE) :
  The most recent snapshot was generated using R version 4.2.1
```