### PR TITLE
binary package validation (via renv)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 # Packrat 0.9.2 (UNRELEASED)
 
-- Update vendored `renv` update to include functions for normalizing and
+- Update vendored `renv` package to include functions for normalizing and
   transforming Posit Package Manager URLs. (#711)
+- Perform a test-load when installing from binary packages. Includes an `renv`
+  update. (#712)
 
 # Packrat 0.9.1
 

--- a/R/renv.R
+++ b/R/renv.R
@@ -1,7 +1,7 @@
 
 #
 # renv 0.17.3-84: A dependency management toolkit for R.
-# Generated using `renv:::vendor()` at 2023-06-12 09:09:27.
+# Generated using `renv:::vendor()` at 2023-06-13 09:06:36.
 #
 
 
@@ -16,7 +16,7 @@ renv$initialize <- function() {
   # set up metadata environment
   metadata <- list(
     embedded = TRUE,
-    version  = "1a0dd23ff61f7e0d2a3dc7a6e7b7e36a4b6c5de0"
+    version  = "0.17.3-84"
   )
 
   # assign into renv

--- a/R/renv.R
+++ b/R/renv.R
@@ -1,7 +1,7 @@
 
 #
-# renv 0.17.3-84: A dependency management toolkit for R.
-# Generated using `renv:::vendor()` at 2023-06-13 09:06:36.
+# renv 0.17.3-87: A dependency management toolkit for R.
+# Generated using `renv:::vendor()` at 2023-06-15 08:36:20.082574.
 #
 
 
@@ -13,17 +13,14 @@ renv$initialize <- function() {
   attr(renv, "name") <- "embedded:renv"
   attr(parent.env(renv), "name") <- "imports:renv"
 
-  # set up metadata environment
-  metadata <- list(
-    embedded = TRUE,
-    version  = "0.17.3-84"
-  )
-
-  # assign into renv
-  assign("_renv_metadata", as.environment(metadata), envir = renv)
-
   # get imports
   imports <- list(
+    tools = c(
+      "file_ext",
+      "pskill",
+      "psnice",
+      "write_PACKAGES"
+    ),
     utils = c(
       "Rprof",
       "URLencode",
@@ -69,6 +66,12 @@ renv$initialize <- function() {
   # source renv into the aforementioned environment
   script <- system.file("vendor/renv.R", package = .packageName)
   sys.source(script, envir = renv)
+
+  # set up metadata environment
+  renv$the$metadata <- as.environment(list(embedded = TRUE, version = "0.17.3-87", sha = "c485f5e8719752b0a7683a90b2cf3b1c44372f6e"))
+
+  # run our load / attach hooks so internal state is initialized
+  renv$renv_zzz_load()
 
   # remove our initialize method when we're done
   rm(list = "initialize", envir = renv)

--- a/R/renv.R
+++ b/R/renv.R
@@ -1,7 +1,7 @@
 
 #
-# renv 0.17.3-62: A dependency management toolkit for R.
-# Generated using `renv:::vendor()` at 2023-06-05 17:36:24.
+# renv 0.17.3-84: A dependency management toolkit for R.
+# Generated using `renv:::vendor()` at 2023-06-12 09:09:27.
 #
 
 
@@ -16,7 +16,7 @@ renv$initialize <- function() {
   # set up metadata environment
   metadata <- list(
     embedded = TRUE,
-    version  = "0.17.3-62"
+    version  = "1a0dd23ff61f7e0d2a3dc7a6e7b7e36a4b6c5de0"
   )
 
   # assign into renv

--- a/R/restore.R
+++ b/R/restore.R
@@ -584,6 +584,16 @@ installPkg <- function(pkgRecord,
       quiet <- isTRUE(packrat::opts$quiet.package.installation())
       install_local_path(path = pkgSrc, reload = FALSE,
                          dependencies = FALSE, quick = TRUE, quiet = quiet)
+      # if we just installed a binary package, check that it can be loaded
+      # (source packages are checked by default on install)
+      if (identical(pkgType, "binary")) {
+        status <- renv$catch(renv$renv_install_test(pkgRecord$name))
+        if (inherits(status, "error")) {
+          message("FAILED")
+          unlink(pkgInstallPath, recursive = TRUE)
+          stop(status)
+        }
+      }
     })
   }
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -591,7 +591,7 @@ installPkg <- function(pkgRecord,
         if (inherits(status, "error")) {
           message("FAILED")
           unlink(pkgInstallPath, recursive = TRUE)
-          stop(status)
+          renv$abort(status)
         }
       }
     })

--- a/inst/vendor/renv.R
+++ b/inst/vendor/renv.R
@@ -1,14 +1,14 @@
 #
-# renv 0.17.3-62: A dependency management toolkit for R.
-# Generated using `renv:::vendor()` at 2023-06-05 17:36:24.
+# renv 0.17.3-84: A dependency management toolkit for R.
+# Generated using `renv:::vendor()` at 2023-06-12 09:09:27.
 #
 
-# aaa.R ======================================================================
+# aaa.R ----------------------------------------------------------------------
 
 
 
 
-# abi.R ======================================================================
+# abi.R ----------------------------------------------------------------------
 
 
 renv_abi_check <- function(packages = NULL,
@@ -66,8 +66,7 @@ renv_abi_check <- function(packages = NULL,
           "however, Rcpp", renv_package_version("Rcpp"), "is currently installed."
         ),
         "Consider installing a new version of Rcpp with 'install.packages(\"Rcpp\")'."
-      ),
-      wrap = FALSE
+      )
     )
   }
 
@@ -180,7 +179,7 @@ renv_abi_packages <- function(project, libpaths) {
 }
 
 
-# acls.R =====================================================================
+# acls.R ---------------------------------------------------------------------
 
 
 renv_acls_reset <- function(source, target = dirname(source)) {
@@ -211,7 +210,7 @@ renv_acls_reset <- function(source, target = dirname(source)) {
 }
 
 
-# actions.R ==================================================================
+# actions.R ------------------------------------------------------------------
 
 
 actions <- function(action = c("snapshot", "restore"),
@@ -328,10 +327,10 @@ renv_actions_restore_clean <- function(actions, clean, project) {
 }
 
 
-# activate.R =================================================================
+# activate.R -----------------------------------------------------------------
 
 
-#' Activate or Deactivate a Project
+#' Activate or deactivate a project
 #'
 #' @description
 #' `activate()` enables renv for a project in both the current session and
@@ -346,8 +345,14 @@ renv_actions_restore_clean <- function(actions, clean, project) {
 #' project library for the current session.
 #'
 #' `deactivate()` removes the infrastructure automatically activate renv in
-#' new session. This removes the auto-loader from the `.Rprofile`; it does
-#' not delete the lockfile or the project library.
+#' new session. By default it will remove the auto-loader from the `.Rprofile`;
+#' use `clean = TRUE` to also delete the lockfile and the project library.
+#'
+#' # Temporary deactivation
+#'
+#' If you need to temporarily disable autoload activation you can set
+#' the `RENV_CONFIG_AUTOLOADER_ENABLED` envvar, e.g.
+#' `Sys.setenv(RENV_CONFIG_AUTOLOADER_ENABLED = "false")`.
 #'
 #' @inherit renv-params
 #'
@@ -456,7 +461,9 @@ renv_activate_version_lockfile <- function(project) {
     return(NULL)
 
   lockfile <- renv_lockfile_read(path)
-  lockfile$Packages[["renv"]]$Version %||% lockfile[["renv"]]$Version
+  lockfile$Packages[["renv"]]$RemoteSha %||%
+    lockfile$Packages[["renv"]]$Version %||%
+    lockfile[["renv"]]$Version
 
 }
 
@@ -472,9 +479,10 @@ renv_activate_prompt <- function(action, library, prompt, project) {
     prompt &&
     interactive() &&
     is.null(library) &&
-    !renv_project_loaded(project)
+    !renv_project_loaded(project) &&
+    !is_testing()
 
-  # for snapshot, since users might want to snapshot their global library
+  # for snapshot, since users might want to snapshot their system library
   # in an renv-lite configuration, only prompt if it looks like they're
   # working within an renv project that hasn't been loaded
   if ("snapshot" %in% action) {
@@ -485,30 +493,35 @@ renv_activate_prompt <- function(action, library, prompt, project) {
   if (!ask)
     return(FALSE)
 
-  fmt <- lines(
-    "",
-    "This project has not yet been activated.",
-    "Activating this project will ensure the project library is used when %s() is called.",
-    "Please see `?renv::activate` for more details.",
-    ""
-  )
+  renv_activate_prompt_impl(action, project)
 
-  notice <- sprintf(fmt, action)
-  vwritef(notice)
-
-  fmt <- "Would you like to activate this project before %s() is called?"
-  question <- sprintf(fmt, action)
-  response <- ask(question, default = TRUE)
-  if (!response)
-    return(FALSE)
-
-  activate(project = project)
-  return(TRUE)
 
 }
 
+renv_activate_prompt_impl <- function(action, project = NULL) {
+  title <- c(
+    sprintf(
+      "It looks like you've called renv::%s() in a project that hasn't been activated yet",
+      action
+    ),
+    "How would you like to proceed?"
+  )
+  choices <- c(
+    activate = "Activate the project and use the project library.",
+    continue = "Do not activate the project and use the current library paths.",
+    cancel = "Cancel and resolve the situation another way."
+  )
 
-# addins.R ===================================================================
+  choice <- menu(choices, title, default = "continue")
+  switch(choice,
+    activate = { activate(project = project); TRUE },
+    continue = FALSE,
+    cancel = cancel(),
+  )
+}
+
+
+# addins.R -------------------------------------------------------------------
 
 
 renv_addins_embed_ui <- function() {
@@ -596,7 +609,7 @@ renv_addins_embed <- function() {
 
 
 
-# aliases.R ==================================================================
+# aliases.R ------------------------------------------------------------------
 
 
 # aliases used primarily for nicer / normalized text output
@@ -621,7 +634,7 @@ alias <- function(text) {
 }
 
 
-# archive.R ==================================================================
+# archive.R ------------------------------------------------------------------
 
 
 renv_archive_type <- function(archive) {
@@ -688,8 +701,7 @@ renv_archive_decompress_zip <- function(archive, files = NULL, exdir = ".", ...)
 
   if (inherits(status, "condition")) {
     fmt <- "failed to decompress '%s' [%s]"
-    message <- sprintf(fmt, basename(archive), conditionMessage(status))
-    stop(simpleError(message))
+    stopf(fmt, basename(archive), conditionMessage(status))
   }
 
   TRUE
@@ -742,10 +754,10 @@ renv_archive_read_zip <- function(archive, file) {
 }
 
 
-# autoload.R =================================================================
+# autoload.R -----------------------------------------------------------------
 
 
-#' Auto-load the Active Project
+#' Auto-load the active project
 #'
 #' Automatically load the renv project associated with a particular directory.
 #' renv will search parent directories for the renv project root; if found,
@@ -783,7 +795,7 @@ renv_autoload_impl <- function() {
 
   # check if we're disabled
   enabled <- Sys.getenv("RENV_AUTOLOAD_ENABLED", unset = "TRUE")
-  if (falsy(enabled, FALSE))
+  if (truthy(enabled))
     return(FALSE)
 
   # bail if load is already being called
@@ -805,8 +817,7 @@ renv_autoload_impl <- function() {
     return(FALSE)
 
   # move to project directory
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
 
   # if we have a project profile, source it
   profile <- file.path(project, ".Rprofile")
@@ -829,7 +840,7 @@ renv_autoload_impl <- function() {
 }
 
 
-# available-packages.R =======================================================
+# available-packages.R -------------------------------------------------------
 
 
 # tools for querying information about packages available on CRAN.
@@ -845,7 +856,7 @@ available_packages <- function(type,
 
     key = list(
       type = type,
-      repos = repos %??% getOption("repos"),
+      repos = repos %||% getOption("repos"),
       cellar = cellar
     ),
 
@@ -867,7 +878,7 @@ renv_available_packages_impl <- function(type,
                                          cellar = FALSE)
 {
   limit <- limit %||% Sys.getenv("R_AVAILABLE_PACKAGES_CACHE_CONTROL_MAX_AGE", "3600")
-  repos <- renv_repos_normalize(repos %??% getOption("repos"))
+  repos <- renv_repos_normalize(repos %||% getOption("repos"))
 
   # invalidate cache if http_proxy or https_proxy environment variables change,
   # since those could effect (or even re-direct?) repository URLs
@@ -900,7 +911,7 @@ renv_available_packages_query <- function(type, repos, quiet = FALSE) {
     renv_scope_options(renv.verbose = FALSE)
 
   fmt <- "* Querying repositories for available %s packages ... "
-  vprintf(fmt, type)
+  printf(fmt, type)
 
   # exclude repositories which are known to not have packages available
   if (type == "binary") {
@@ -915,7 +926,7 @@ renv_available_packages_query <- function(type, repos, quiet = FALSE) {
   names(dbs) <- names(repos)
 
   # notify finished
-  vwritef("Done!")
+  writef("Done!")
 
   # propagate errors
   errors <- as.list(errors)
@@ -939,21 +950,24 @@ renv_available_packages_query <- function(type, repos, quiet = FALSE) {
 
 renv_available_packages_query_impl_packages_rds <- function(url) {
   path <- file.path(url, "PACKAGES.rds")
-  destfile <- tempfile("renv-packages-", fileext = ".rds")
+  destfile <- renv_scope_tempfile("renv-packages-", fileext = ".rds")
+
   download(url = path, destfile = destfile, quiet = TRUE)
   suppressWarnings(readRDS(destfile))
 }
 
 renv_available_packages_query_impl_packages_gz <- function(url) {
   path <- file.path(url, "PACKAGES.gz")
-  destfile <- tempfile("renv-packages-", fileext = ".gz")
+  destfile <- renv_scope_tempfile("renv-packages-", fileext = ".gz")
+
   download(url = path, destfile = destfile, quiet = TRUE)
   suppressWarnings(read.dcf(destfile))
 }
 
 renv_available_packages_query_impl_packages <- function(url) {
   path <- file.path(url, "PACKAGES")
-  destfile <- tempfile("renv-packages-")
+  destfile <- renv_scope_tempfile("renv-packages-")
+
   download(url = path, destfile = destfile, quiet = TRUE)
   suppressWarnings(read.dcf(destfile))
 }
@@ -1328,8 +1342,8 @@ renv_available_packages_latest_repos <- function(package,
                                                  type = NULL,
                                                  repos = NULL)
 {
-  type  <- type %??% getOption("pkgType")
-  repos <- repos %??% getOption("repos")
+  type  <- type %||% getOption("pkgType")
+  repos <- repos %||% getOption("repos")
 
   # detect requests for only source packages
   if (identical(type, "source"))
@@ -1532,7 +1546,7 @@ renv_available_packages_flatten <- function(dbs) {
 }
 
 
-# backports.R ================================================================
+# backports.R ----------------------------------------------------------------
 
 
 if (is.null(.BaseNamespaceEnv$dir.exists)) {
@@ -1553,7 +1567,7 @@ if (is.null(.BaseNamespaceEnv$lengths)) {
 }
 
 
-# base64.R ===================================================================
+# base64.R -------------------------------------------------------------------
 
 
 `_renv_base64_table` <- as.integer(charToRaw("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="))
@@ -1643,13 +1657,14 @@ renv_base64_encode <- function(text) {
 
 }
 
+`_renv_base64_decode_table` <- NULL
 renv_base64_decode_table <- function() {
-  global("base64.decode.table", {
+  `_renv_base64_decode_table` <<- `_renv_base64_decode_table` %||% {
     table <- integer(255)
     text <- "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
     table[utf8ToInt(text)] <- seq_len(nchar(text)) - 1L
     table
-  })
+  }
 }
 
 renv_base64_decode_main <- function(input) {
@@ -1718,7 +1733,7 @@ renv_base64_decode <- function(encoded) {
 }
 
 
-# bind.R =====================================================================
+# bind.R ---------------------------------------------------------------------
 
 
 bind <- function(data, names = NULL, index = "Index") {
@@ -1797,7 +1812,7 @@ bind <- function(data, names = NULL, index = "Index") {
 
 
 
-# binding.R ==================================================================
+# binding.R ------------------------------------------------------------------
 
 
 renv_binding_init <- function(...) {
@@ -1839,7 +1854,7 @@ renv_binding_replace <- function(symbol, replacement, envir) {
 }
 
 
-# bioconductor.R =============================================================
+# bioconductor.R -------------------------------------------------------------
 
 
 renv_bioconductor_init <- function(library = NULL) {
@@ -1859,7 +1874,7 @@ renv_bioconductor_init_biocmanager <- function(library = NULL) {
     return(TRUE)
 
   ensure_directory(library)
-  install("BiocManager", library = library)
+  install("BiocManager", library = library, prompt = FALSE)
   TRUE
 
 }
@@ -1874,8 +1889,7 @@ renv_bioconductor_init_biocinstaller <- function(library = NULL) {
     return(TRUE)
 
   url <- "https://bioconductor.org/biocLite.R"
-  destfile <- tempfile("renv-bioclite-", fileext = ".R")
-  defer(unlink(destfile))
+  destfile <- renv_scope_tempfile("renv-bioclite-", fileext = ".R")
   download(url, destfile = destfile, quiet = TRUE)
 
   ensure_directory(library)
@@ -1967,14 +1981,14 @@ renv_bioconductor_repos_biocinstaller <- function(version) {
 }
 
 
-# bootstrap.R ================================================================
+# bootstrap.R ----------------------------------------------------------------
 
 
-`%||%` <- function(x, y) {
-  if (length(x)) x else y
+startswith <- function(string, prefix) {
+  substring(string, 1, nchar(prefix)) == prefix
 }
 
-`%??%` <- function(x, y) {
+`%||%` <- function(x, y) {
   if (is.null(x)) y else x
 }
 
@@ -1993,16 +2007,30 @@ catf <- function(fmt, ..., appendLF = TRUE) {
 
 bootstrap <- function(version, library) {
 
+  # load failed; inform user we're about to bootstrap
+  catf("Bootstrapping renv %s:", version)
+
   # attempt to download renv
-  tarball <- tryCatch(renv_bootstrap_download(version), error = identity)
-  if (inherits(tarball, "error"))
-    stop("failed to download renv ", version)
+  withCallingHandlers(
+    tarball <- renv_bootstrap_download(version),
+    error = function(err) {
+      stop("failed to download:\n", conditionMessage(err))
+    }
+  )
+  on.exit(unlink(tarball), add = TRUE)
 
   # now attempt to install
-  status <- tryCatch(renv_bootstrap_install(version, tarball, library), error = identity)
-  if (inherits(status, "error"))
-    stop("failed to install renv ", version)
+  withCallingHandlers(
+    status <- renv_bootstrap_install(version, tarball, library),
+    error = function(err) {
+      stop("failed to install:\n", conditionMessage(err))
+    }
+  )
 
+  # add empty line to break up bootstrapping from normal output
+  catf("\n")
+
+  return(invisible())
 }
 
 renv_bootstrap_tests_running <- function() {
@@ -2031,13 +2059,6 @@ renv_bootstrap_repos <- function() {
   repos <- tryCatch(renv_bootstrap_repos_lockfile(), error = identity)
   if (!inherits(repos, "error") && length(repos))
     return(repos)
-
-  # if we're testing, re-use the test repositories
-  if (renv_bootstrap_tests_running()) {
-    repos <- getOption("renv.tests.repos")
-    if (!is.null(repos))
-      return(repos)
-  }
 
   # retrieve current repos
   repos <- getOption("repos")
@@ -2082,19 +2103,11 @@ renv_bootstrap_repos_lockfile <- function() {
 
 renv_bootstrap_download <- function(version) {
 
-  # if the renv version number has 4 components, assume it must
-  # be retrieved via github
-  nv <- numeric_version(version)
-  components <- unclass(nv)[[1]]
-
-  # if this appears to be a development version of 'renv', we'll
-  # try to restore from github
-  dev <- length(components) == 4L
-
   # begin collecting different methods for finding renv
   methods <- c(
     renv_bootstrap_download_tarball,
-    if (dev)
+    # dev versions can only come from GitHub
+    if (renv_bootstrap_version_is_dev(version))
       renv_bootstrap_download_github
     else c(
       renv_bootstrap_download_cran_latest,
@@ -2108,7 +2121,7 @@ renv_bootstrap_download <- function(version) {
       return(path)
   }
 
-  stop("failed to download renv ", version)
+  stop("All download methods failed")
 
 }
 
@@ -2172,7 +2185,7 @@ renv_bootstrap_download_cran_latest <- function(version) {
   type  <- spec$type
   repos <- spec$repos
 
-  catf("* Downloading renv %s ... ", version, appendLF = FALSE)
+  catf("* Downloading %s from <%s> ... ", type, repos, appendLF = FALSE)
 
   baseurl <- utils::contrib.url(repos = repos, type = type)
   ext <- if (identical(type, "source"))
@@ -2196,7 +2209,7 @@ renv_bootstrap_download_cran_latest <- function(version) {
   }
 
   # report success and return
-  catf("OK (downloaded %s)", type)
+  catf("OK")
   destfile
 
 }
@@ -2253,7 +2266,7 @@ renv_bootstrap_download_cran_archive <- function(version) {
   urls <- file.path(repos, "src/contrib/Archive/renv", name)
   destfile <- file.path(tempdir(), name)
 
-  catf("* Downloading renv %s ... ", version, appendLF = FALSE)
+  catf("* Downloading from archive ... ", appendLF = FALSE)
 
   for (url in urls) {
 
@@ -2301,7 +2314,7 @@ renv_bootstrap_download_tarball <- function(version) {
 
   }
 
-  catf("* Bootstrapping with tarball at path '%s'.", tarball)
+  catf("* Using local tarball '%s'", tarball)
   tarball
 
 }
@@ -2328,7 +2341,7 @@ renv_bootstrap_download_github <- function(version) {
     on.exit(do.call(base::options, saved), add = TRUE)
   }
 
-  catf("* Downloading renv %s from GitHub ... ", version, appendLF = FALSE)
+  catf("* Downloading version %s from GitHub ... ", version, appendLF = FALSE)
 
   url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
   name <- sprintf("renv_%s.tar.gz", version)
@@ -2344,17 +2357,105 @@ renv_bootstrap_download_github <- function(version) {
     return(FALSE)
   }
 
+  renv_bootstrap_download_augment(destfile)
+
   catf("OK")
   return(destfile)
 
 }
 
+# Add Sha to DESCRIPTION. This is stop gap until #890, after which we
+# can use renv::install() to fully capture metadata.
+renv_bootstrap_download_augment <- function(destfile) {
+  sha <- renv_bootstrap_git_extract_sha1_tar(destfile)
+  if (is.null(sha)) {
+    return()
+  }
+
+  # Untar
+  tempdir <- tempfile("renv-github-")
+  on.exit(unlink(tempdir, recursive = TRUE), add = TRUE)
+  untar(destfile, exdir = tempdir)
+  pkgdir <- dir(tempdir, full.names = TRUE)[[1]]
+
+  # Modify description
+  desc_path <- file.path(pkgdir, "DESCRIPTION")
+  desc_lines <- readLines(desc_path)
+  remotes_fields <- c(
+    "RemoteType: github",
+    "RemoteHost: api.github.com",
+    "RemoteRepo: renv",
+    "RemoteUsername: rstudio",
+    "RemotePkgRef: rstudio/renv",
+    paste("RemoteRef: ", sha),
+    paste("RemoteSha: ", sha)
+  )
+  writeLines(c(desc_lines[desc_lines != ""], remotes_fields), con = desc_path)
+
+  # Re-tar
+  local({
+    old <- setwd(tempdir)
+    on.exit(setwd(old), add = TRUE)
+
+    tar(destfile, compression = "gzip")
+  })
+  invisible()
+}
+
+# Extract the commit hash from a git archive. Git archives include the SHA1
+# hash as the comment field of the tarball pax extended header
+# (see https://www.kernel.org/pub/software/scm/git/docs/git-archive.html)
+# For GitHub archives this should be the first header after the default one
+# (512 byte) header.
+renv_bootstrap_git_extract_sha1_tar <- function(bundle) {
+
+  # open the bundle for reading
+  # We use gzcon for everything because (from ?gzcon)
+  # > Reading from a connection which does not supply a ‘gzip’ magic
+  # > header is equivalent to reading from the original connection
+  conn <- gzcon(file(bundle, open = "rb", raw = TRUE))
+  on.exit(close(conn))
+
+  # The default pax header is 512 bytes long and the first pax extended header
+  # with the comment should be 51 bytes long
+  # `52 comment=` (11 chars) + 40 byte SHA1 hash
+  len <- 0x200 + 0x33
+  res <- rawToChar(readBin(conn, "raw", n = len)[0x201:len])
+
+  if (grepl("^52 comment=", res)) {
+    sub("52 comment=", "", res)
+  } else {
+    NULL
+  }
+}
+
 renv_bootstrap_install <- function(version, tarball, library) {
 
   # attempt to install it into project library
-  catf("* Installing renv %s ... ", version, appendLF = FALSE)
+  catf("* Installing ... ", appendLF = FALSE)
   dir.create(library, showWarnings = FALSE, recursive = TRUE)
 
+  output <- renv_bootstrap_install_impl(library, tarball)
+
+  # check for successful install
+  status <- attr(output, "status")
+  if (is.numeric(status) && !identical(status, 0L)) {
+    catf("FAILED")
+
+    header <- "Error installing renv:"
+    lines <- paste(rep.int("=", nchar(header)), collapse = "")
+    text <- c(header, lines, output)
+    writeLines(text, con = stdout())
+    stop("Failed")
+  } else {
+    catf("OK")
+  }
+
+  status
+
+}
+
+renv_bootstrap_install_impl <- function(library, tarball) {
   # invoke using system2 so we can capture and report output
   bin <- R.home("bin")
   exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
@@ -2366,19 +2467,7 @@ renv_bootstrap_install <- function(version, tarball, library) {
     shQuote(path.expand(tarball))
   )
 
-  output <- system2(r, args, stdout = TRUE, stderr = TRUE)
-  catf("Done!")
-
-  # check for successful install
-  status <- attr(output, "status")
-  if (is.numeric(status) && !identical(status, 0L)) {
-    header <- "Error installing renv:"
-    lines <- paste(rep.int("=", nchar(header)), collapse = "")
-    text <- c(header, lines, output)
-    writeLines(text, con = stderr())
-  }
-
-  status
+  system2(r, args, stdout = TRUE, stderr = TRUE)
 
 }
 
@@ -2588,29 +2677,37 @@ renv_bootstrap_library_root_impl <- function(project) {
 
 }
 
-renv_bootstrap_validate_version <- function(version) {
+renv_bootstrap_validate_version <- function(version, description = NULL) {
+  version_is_version <- grepl("[.-]", version)
+  description <- description %||% utils::packageDescription("renv")
 
-  loadedversion <- utils::packageDescription("renv", fields = "Version")
-  if (version == loadedversion)
-    return(TRUE)
+  if (version_is_version) {
+    loaded <- description$Version
+    if (identical(loaded, version)) {
+      return(TRUE)
+    }
+  } else {
+    loaded <- description$RemoteSha
+    if (startswith(loaded, version)) {
+      return(TRUE)
+    }
+  }
 
   # assume four-component versions are from GitHub;
   # three-component versions are from CRAN
-  components <- strsplit(loadedversion, "[.-]")[[1]]
-  remote <- if (length(components) == 4L)
-    paste("rstudio/renv", loadedversion, sep = "@")
-  else
-    paste("renv", loadedversion, sep = "@")
+  remote <- if (renv_bootstrap_version_is_dev(version)) {
+    paste("rstudio/renv", loaded, sep = "@")
+  } else {
+    paste("renv", loaded, sep = "@")
+  }
 
   fmt <- paste(
     "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
-    "Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
-    "Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
+    "* Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
+    "* Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
     sep = "\n"
   )
-
-  msg <- sprintf(fmt, loadedversion, version, remote)
-  warning(msg, call. = FALSE)
+  catf(fmt, loaded, version, remote)
 
   FALSE
 
@@ -2780,9 +2877,20 @@ renv_bootstrap_user_dir_impl <- function() {
 
 }
 
+renv_bootstrap_version_is_dev <- function(version) {
+  # if the renv version number is a sha, or has 4 components, it must
+  # be retrieved via github
+  if (!grepl("[.-]", version)) {
+    # not . or -, so must be a sha
+    TRUE
+  } else {
+    components <- strsplit(version, "[.-]")[[1]]
+    length(components) != 3
+  }
+}
 
 
-# cache.R ====================================================================
+# cache.R --------------------------------------------------------------------
 
 
 # tools for interacting with the renv global package cache
@@ -2948,8 +3056,7 @@ renv_cache_synchronize_impl <- function(cache, record, linkable, path) {
 
   # double-check that the cache is writable
   writable <- local({
-    file <- tempfile("renv-tempfile-", tmpdir = parent)
-    defer(unlink(file, force = TRUE))
+    file <- renv_scope_tempfile("renv-tempfile-", tmpdir = parent)
     status <- catchall(file.create(file))
     file.exists(file)
   })
@@ -2962,8 +3069,7 @@ renv_cache_synchronize_impl <- function(cache, record, linkable, path) {
   defer(restore())
 
   # get ready to copy / move into cache
-  fmt <- "%s %s [%s] into the cache ..."
-  vwritef(fmt, if (linkable) "Moving" else "Copying", record$Package, record$Version)
+  renv_install_step_start("Caching", record$Package)
 
   before <- Sys.time()
 
@@ -3015,8 +3121,10 @@ renv_cache_synchronize_impl <- function(cache, record, linkable, path) {
   time <- difftime(after, before, units = "auto")
 
   # report status to user
-  fmt <- "\tOK [%s to cache in %s]"
-  vwritef(fmt, if (linkable) "moved" else "copied", renv_difftime_format(time))
+  renv_install_step_ok(
+    if (linkable) "moved" else "copied",
+    time = time
+  )
 
   TRUE
 
@@ -3071,8 +3179,7 @@ renv_cache_diagnose_corrupt_metadata <- function(paths, problems, verbose) {
       renv_pretty_print(
         renv_cache_format_path(bad),
         "The following package(s) are missing 'Meta/package.rds':",
-        "These packages should be purged and reinstalled.",
-        wrap = FALSE
+        "These packages should be purged and reinstalled."
       )
     }
     # nocov end
@@ -3101,8 +3208,7 @@ renv_cache_diagnose_corrupt_metadata <- function(paths, problems, verbose) {
       renv_pretty_print(
         renv_cache_format_path(bad),
         "The following package(s) have corrupt 'Meta/package.rds' files:",
-        "These packages should be purged and reinstalled.",
-        wrap = FALSE
+        "These packages should be purged and reinstalled."
       )
     }
     # nocov end
@@ -3133,8 +3239,7 @@ renv_cache_diagnose_missing_descriptions <- function(paths, problems, verbose) {
     renv_pretty_print(
       renv_cache_format_path(bad),
       "The following packages are missing DESCRIPTION files in the cache:",
-      "These packages should be purged and reinstalled.",
-      wrap = FALSE
+      "These packages should be purged and reinstalled."
     )
   }
   # nocov end
@@ -3168,8 +3273,7 @@ renv_cache_diagnose_bad_hash <- function(paths, problems, verbose) {
     renv_pretty_print(
       entries,
       "The following packages have incorrect hashes:",
-      "Consider using `renv::rehash()` to re-hash these packages.",
-      wrap = FALSE
+      "Consider using `renv::rehash()` to re-hash these packages."
     )
   }
   # nocov end
@@ -3212,8 +3316,7 @@ renv_cache_diagnose_wrong_built_version <- function(paths, problems, verbose) {
       renv_pretty_print(
         paths[isna],
         "The following packages have no 'Built' field recorded in their DESCRIPTION file:",
-        "renv is unable to validate the version of R this package was built for.",
-        wrap = FALSE
+        "renv is unable to validate the version of R this package was built for."
       )
 
     }
@@ -3251,8 +3354,7 @@ renv_cache_diagnose_wrong_built_version <- function(paths, problems, verbose) {
     renv_pretty_print(
       renv_cache_format_path(paths[wrong]),
       "The following packages in the cache were built for a different version of R:",
-      "These packages will need to be purged and reinstalled.",
-      wrap = FALSE
+      "These packages will need to be purged and reinstalled."
     )
 
   }
@@ -3349,8 +3451,7 @@ renv_cache_clean_empty <- function(cache = NULL) {
 renv_cache_clean_empty_impl <- function(cache) {
 
   # move to cache directory
-  owd <- setwd(cache)
-  defer(setwd(owd))
+  renv_scope_wd(cache)
 
   # construct system command for removing empty directories
   action <- "removing empty directories"
@@ -3429,7 +3530,7 @@ renv_cache_linkable <- function(project, library) {
 }
 
 
-# call.R =====================================================================
+# call.R ---------------------------------------------------------------------
 
 
 # given a call of the form e.g. 'pkg::foo()' or 'foo()',
@@ -3441,10 +3542,7 @@ renv_call_expect <- function(node, package, methods) {
     return(NULL)
 
   # check for call of the form 'pkg::foo(a, b, c)'
-  colon <-
-    is.call(node[[1L]]) &&
-    is.name(node[[1L]][[1L]]) &&
-    as.character(node[[1L]][[1L]]) %in% c("::", ":::")
+  colon <- renv_call_matches(node[[1L]], name = c("::", ":::"), n_args = 2)
 
   if (colon) {
 
@@ -3474,10 +3572,7 @@ renv_call_normalize <- function(node, stack) {
 
   # check for magrittr pipe -- if this part of the expression is
   # being piped into, then we need to munge the call
-  ispipe <-
-    is.call(node) &&
-    is.symbol(node[[1L]]) &&
-    as.character(node[[1L]]) %in% c("%>%", "%T>%", "%<>%")
+  ispipe <- renv_call_matches(node, name = c("%>%", "%T>%", "%<>%"))
 
   if (!ispipe)
     return(node)
@@ -3511,7 +3606,26 @@ renv_call_normalize <- function(node, stack) {
 }
 
 
-# cellar.R ===================================================================
+renv_call_matches <- function(call, name = NULL, n_args = NULL) {
+  if (!is.call(call))
+    return(FALSE)
+
+  if (!is.null(name)) {
+    if (!is.name(call[[1]]))
+      return(FALSE)
+
+    if (!as.character(call[[1]]) %in% name)
+      return(FALSE)
+  }
+
+  if (!is.null(n_args) && length(call) != n_args + 1L)
+    return(FALSE)
+
+  TRUE
+}
+
+
+# cellar.R -------------------------------------------------------------------
 
 
 renv_cellar_roots <- function(project = NULL) {
@@ -3570,7 +3684,7 @@ renv_cellar_latest <- function(package, project) {
 }
 
 
-# check.R ====================================================================
+# check.R --------------------------------------------------------------------
 
 
 renv_check_unknown_source <- function(records, project = NULL) {
@@ -3618,10 +3732,10 @@ renv_check_unknown_source <- function(records, project = NULL) {
 
 
 
-# checkout.R =================================================================
+# checkout.R -----------------------------------------------------------------
 
 
-#' Checkout a Repository
+#' Checkout a repository
 #'
 #' `renv::checkout()` can be used to install the latest packages available from
 #' a (set of) package repositories.
@@ -3685,13 +3799,13 @@ checkout <- function(repos = NULL,
   renv_project_lock(project = project)
 
   # set new repositories
-  repos <- repos %??% renv_checkout_repos(date)
+  repos <- repos %||% renv_checkout_repos(date)
   options(repos = repos)
 
   # TODO: Activate Bioconductor if it appears to be used by this project
 
   # select packages to install
-  packages <- packages %??% renv_checkout_packages(project = project)
+  packages <- packages %||% renv_checkout_packages(project = project)
 
   # get the associated remotes for these packages
   remotes <- renv_checkout_remotes(packages, project)
@@ -3709,7 +3823,12 @@ checkout <- function(repos = NULL,
 }
 
 renv_checkout_packages <- function(project) {
-  renv_dependencies_impl(project, progress = FALSE, field = "Package")
+  renv_dependencies_impl(
+    project,
+    progress = FALSE,
+    field = "Package",
+    dev = TRUE
+  )
 }
 
 renv_checkout_remotes <- function(packages, project) {
@@ -3822,7 +3941,7 @@ renv_checkout_repos <- function(date) {
     url <- file.path(root, candidate)
     if (renv_download_available(file.path(url, "src/contrib/PACKAGES"))) {
       fmt <- "* Snapshot date '%s' not available; using '%s' instead"
-      messagef(fmt, date, candidate)
+      printf(fmt, date, candidate)
       return(url)
     }
   }
@@ -3832,209 +3951,14 @@ renv_checkout_repos <- function(date) {
 }
 
 
-# ci.R =======================================================================
+# clean.R --------------------------------------------------------------------
 
 
-renv_ci_dependencies <- function() {
-
-  # ensure ci directory exists
-  ensure_directory("ci")
-
-  # save R version
-  saveRDS(R.version, file = "ci/version.rds", version = 2L)
-
-  # find the packages used in this project
-  records <- renv_project_remotes(project = getwd())
-  packages <- extract_chr(records, "Package")
-
-  # find recursive dependencies of these packages
-  revdeps <- tools::package_dependencies(packages, recursive = TRUE)
-
-  # collapse into unique list
-  all <- sort(unique(unlist(revdeps)))
-
-  # get versions of these dependencies
-  db <- as.data.frame(
-    available.packages(filters = c("OS_type", "duplicates")),
-    stringsAsFactors = FALSE
-  )
-
-  # retrieve fields
-  resolved <- db[db$Package %in% all, c("Package", "Version")]
-  rownames(resolved) <- NULL
-
-  # set version if available
-  envvar <- case(
-    renv_platform_linux()   ~ "RENV_CI_CACHE_VERSION_LINUX",
-    renv_platform_macos()   ~ "RENV_CI_CACHE_VERSION_MACOS",
-    renv_platform_windows() ~ "RENV_CI_CACHE_VERSION_WINDOWS"
-  )
-
-  # set cache version
-  version <- Sys.getenv(envvar, unset = NA)
-  if (!is.na(version))
-    attr(resolved, "cache") <- version
-
-  # print it out, just for our own information
-  print(resolved)
-
-  # save to file for hashing
-  saveRDS(resolved, file = "ci/dependencies.rds", version = 2L)
-
-}
-
-renv_ci_repair <- function() {
-
-  # get installed packages
-  library <- renv_libpaths_active()
-  db <- installed_packages(lib.loc = library)
-
-  # attempt to load these packages
-  packages <- db$Package
-  names(packages) <- packages
-  ok <- map_lgl(packages, requireNamespace, quietly = TRUE)
-
-  # check which failed to load
-  broken <- packages[!ok]
-  if (empty(broken)) {
-    vwritef("* All installed packages can be successfully loaded.")
-    return(broken)
-  }
-
-  # notify the user
-  renv_pretty_print(
-    values    = paste("-", packages),
-    preamble  = "The following package(s) could not be successfully loaded:",
-    postamble = "These packages will be removed and later reinstalled.",
-    wrap      = FALSE
-  )
-
-  # remove each broken package
-  paths <- file.path(library, broken)
-  unlink(paths, recursive = TRUE)
-
-  return(broken)
-
-}
-
-
-# cite.R =====================================================================
-
-
-# TODO
-#
-# Different citation styles:
-# - https://pandoc.org/MANUAL.html#citations
-# - https://www.zotero.org/styles
-# - https://pandoc.org/MANUAL.html#option--csl
-#
-# Path to pandoc? Safe pandoc invocation?
-# Output formats? (text, markdown, etc)
-# Write to file? (e.g. file called PACKAGE-CITATIONS?)
-# Include only top-level packages? All recursive dependencies?
-# Allow package-defined citations, or form only from DESCRIPTION?
-# What about packages with multiple bibtex entries?
-cite <- function(type = c("plain", "bibtex"),
-                 ...,
-                 project = NULL)
-{
-  renv_scope_error_handler()
-  renv_dots_check(...)
-
-  project <- renv_project_resolve(project)
-  type <- match.arg(type)
-
-  packages <- sort(.packages(all.available = TRUE))
-  names(packages) <- packages
-  vprintf("Generating citations ... ")
-  citations <- lapply(packages, function(package) {
-    catchall(citation(package))
-  })
-  vwritef("Done!")
-
-  erridx <- map_lgl(citations, inherits, what = "condition")
-  errs <- citations[erridx]
-  if (length(errs)) {
-
-      msg <- paste(
-      format(paste0(names(errs), ":")),
-      map_chr(errs, conditionMessage)
-    )
-
-    renv_pretty_print(
-      msg,
-      "renv could not generate citations for the following packages:",
-      "You may need to manually form a citation for these packages.",
-      wrap = FALSE
-    )
-
-  }
-
-  bibtex <-
-    enumerate(citations, renv_citation_bibtex) %>%
-    filter(is.character) %>%
-    unlist()
-
-  for (i in seq_along(bibtex)) {
-    replacement <- sprintf("{citation%i,", i)
-    bibtex[[i]] <- sub("{,", replacement, bibtex[[i]], fixed = TRUE)
-    bibtex[[i]] <- sub("title = \\{(.*)\\}", "title = {{\\1}}", bibtex[[i]])
-  }
-
-  dir <- tempfile("renv-cite-")
-  dir.create(dir, recursive = TRUE)
-  owd <- setwd(dir)
-  defer(setwd(owd))
-
-  writeLines(paste(bibtex, collapse = "\n"), con = "bibliography.bib")
-
-  md <- c(
-    "---",
-    "bibliography: bibliography.bib",
-    "biblio-style: apalike",
-    "nocite: '@*'",
-    "---",
-    "",
-    "# Bibliography"
-  )
-
-  writeLines(md, con = "input.md")
-
-  args <- c(
-    "--bibliography=bibliography.bib",
-    "--standalone",
-    "input.md",
-    "-o",
-    "output.html"
-  )
-
-  system2("pandoc", args)
-  system("open output.html")
-
-}
-
-renv_citation_bibtex <- function(package, citation) {
-
-  status <- catch(toBibtex(citation))
-  if (inherits(status, "error")) {
-    fmt <- "could not generate bibtex for package '%s'"
-    warningf(fmt, package)
-    return(NULL)
-  }
-
-  status
-
-}
-
-
-# clean.R ====================================================================
-
-
-#' Clean a Project
+#' Clean a project
 #'
 #' Clean up a project and its associated \R libraries.
 #'
-#' @section Actions:
+#' # Actions
 #'
 #' The following clean actions are available:
 #'
@@ -4061,7 +3985,7 @@ renv_citation_bibtex <- function(package, citation) {
 #' \item{`system.library`}{
 #'
 #'   In general, it is recommended that only packages distributed with \R
-#'   are installed into the system library (the library path referred to
+#'   are installed into the default library (the library path referred to
 #'   by `.Library`). Use this action to remove any user-installed packages
 #'   that have been installed to the system library.
 #'
@@ -4126,7 +4050,7 @@ clean <- function(project = NULL,
   for (method in methods)
     tryCatch(method(project, prompt), error = warning)
 
-  vwritef("* The project has been cleaned.")
+  writef("* The project has been cleaned.")
   invisible(project)
 }
 
@@ -4149,7 +4073,7 @@ renv_clean_actions <- function(prompt) {
 renv_clean_library_tempdirs <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No temporary directories were found in the project library.")
+    writef("* No temporary directories were found in the project library.")
     FALSE
   }
 
@@ -4165,8 +4089,7 @@ renv_clean_library_tempdirs <- function(project, prompt) {
 
     renv_pretty_print(
       bad,
-      "The following directories will be removed:",
-      wrap = FALSE
+      "The following directories will be removed:"
     )
 
     if (prompt && !proceed())
@@ -4185,12 +4108,12 @@ renv_clean_library_tempdirs <- function(project, prompt) {
 renv_clean_system_library <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No non-system packages were discovered in the system library.")
+    writef("* No non-system packages were discovered in the system library.")
     FALSE
   }
 
   # explicitly query for packages
-  syslib <- renv_path_normalize(renv_libpaths_system(), winslash = "/", mustWork = FALSE)
+  syslib <- renv_path_normalize(renv_libpaths_system())
   db <- installed_packages(lib.loc = syslib, priority = "NA")
   packages <- setdiff(db$Package, "translations")
 
@@ -4237,7 +4160,7 @@ renv_clean_system_library <- function(project, prompt) {
 renv_clean_unused_packages <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No unused packages were found in the project library.")
+    writef("* No unused packages were found in the project library.")
     FALSE
   }
 
@@ -4248,7 +4171,7 @@ renv_clean_unused_packages <- function(project, prompt) {
     return(ntd())
 
   # find packages used in the project and their dependencies
-  deps <- dependencies(project, progress = FALSE)
+  deps <- renv_dependencies_impl(project, progress = FALSE)
   paths <- renv_package_dependencies(deps$Package, project = project)
   packages <- names(paths)
 
@@ -4283,7 +4206,7 @@ renv_clean_unused_packages <- function(project, prompt) {
 renv_clean_package_locks <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No stale package locks were found.")
+    writef("* No stale package locks were found.")
     FALSE
   }
 
@@ -4308,8 +4231,7 @@ renv_clean_package_locks <- function(project, prompt) {
     renv_pretty_print(
       basename(old),
       "The following stale package locks were discovered in your library:",
-      "These locks will be removed.",
-      wrap = FALSE
+      "These locks will be removed."
     )
 
     if (prompt && !proceed())
@@ -4326,7 +4248,7 @@ renv_clean_package_locks <- function(project, prompt) {
 renv_clean_cache <- function(project, prompt) {
 
   ntd <- function() {
-    vwritef("* No unused packages were found in the renv cache.")
+    writef("* No unused packages were found in the renv cache.")
     FALSE
   }
 
@@ -4343,14 +4265,13 @@ renv_clean_cache <- function(project, prompt) {
     renv_pretty_print(
       projlist[missing],
       "The following projects are monitored by renv, but no longer exist:",
-      "These projects will be removed from renv's project list.",
-      wrap = FALSE
+      "These projects will be removed from renv's project list."
     )
 
     if (prompt && !proceed())
       return(FALSE)
 
-    writeLines(projlist[!missing], projects, useBytes = TRUE)
+    writeLines(projlist[!missing], con = projects, useBytes = TRUE)
 
   }
 
@@ -4380,8 +4301,7 @@ renv_clean_cache <- function(project, prompt) {
     renv_pretty_print(
       renv_cache_format_path(diff),
       "The following packages are installed in the cache but no longer used:",
-      "These packages will be removed.",
-      wrap = FALSE
+      "These packages will be removed."
     )
 
     if (prompt && !proceed())
@@ -4392,14 +4312,14 @@ renv_clean_cache <- function(project, prompt) {
   # remove the directories
   unlink(diff, recursive = TRUE)
   renv_cache_clean_empty()
-  vwritef("* %i package(s) have been removed.", length(diff))
+  writef("* %i package(s) have been removed.", length(diff))
   TRUE
 
 }
 # nocov end
 
 
-# cli.R ======================================================================
+# cli.R ----------------------------------------------------------------------
 
 
 renv_cli_install <- function(target = NULL) {
@@ -4541,7 +4461,7 @@ renv_cli_unknown <- function(method, exports) {
 
   candidates <- names(distance)[distance == n]
   fmt <- "did you mean %s?"
-  vwritef(fmt, paste(shQuote(candidates), collapse = " or "))
+  writef(fmt, paste(shQuote(candidates), collapse = " or "))
   return(1L)
 
 }
@@ -4561,7 +4481,7 @@ renv_cli_parse <- function(text) {
 }
 
 
-# conda.R ====================================================================
+# conda.R --------------------------------------------------------------------
 
 
 # given the path to a Python installation managed by conda, attempt to
@@ -4616,7 +4536,7 @@ renv_conda_find_impl <- function(python) {
 }
 
 
-# condition.R ================================================================
+# condition.R ----------------------------------------------------------------
 
 
 renv_condition_signal <- function(class = NULL, data = NULL) {
@@ -4630,7 +4550,7 @@ renv_condition_data <- function(condition) {
 }
 
 
-# config-defaults.R ==========================================================
+# config-defaults.R ----------------------------------------------------------
 
 
 # Auto-generated by 'tools/tools-generate-config.R'
@@ -4846,7 +4766,7 @@ config <- list(
     )
   },
 
-  mran.enabled = function(..., default = TRUE) {
+  mran.enabled = function(..., default = FALSE) {
     renv_config_get(
       name    = "mran.enabled",
       type    = "logical[1]",
@@ -4859,6 +4779,33 @@ config <- list(
     renv_config_get(
       name    = "pak.enabled",
       type    = "logical[1]",
+      default = default,
+      args    = list(...)
+    )
+  },
+
+  ppm.enabled = function(..., default = TRUE) {
+    renv_config_get(
+      name    = "ppm.enabled",
+      type    = "logical[1]",
+      default = default,
+      args    = list(...)
+    )
+  },
+
+  ppm.default = function(..., default = TRUE) {
+    renv_config_get(
+      name    = "ppm.default",
+      type    = "logical[1]",
+      default = default,
+      args    = list(...)
+    )
+  },
+
+  ppm.url = function(..., default = "https://packagemanager.posit.co/cran/latest") {
+    renv_config_get(
+      name    = "ppm.url",
+      type    = "character[1]",
       default = default,
       args    = list(...)
     )
@@ -4975,10 +4922,10 @@ config <- list(
 )
 
 
-# config.R ===================================================================
+# config.R -------------------------------------------------------------------
 
 
-#' User-Level Configuration of renv
+#' User-level settings
 #'
 #' Configure different behaviors of renv.
 #'
@@ -5016,7 +4963,7 @@ config <- list(
 #'
 #' @eval renv_roxygen_config_section()
 #'
-#' @section Copy Methods:
+#' @section Copy methods:
 #'
 #' If you find that renv is unable to copy some directories in your
 #' environment, you may want to try setting the `copy.method` option. By
@@ -5050,7 +4997,7 @@ config <- list(
 #' attempt to copy a directory could leave a half-copied directory behind
 #' in the final location.
 #'
-#' @section Project-Local Settings:
+#' @section Project-local settings:
 #'
 #' For settings that should persist alongside a particular project, the
 #' various settings available in [settings] can be used.
@@ -5207,7 +5154,7 @@ renv_config_install_staged <- function(default = TRUE) {
 }
 
 
-# consent.R ==================================================================
+# consent.R ------------------------------------------------------------------
 
 
 #' Consent to usage of renv
@@ -5248,7 +5195,7 @@ consent <- function(provided = FALSE) {
   # compute path to root directory
   root <- renv_paths_root()
   if (renv_file_type(root) == "directory") {
-    vwritef("* Consent to use renv has already been provided -- nothing to do.")
+    writef("* Consent to use renv has already been provided -- nothing to do.")
     return(invisible(TRUE))
   }
 
@@ -5257,7 +5204,7 @@ consent <- function(provided = FALSE) {
   contents <- readLines(template)
   replacements <- list(RENV_PATHS_ROOT = renv_path_pretty(root))
   welcome <- renv_template_replace(contents, replacements)
-  writeLines(welcome)
+  writef(welcome)
 
   # ask user if they want to proceed
   response <- catchall(proceed(default = provided))
@@ -5269,7 +5216,7 @@ consent <- function(provided = FALSE) {
   # cache the user response
   options(renv.consent = TRUE)
   ensure_directory(root)
-  vwritef("* %s has been created.", renv_path_pretty(root))
+  writef("* %s has been created.", renv_path_pretty(root))
 
   invisible(TRUE)
 
@@ -5292,9 +5239,9 @@ renv_consent_check <- function() {
   # check for implicit consent
   consented <-
     !interactive() ||
-    !is.na(Sys.getenv("CI", unset = NA)) ||
-    !is.na(Sys.getenv("GITHUB_ACTION", unset = NA)) ||
-    !is.na(Sys.getenv("RENV_PATHS_ROOT", unset = NA)) ||
+    renv_envvar_exists("CI") ||
+    renv_envvar_exists("GITHUB_ACTION") ||
+    renv_envvar_exists("RENV_PATHS_ROOT") ||
     file.exists("/.singularity.d") ||
     renv_virtualization_type() != "native"
 
@@ -5309,7 +5256,7 @@ renv_consent_check <- function() {
 }
 
 
-# cran.R =====================================================================
+# cran.R ---------------------------------------------------------------------
 
 
 # nocov start
@@ -5352,7 +5299,7 @@ renv_cran_status_maintainer_email <- function(package = NULL) {
 # nocov end
 
 
-# curl.R =====================================================================
+# curl.R ---------------------------------------------------------------------
 
 
 `_renv_curl_valid` <- new.env(parent = emptyenv())
@@ -5372,7 +5319,7 @@ renv_curl_exe <- function() {
 
 renv_curl_validate <- function(curl) {
 
-  `_renv_curl_valid`[[curl]] <- `_renv_curl_valid`[[curl]] %??% {
+  `_renv_curl_valid`[[curl]] <- `_renv_curl_valid`[[curl]] %||% {
     renv_curl_validate_impl(curl)
   }
 
@@ -5395,7 +5342,7 @@ renv_curl_validate_impl <- function(curl) {
   )
 
   if (!inherits(output, "error")) {
-    status <- attr(output, "status") %??% 0L
+    status <- attr(output, "status") %||% 0L
     if (status == 0L)
       return(curl)
   }
@@ -5437,7 +5384,7 @@ renv_curl_exe_missing <- function(curl) {
 }
 
 
-# data_frame.R ===============================================================
+# data_frame.R ---------------------------------------------------------------
 
 
 data_frame <- function(...) {
@@ -5483,7 +5430,7 @@ as_data_frame <- function(data) {
 }
 
 
-# dcf.R ======================================================================
+# dcf.R ----------------------------------------------------------------------
 
 
 # similar to base::read.dcf(), but:
@@ -5600,11 +5547,13 @@ renv_dcf_write <- function(x, file = "") {
 }
 
 
-# deactivate.R ===============================================================
+# deactivate.R ---------------------------------------------------------------
 
 #' @rdname activate
+#' @param clean If `TRUE`, will also remove the `renv/` directory and the
+#'   lockfile.
 #' @export
-deactivate <- function(project = NULL) {
+deactivate <- function(project = NULL, clean = FALSE) {
 
   renv_scope_error_handler()
 
@@ -5615,13 +5564,18 @@ deactivate <- function(project = NULL) {
 
   unload(project)
 
+  if (clean) {
+    unlink(file.path(project, "renv.lock"))
+    unlink(file.path(project, "renv"), recursive = TRUE, force = TRUE)
+  }
+
   renv_restart_request(project, reason = "renv deactivated")
   invisible(project)
 
 }
 
 
-# debug.R ====================================================================
+# debug.R --------------------------------------------------------------------
 
 
 renv_debugging <- function() {
@@ -5629,24 +5583,13 @@ renv_debugging <- function() {
 }
 
 
-# defer.R ====================================================================
+# defer.R --------------------------------------------------------------------
 
 
 # environment hosting exit callbacks
 `_renv_defer_callbacks` <- new.env(parent = emptyenv())
 
-# counter used for mapping environments to the callbacks
-`_renv_defer_id` <- 1L
-
-# stand-in for the global environment
-`_renv_defer_placeholder` <- new.env(parent = emptyenv())
-
 defer <- function(expr, envir = parent.frame()) {
-
-  # exit handlers set on the global environment might get run unexpectedly,
-  # so put those handlers on a placeholder that's under our control
-  if (identical(envir, globalenv()))
-    envir <- `_renv_defer_placeholder`
 
   handler <- renv_defer_add(
     list(expr = substitute(expr), envir = parent.frame()),
@@ -5658,16 +5601,7 @@ defer <- function(expr, envir = parent.frame()) {
 }
 
 renv_defer_id <- function(envir) {
-
-  # check for existing id
-  id <- attr(envir, "__renv_defer_id__", exact = TRUE)
-  if (!is.null(id))
-    return(id)
-
-  # no id; bump the global count and add a new id
-  `_renv_defer_id` <<- `_renv_defer_id` + 1L
-  attr(envir, "__renv_defer_id__") <- as.character(`_renv_defer_id`)
-
+  format.default(envir)
 }
 
 renv_defer_get <- function(envir) {
@@ -5693,25 +5627,25 @@ renv_defer_set <- function(envir, handlers) {
 }
 
 renv_defer_remove <- function(envir) {
-
-  # get environment id
   id <- renv_defer_id(envir)
-  if (is.null(id))
-    stopf("internal error: %s has no id", format(envir))
-
-  # remove our stored handlers
   rm(list = id, envir = `_renv_defer_callbacks`)
-
-  # unset the handler id on the environment
-  attr(envir, "__renv_defer_id__") <- NULL
-
 }
 
-renv_defer_execute <- function(envir) {
+renv_defer_execute <- function(envir = parent.frame()) {
+
+  # check for handlers -- may be NULL if they were intentionally executed
+  # early via a call to `renv_defer_execute()`
   handlers <- renv_defer_get(envir)
+  if (is.null(handlers))
+    return()
+
+  # execute the existing handlers
   for (handler in handlers)
     tryCatch(eval(handler$expr, handler$envir), error = identity)
+
+  # remove the handlers
   renv_defer_remove(envir)
+
 }
 
 renv_defer_add <- function(envir, handler) {
@@ -5721,12 +5655,12 @@ renv_defer_add <- function(envir, handler) {
 }
 
 
-# dependencies.R =============================================================
+# dependencies.R -------------------------------------------------------------
 
 
 `_renv_dependencies` <- new.env(parent = emptyenv())
 
-#' Find R Package Dependencies in a Project
+#' Find R package dependencies in a project
 #'
 #' @description
 #' `dependencies()` will crawl files within your project, looking for \R files
@@ -5840,7 +5774,7 @@ renv_defer_add <- function(envir, handler) {
 #'     # code in this chunk will _not_ be ignored
 #'     ```
 #'
-#' @section Development Dependencies:
+#' # Development dependencies
 #'
 #' renv attempts to distinguish between 'development' dependencies and
 #' 'runtime' dependencies. For example, you might rely on e.g.
@@ -5870,10 +5804,14 @@ renv_defer_add <- function(envir, handler) {
 #'   * `"fatal"`: errors are fatal and stop execution.
 #'   *  `"ignored"`: errors are ignored and not reported to the user.
 #'
-#' @param dev Boolean; include 'development' dependencies as well? That is,
-#'   packages which may be required during development but are unlikely to be
-#'   required during runtime for your project. By default, only runtime
-#'   dependencies are returned.
+#' @param dev Boolean; include development dependencies? These packages are
+#'   typically required when developing the project, but not when running it
+#'   (i.e. you want them installed when humans are working on the project but
+#'   not when computers are deploying it).
+#'
+#'   Development dependencies include packages listed in the `Suggests` field
+#'   of a `DESCRIPTION` found in the project root, and roxygen2 or devtools if
+#'   their use is implied by other project metadata.
 #'
 #' @return An \R `data.frame` of discovered dependencies, mapping inferred
 #'   package names to the files in which they were discovered. Note that the
@@ -5899,7 +5837,7 @@ dependencies <- function(
 {
   renv_scope_error_handler()
 
-  deps <- renv_dependencies_impl(
+  renv_dependencies_impl(
     path     = path,
     root     = root,
     progress = progress,
@@ -5907,14 +5845,6 @@ dependencies <- function(
     dev      = dev,
     ...
   )
-
-  if (empty(deps) || nrow(deps) == 0L)
-    return(renv_dependencies_list_empty())
-
-  # drop NAs, and only keep 'dev' dependencies if requested
-  deps <- deps[deps$Dev %in% c(dev, FALSE), ]
-
-  deps
 }
 
 renv_dependencies_impl <- function(
@@ -5930,7 +5860,7 @@ renv_dependencies_impl <- function(
   if (is.function(path))
     return(renv_dependencies_discover_r(expr = body(path)))
 
-  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+  path <- renv_path_normalize(path, mustWork = TRUE)
   root <- root %||% renv_dependencies_root(path)
 
   # ignore errors when testing, unless explicitly asked for
@@ -5962,12 +5892,19 @@ renv_dependencies_impl <- function(
   deps <- renv_dependencies_discover(files, progress, errors)
   renv_dependencies_report(errors)
 
+  if (empty(deps) || nrow(deps) == 0L) {
+    deps <- renv_dependencies_list_empty()
+  } else {
+    # drop NAs, and only keep 'dev' dependencies if requested
+    deps <- deps[deps$Dev %in% c(dev, FALSE), ]
+  }
+
   take(deps, field)
 }
 
 renv_dependencies_root <- function(path = getwd()) {
 
-  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+  path <- renv_path_normalize(path, mustWork = TRUE)
 
   project <- renv_project_get(default = NULL)
   if (!is.null(project) && all(renv_path_within(path, project)))
@@ -6091,7 +6028,7 @@ renv_dependencies_find_dir <- function(path, root, depth) {
   # check if we've already scanned this directory
   # (necessary to guard against recursive symlinks)
   if (!renv_platform_windows()) {
-    norm <- renv_path_normalize(path, mustWork = FALSE)
+    norm <- renv_path_normalize(path)
     state <- renv_dependencies_state()
     if (visited(norm, state$scanned))
       return(character())
@@ -6175,10 +6112,10 @@ renv_dependencies_discover <- function(paths, progress, errors) {
   # otherwise, run with progress reporting
 
   # nocov start
-  vprintf("Finding R package dependencies ... ")
+  printf("Finding R package dependencies ... ")
   callback <- renv_progress_callback(renv_dependencies_discover_impl, length(paths))
   deps <- lapply(paths, callback)
-  vwritef("Done!")
+  writef("Done!")
 
   bind(deps)
   # nocov end
@@ -6193,9 +6130,11 @@ renv_dependencies_discover_impl <- function(path) {
     warningf(fmt, renv_path_pretty(path))
   }
 
-  result <- tryCatch(callback(path), error = warning)
-  if (inherits(result, "condition"))
+  result <- catch(callback(path))
+  if (inherits(result, "error")) {
+    warning(result)
     return(NULL)
+  }
 
   result
 
@@ -6219,7 +6158,7 @@ renv_dependencies_discover_preflight <- function(paths, errors) {
     "Set `options(renv.config.dependencies.limit = Inf)` to disable this warning.",
     ""
   )
-  vwritef(lines, length(paths))
+  writef(lines, length(paths))
 
   if (identical(errors, "reported"))
     return(TRUE)
@@ -6243,46 +6182,42 @@ renv_dependencies_discover_description <- function(path,
   if (inherits(dcf, "error"))
     return(renv_dependencies_error(path, error = dcf))
 
-  # read fields from project options if available
-  fields <-
-    fields %||%
-    renv_dependencies_discover_description_fields() %||%
-    c("Depends", "Imports", "LinkingTo")
+  if (is.null(fields)) {
+    # Most callers don't pass in project so we need to get it from global state
+    project <- project %||%
+      renv_dependencies_state(key = "root") %||%
+      renv_restore_state(key = "root") %||%
+      renv_project_resolve()
 
-  # if this is the DESCRIPTION file for the active project, include
-  # Suggests since they're often needed as well. such packages will be
-  # considered development dependencies, except for package projects
-  type <- "unknown"
-  project <-
-    project %||%
-    renv_dependencies_state(key = "root") %||%
-    renv_project_resolve()
+    fields <- settings$package.dependency.fields(project = project)
 
-  if (renv_path_same(file.path(project, "DESCRIPTION"), path)) {
+    # if this is the DESCRIPTION file for the active project, include
+    # the dependencies for the active profile (if any) and Suggested fields.
+    if (renv_path_same(file.path(project, "DESCRIPTION"), path)) {
 
-    # collect profile-specific dependencies as well
-    profile <- renv_profile_get()
-    field <- if (length(profile))
-      sprintf("Config/renv/profiles/%s/dependencies", profile)
+      # collect profile-specific dependencies as well
+      profile <- renv_profile_get()
+      profile_field <- if (length(profile))
+        sprintf("Config/renv/profiles/%s/dependencies", profile)
 
-    fields <- c(fields, "Suggests", field)
-    type <- renv_description_type(desc = dcf)
-
+      fields <- c(fields, "Suggests", profile_field)
+    }
+  } else {
+    fields <- renv_description_dependency_fields(fields)
   }
 
   data <- map(
     fields,
     renv_dependencies_discover_description_impl,
     dcf  = dcf,
-    path = path,
-    type = type
+    path = path
   )
 
   bind(data)
 
 }
 
-renv_dependencies_discover_description_impl <- function(dcf, field, path, type) {
+renv_dependencies_discover_description_impl <- function(dcf, field, path) {
 
   # read field
   contents <- dcf[[field]]
@@ -6307,42 +6242,13 @@ renv_dependencies_discover_description_impl <- function(dcf, field, path, type) 
     return(list())
 
   # create dependency list
-  dev <- field == "Suggests" && type != "package"
   renv_dependencies_list(
     path,
     extract_chr(matches, 2L),
     extract_chr(matches, 3L),
     extract_chr(matches, 4L),
-    dev
+    dev = field == "Suggests"
   )
-
-}
-
-renv_dependencies_discover_description_fields <- function() {
-
-  # this is all very gross -- the project should be passed
-  # along by the caller instead, but doing so is annoying
-  project <- local({
-
-    # are we being called as part of renv::dependencies()?
-    # if so, then use the root directory as the project root
-    state <- renv_dependencies_state()
-    if (!is.null(state))
-      return(state$root)
-
-    # are we being called as part of renv::restore()?
-    # if so, then use the associated project directory
-    state <- renv_restore_state()
-    if (!is.null(state))
-      return(state$project)
-
-    # all else fails, use the current directory
-    getwd()
-
-  })
-
-  # we've figured out the correct project; get the settings
-  settings$package.dependency.fields(project = project)
 
 }
 
@@ -6437,15 +6343,12 @@ renv_dependencies_discover_rmd_yaml_header <- function(path, mode) {
 
   # check recursively for package usages of the form 'package::method'
   recurse(yaml, function(node, stack) {
-
     # look for keys of the form 'package::method'
     values <- c(names(node), if (pstring(node)) node)
     for (value in values) {
-      parts <- strsplit(value, ":{2,3}")[[1L]]
-      if (length(parts) == 2L) {
-        name <- parts[[1L]]
-        if (grepl(pattern, name))
-          deps$push(parts[[1L]])
+      call <- tryCatch(parse(text = value)[[1]], error = function(err) NULL)
+      if (renv_call_matches(call, name = c("::", ":::"), n_args = 2)) {
+        deps$push(as.character(call[[2L]]))
       }
     }
 
@@ -6708,7 +6611,7 @@ renv_dependencies_discover_r <- function(path = NULL,
   # update current path
   state <- renv_dependencies_state()
   if (!is.null(state))
-    renv_scope_var("path", path, frame = state)
+    renv_scope_binding(state, "path", path)
 
   methods <- c(
     renv_dependencies_discover_r_methods,
@@ -6726,7 +6629,7 @@ renv_dependencies_discover_r <- function(path = NULL,
     renv_dependencies_discover_r_database
   )
 
-  envir <- envir %??% new.env(parent = emptyenv())
+  envir <- envir %||% new.env(parent = emptyenv())
   recurse(expr, function(node, stack) {
 
     # normalize calls (handle magrittr pipes)
@@ -6842,11 +6745,7 @@ renv_dependencies_discover_r_require_namespace <- function(node, stack, envir) {
 
 renv_dependencies_discover_r_colon <- function(node, stack, envir) {
 
-  ok <-
-    is.call(node) &&
-    length(node) == 3 &&
-    is.name(node[[1]]) &&
-    as.character(node[[1]]) %in% c("::", ":::")
+  ok <- renv_call_matches(node, name = c("::", ":::"), n_args = 2)
 
   if (!ok)
     return(FALSE)
@@ -6879,7 +6778,7 @@ renv_dependencies_discover_r_pacman <- function(node, stack, envir) {
   char <- node[["char"]]
 
   # detect vector of packages passed as vector
-  if (is.call(char) && identical(char[[1L]], as.name("c")))
+  if (renv_call_matches(char, name = "c"))
     parts <- c(parts, as.list(char[-1L]))
 
   # detect plain old package name
@@ -6918,10 +6817,7 @@ renv_dependencies_discover_r_pacman <- function(node, stack, envir) {
 renv_dependencies_discover_r_modules <- function(node, stack, envir) {
 
   # check for call of the form 'pkg::foo(a, b, c)'
-  colon <-
-    is.call(node[[1L]]) &&
-    is.name(node[[1L]][[1L]]) &&
-    as.character(node[[1L]][[1L]]) %in% c("::", ":::")
+  colon <- renv_call_matches(node[[1]], name = c("::", ":::"), n_args = 2)
 
   node <- renv_call_expect(node, "modules", c("import"))
   if (is.null(node))
@@ -7013,18 +6909,17 @@ renv_dependencies_discover_r_box <- function(node, stack, envir) {
 
 renv_dependencies_discover_r_box_impl <- function(node, stack, envir) {
 
-  # if we're referencing a package via '/', try to extract those
-  while (is.call(node) && identical(node[[1L]], as.name("/")))
-    node <- node[[2L]]
+  # if the call uses /, it's a path, not a package
+  while (renv_call_matches(node, name = "/"))
+    return(FALSE)
 
   # if the node is just a symbol, then it's the name of a package
   # otherwise, if it's a call to `[`, the first argument is the package name
   name <- if (is.symbol(node) && !identical(node, quote(expr = ))) {
     as.character(node)
   } else if (
-    is.call(node) &&
+    renv_call_matches(node, name = "[") &&
       length(node) > 1L &&
-      identical(node[[1L]], as.name("[")) &&
       is.symbol(node[[2L]])) {
     as.character(node[[2L]])
   }
@@ -7334,8 +7229,7 @@ renv_dependencies_require <- function(package, type = NULL) {
     )
 
     within <- if (is.null(type)) "this project" else paste(type, "files")
-    msg <- sprintf(fmt, package, within)
-    warning(msg, call. = FALSE)
+    warningf(fmt, package, within)
 
   }
 
@@ -7343,18 +7237,20 @@ renv_dependencies_require <- function(package, type = NULL) {
 
 }
 
+`_renv_dependencies_state` <- NULL
+
 renv_dependencies_state <- function(key = NULL) {
-  state <- renv_global_get("dependencies.state")
+  state <- `_renv_dependencies_state`
   if (is.null(key)) state else state[[key]]
 }
 
 renv_dependencies_begin <- function(root = NULL) {
   state <- env(root = root, scanned = env(), problems = stack())
-  renv_global_set("dependencies.state", state)
+  `_renv_dependencies_state` <<- state
 }
 
 renv_dependencies_end <- function() {
-  renv_global_clear("dependencies.state")
+  `_renv_dependencies_state` <<- NULL
 }
 
 renv_dependencies_error <- function(path, error = NULL, packages = NULL) {
@@ -7389,7 +7285,7 @@ renv_dependencies_report <- function(errors) {
   if (empty(problems))
     return(TRUE)
 
-  ewritef("WARNING: One or more problems were discovered while enumerating dependencies.\n")
+  writef("WARNING: One or more problems were discovered while enumerating dependencies.\n")
 
   # bind into list
   bound <- bapply(problems, function(problem) {
@@ -7408,10 +7304,10 @@ renv_dependencies_report <- function(errors) {
     prefix <- format(paste("ERROR", seq_along(problem$message)))
     messages <- paste(prefix, problem$message, sep = ": ", collapse = "\n\n")
     text <- c(file, lines, "", messages, "")
-    ewritef(text)
+    writef(text)
   })
 
-  ewritef("Please see `?renv::dependencies` for more information.")
+  writef("Please see `?renv::dependencies` for more information.")
 
   if (identical(errors, "fatal")) {
     fmt <- "one or more errors occurred while enumerating dependencies"
@@ -7425,7 +7321,7 @@ renv_dependencies_report <- function(errors) {
 
 renv_dependencies_scope <- function(path, action, envir = NULL) {
 
-  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+  path <- renv_path_normalize(path, mustWork = TRUE)
   if (exists(path, envir = `_renv_dependencies`))
     return(get(path, envir = `_renv_dependencies`))
 
@@ -7433,7 +7329,7 @@ renv_dependencies_scope <- function(path, action, envir = NULL) {
   message <- paste(action, "aborted")
 
   deps <- withCallingHandlers(
-    dependencies(path, progress = FALSE, errors = errors, dev = TRUE),
+    renv_dependencies_impl(path, progress = FALSE, errors = errors, dev = TRUE),
     renv.dependencies.error = renv_dependencies_error_handler(message, errors)
   )
 
@@ -7482,7 +7378,7 @@ renv_dependencies_eval <- function(expr) {
 }
 
 
-# description.R ==============================================================
+# description.R --------------------------------------------------------------
 
 
 renv_description_read <- function(path = NULL,
@@ -7569,35 +7465,6 @@ renv_description_path <- function(path) {
   path
 }
 
-renv_description_type <- function(path = NULL, desc = NULL) {
-
-  # read DESCRIPTION file when 'desc' not explicitly supplied
-  if (is.null(desc)) {
-
-    # read DESCRIPTION file
-    desc <- catch(renv_description_read(path))
-    if (inherits(desc, "error")) {
-      warning(desc)
-      return("unknown")
-    }
-
-  }
-
-  # check for explicitly recorded type
-  type <- desc$Type
-  if (!is.null(type))
-    return(tolower(type))
-
-  # infer otherwise from 'Package' field otherwise
-  package <- desc$Package
-  if (!is.null(package))
-    return("package")
-
-  # default to unknown
-  "unknown"
-
-}
-
 # parse the dependency requirements normally presented in
 # Depends, Imports, Suggests, and so on
 renv_description_parse_field <- function(field) {
@@ -7628,40 +7495,6 @@ renv_description_parse_field <- function(field) {
     Require = extract_chr(matches, 3L),
     Version = extract_chr(matches, 4L)
   )
-
-}
-
-renv_description_remotes <- function(descpath) {
-
-  # read Remotes field from DESCRIPTION
-  desc <- renv_description_read(path = descpath)
-  remotes <- desc[["Remotes"]]
-  if (is.null(remotes))
-    return(NULL)
-
-  # parse each remote entry
-  entries <- strsplit(remotes, "\\s*,\\s*", perl = TRUE)[[1L]]
-  parsed <- map(entries, renv_description_remotes_parse)
-
-  # ensure named
-  names(parsed) <- map_chr(parsed, `[[`, "Package")
-
-  # and return
-  parsed
-
-}
-
-renv_description_remotes_parse <- function(entry) {
-
-  status <- catch(renv_remotes_resolve(entry))
-
-  if (inherits(status, "error")) {
-    fmt <- "failed to resolve remote '%s' from project DESCRIPTION file; skipping"
-    warningf(fmt, entry)
-    return(NULL)
-  }
-
-  status
 
 }
 
@@ -7716,10 +7549,10 @@ renv_description_dependency_fields <- function(fields, project) {
 }
 
 
-# diagnostics.R ==============================================================
+# diagnostics.R --------------------------------------------------------------
 
 
-#' Print a Diagnostics Report
+#' Print a diagnostics report
 #'
 #' Print a diagnostics report, summarizing the state of a project using renv.
 #' This report can occasionally be useful when diagnosing issues with renv.
@@ -7760,34 +7593,34 @@ diagnostics <- function(project = NULL) {
   fmt <- "Diagnostics Report [renv %s]"
   title <- sprintf(fmt, renv_metadata_version())
   lines <- paste(rep.int("=", nchar(title)), collapse = "")
-  vwritef(c(title, lines, ""))
+  writef(c(title, lines, ""))
 
   for (reporter in reporters) {
     tryCatch(reporter(project), error = renv_error_handler)
-    vwritef()
+    writef()
   }
 
 }
 
 renv_diagnostics_session <- function(project) {
-  vwritef(header("Session Info"))
+  writef(header("Session Info"))
   renv_scope_options(width = 80)
   print(sessionInfo())
 }
 
 renv_diagnostics_project <- function(project) {
-  vwritef(header("Project"))
-  vwritef("Project path: %s", renv_path_pretty(project))
+  writef(header("Project"))
+  writef("Project path: %s", renv_path_pretty(project))
 }
 
 renv_diagnostics_status <- function(project) {
-  vwritef(header("Status"))
+  writef(header("Status"))
   status(project = project)
 }
 
 renv_diagnostics_packages <- function(project) {
 
-  vwritef(header("Packages"))
+  writef(header("Packages"))
 
   # collect state of lockfile, library, dependencies
   lockfile <- renv_diagnostics_packages_lockfile(project)
@@ -7846,8 +7679,8 @@ renv_diagnostics_packages <- function(project) {
 
   # print library codes
   fmt <- "[%s]: %s"
-  vwritef()
-  vwritef(fmt, format(seq_along(levels(flibpaths))), format(levels(flibpaths)))
+  writef()
+  writef(fmt, format(seq_along(levels(flibpaths))), format(levels(flibpaths)))
 
 }
 
@@ -7881,7 +7714,7 @@ renv_diagnostics_packages_lockfile <- function(project) {
 
   lockpath <- renv_lockfile_path(project = project)
   if (!file.exists(lockpath)) {
-    vwritef("This project has not yet been snapshotted: 'renv.lock' does not exist.")
+    writef("This project has not yet been snapshotted: 'renv.lock' does not exist.")
     return(list())
   }
 
@@ -7894,7 +7727,7 @@ renv_diagnostics_packages_library <- function(project) {
   library <- renv_paths_library(project = project)
   if (!file.exists(library)) {
     fmt <- "The project library %s does not exist."
-    vwritef(fmt, renv_path_pretty(library))
+    writef(fmt, renv_path_pretty(library))
   }
 
   snapshot(project = project, lockfile = NULL, type = "all")
@@ -7903,20 +7736,22 @@ renv_diagnostics_packages_library <- function(project) {
 
 renv_diagnostics_packages_dependencies <- function(project) {
 
-  dependencies(project,
-               progress = FALSE,
-               errors = "reported",
-               dev = TRUE)
+  renv_dependencies_impl(
+    project,
+    progress = FALSE,
+    errors = "reported",
+    dev = TRUE
+  )
 
 }
 
 renv_diagnostics_abi <- function(project) {
 
-  vwritef(header("ABI"))
+  writef(header("ABI"))
   tryCatch(
     renv_abi_check(),
     error = function(e) {
-      vwritef(conditionMessage(e))
+      writef(conditionMessage(e))
     }
   )
 
@@ -7924,19 +7759,21 @@ renv_diagnostics_abi <- function(project) {
 
 renv_diagnostics_profile <- function(project) {
 
-  vwritef(header("User Profile"))
+  writef(header("User Profile"))
 
   userprofile <- "~/.Rprofile"
   if (!file.exists(userprofile))
-    return(vwritef("[no user profile detected]"))
+    return(writef("[no user profile detected]"))
 
-  deps <- dependencies(userprofile,
-                       progress = FALSE,
-                       errors = "reported",
-                       dev = TRUE)
+  deps <- renv_dependencies_impl(
+    userprofile,
+    progress = FALSE,
+    errors = "reported",
+    dev = TRUE
+  )
 
   if (empty(deps))
-    return(vwritef("[no R packages referenced in user profile"))
+    return(writef("[no R packages referenced in user profile"))
 
   renv_scope_options(width = 200)
   print(deps)
@@ -7944,13 +7781,13 @@ renv_diagnostics_profile <- function(project) {
 }
 
 renv_diagnostics_settings <- function(project) {
-  vwritef(header("Settings"))
+  writef(header("Settings"))
   str(renv_settings_get(project))
 }
 
 renv_diagnostics_options <- function(project) {
 
-  vwritef(header("Options"))
+  writef(header("Options"))
 
   keys <- c(
     "defaultPackages",
@@ -7971,7 +7808,7 @@ renv_diagnostics_options <- function(project) {
 
 renv_diagnostics_envvars <- function(project) {
 
-  vwritef(header("Environment Variables"))
+  writef(header("Environment Variables"))
 
   envvars <- convert(as.list(Sys.getenv()), "character")
 
@@ -7983,7 +7820,7 @@ renv_diagnostics_envvars <- function(project) {
 
   matches <- envvars[useful]
   if (empty(matches))
-    return(vwritef("[no renv environment variables available]"))
+    return(writef("[no renv environment variables available]"))
 
   names(matches) <- useful
   matches[is.na(matches)] <- "<NA>"
@@ -7992,32 +7829,36 @@ renv_diagnostics_envvars <- function(project) {
   keys <- names(matches)
   vals <- matches
   formatted <- paste(format(keys), vals, sep = " = ")
-  vwritef(formatted)
+  writef(formatted)
 
 }
 
 renv_diagnostics_path <- function(project) {
-  vwritef(header("PATH"))
+  writef(header("PATH"))
   path <- strsplit(Sys.getenv("PATH"), .Platform$path.sep, fixed = TRUE)[[1]]
-  vwritef(paste("-", path))
+  writef(paste("-", path))
 }
 
 renv_diagnostics_cache <- function(project) {
 
-  vwritef(header("Cache"))
+  writef(header("Cache"))
 
   fmt <- "There are a total of %s installed in the renv cache."
   cachelist <- renv_cache_list()
-  vwritef(fmt, nplural("package", length(cachelist)))
-  vwritef("Cache path: %s", renv_path_pretty(renv_paths_cache()))
+  writef(fmt, nplural("package", length(cachelist)))
+  writef("Cache path: %s", renv_path_pretty(renv_paths_cache()))
 
 }
 
 
-# difftime.R =================================================================
+# difftime.R -----------------------------------------------------------------
 
 
 renv_difftime_format <- function(time, digits = 2L) {
+
+  if (is_testing()) {
+    return ("XXXX seconds")
+  }
 
   units <- attr(time, "units") %||% ""
   if (units == "secs" && time < 0.1) {
@@ -8062,8 +7903,20 @@ renv_difftime_format_short <- function(time, digits = 2L) {
 
 }
 
+renv_difftime_format_slow <- function(time, prefix = "", threshold = 1) {
+  if (renv_tests_running()) {
+    return("")
+  }
 
-# dots.R =====================================================================
+  if (as.difftime(time, units = "secs") < threshold) {
+    return("")
+  }
+
+  paste0(prefix, renv_difftime_format(time))
+}
+
+
+# dots.R ---------------------------------------------------------------------
 
 
 renv_dots_check <- function(...) {
@@ -8073,9 +7926,11 @@ renv_dots_check <- function(...) {
 
   # accept 'bioc' as an alias for 'bioconductor'
   bioc <- dots[["bioc"]]
-  if (!is.null("bioc") && exists("bioconductor", envir = parent)) {
-    assign("bioconductor", bioc, envir = parent)
-    dots[["bioc"]] <- NULL
+  if (!is.null(bioc) && exists("bioconductor", envir = parent)) {
+    if (is.null(parent$bioconductor)) {
+      assign("bioconductor", bioc, envir = parent)
+      dots[["bioc"]] <- NULL
+    }
   }
 
   # allow 'confirm' as an alias for 'prompt'
@@ -8105,7 +7960,7 @@ renv_dots_check <- function(...) {
 }
 
 
-# dotty.R ====================================================================
+# dotty.R --------------------------------------------------------------------
 
 
 `_renv_dotdot` <- as.symbol("..")
@@ -8196,7 +8051,7 @@ renv_dotty_find <- function(parts) {
 }
 
 
-# download.R =================================================================
+# download.R -----------------------------------------------------------------
 
 
 # download a file from 'url' to file 'destfile'. the 'type'
@@ -8239,7 +8094,7 @@ download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) 
   destfile <- chartr("\\", "/", destfile)
 
   # notify user we're about to try downloading
-  vwritef("Retrieving '%s' ...", url)
+  writef("Retrieving '%s' ...", url)
 
   # add custom headers as appropriate for the URL
   headers <- c(headers, renv_download_custom_headers(url))
@@ -8257,7 +8112,7 @@ download <- function(url, destfile, type = NULL, quiet = FALSE, headers = NULL) 
   if (identical(info$isdir, FALSE)) {
     size <- renv_download_size(url, type, headers)
     if (info$size == size) {
-      vwritef("\tOK [file is up to date]")
+      writef("\tOK [file is up to date]")
       return(destfile)
     }
   }
@@ -8421,7 +8276,6 @@ renv_download_default_agent_scope_impl <- function(headers, envir = parent.frame
 
   utils <- asNamespace("utils")
   makeUserAgent <- utils$makeUserAgent
-
   ok <-
     is.function(makeUserAgent) &&
     identical(formals(makeUserAgent), pairlist(format = TRUE))
@@ -8433,11 +8287,9 @@ renv_download_default_agent_scope_impl <- function(headers, envir = parent.frame
   all <- c("User-Agent" = agent, headers)
   headertext <- paste0(names(all), ": ", all, "\r\n", collapse = "")
 
-  renv_binding_replace("makeUserAgent", envir = utils, function(format = TRUE) {
+  renv_scope_binding(utils, "makeUserAgent", function(format = TRUE) {
     if (format) headertext else agent
-  })
-
-  defer(renv_binding_replace("makeUserAgent", makeUserAgent, envir = utils), envir = envir)
+  }, frame = envir)
 
   return(TRUE)
 
@@ -8846,10 +8698,15 @@ renv_download_report <- function(elapsed, file) {
     return()
 
   info <- renv_file_info(file)
-  size <- structure(info$size, class = "object_size")
+  if (renv_tests_running()) {
+    size <- "XXXX bytes"
+  } else {
+    size <- structure(info$size, class = "object_size")
+  }
+
 
   fmt <- "\tOK [downloaded %s in %s]"
-  vwritef(fmt, format(size, units = "auto"), renv_difftime_format(elapsed))
+  writef(fmt, format(size, units = "auto"), renv_difftime_format(elapsed))
 
 }
 
@@ -9053,7 +8910,7 @@ renv_download_available_fallback <- function(url) {
 
 renv_download_error <- function(url, fmt, ...) {
   msg <- sprintf(fmt, ...)
-  vwritef("\tERROR [%s]", msg)
+  writef("\tERROR [%s]", msg)
   stopf("error downloading '%s' [%s]", url, msg, call. = FALSE)
 }
 
@@ -9070,7 +8927,7 @@ renv_download_trace_begin <- function(url, type) {
   msg <- sprintf(fmt, url, type)
 
   title <- header(msg, n = 78L)
-  writeLines(c(title, ""))
+  writef(c(title, ""))
 
 }
 
@@ -9080,7 +8937,7 @@ renv_download_trace_request <- function(text) {
     return()
 
   title <- header("Request", n = 78L, prefix = "##")
-  writeLines(c(title, text, ""))
+  writef(c(title, text, ""))
 
 }
 
@@ -9092,17 +8949,17 @@ renv_download_trace_result <- function(output) {
   title <- header("Output", prefix = "##", n = 78L)
   text <- if (empty(output)) "[no output generated]" else output
   all <- c(title, text, "")
-  writeLines(all)
+  writef(all)
 
   status <- attr(output, "status", exact = TRUE) %||% 0L
   title <- header("Status", prefix = "##", n = 78L)
   all <- c(title, status, "")
-  writeLines(all)
+  writef(all)
 
 }
 
 
-# dynamic.R ==================================================================
+# dynamic.R ------------------------------------------------------------------
 
 
 #
@@ -9129,7 +8986,7 @@ dynamic <- function(key, value, envir = NULL) {
 
   # get a unique id for the scope where this function was invoked
   caller <- sys.call(sys.parent())[[1L]]
-  if (is.call(caller) && identical(caller[[1L]], as.symbol(":::")))
+  if (renv_call_matches(caller, name = ":::"))
     caller <- caller[[3L]]
 
   # handle cases like FUN
@@ -9147,7 +9004,7 @@ dynamic <- function(key, value, envir = NULL) {
   }
 
   # make sure we have a dynamic scope active
-  `_renv_dynamic_envir` <<- `_renv_dynamic_envir` %??% {
+  `_renv_dynamic_envir` <<- `_renv_dynamic_envir` %||% {
     renv_dynamic_envir(envir)
   }
 
@@ -9163,7 +9020,7 @@ dynamic <- function(key, value, envir = NULL) {
   id <- sprintf("%s(%s)", as.character(caller), key)
 
   # memoize the result of the expression
-  `_renv_dynamic_objects`[[id]] <- `_renv_dynamic_objects`[[id]] %??% {
+  `_renv_dynamic_objects`[[id]] <- `_renv_dynamic_objects`[[id]] %||% {
     dlog("dynamic", "memoizing dynamic value for '%s'", id)
     value
   }
@@ -9172,7 +9029,7 @@ dynamic <- function(key, value, envir = NULL) {
 
 renv_dynamic_envir <- function(envir = NULL) {
 
-  envir <- envir %??% renv_dynamic_envir_impl()
+  envir <- envir %||% renv_dynamic_envir_impl()
   defer(renv_dynamic_reset(), envir = envir)
 
   dlog("dynamic", "using dynamic environment '%s'", format(envir))
@@ -9196,7 +9053,7 @@ renv_dynamic_reset <- function() {
 }
 
 
-# embed.R ====================================================================
+# embed.R --------------------------------------------------------------------
 
 #' Capture and re-use dependencies within a `.R` or `.Rmd`
 #'
@@ -9306,7 +9163,7 @@ renv_embed_create <- function(path = NULL,
   lockfile <- renv_embed_lockfile_resolve(lockfile, project)
 
   # figure out recursive package dependencies
-  deps <- dependencies(path, progress = FALSE)
+  deps <- renv_dependencies_impl(path, progress = FALSE)
   packages <- sort(unique(deps$Package))
   all <- renv_package_dependencies(packages)
 
@@ -9468,7 +9325,7 @@ renv_embed_lockfile_resolve <- function(lockfile, project) {
 }
 
 
-# encoding.R =================================================================
+# encoding.R -----------------------------------------------------------------
 
 
 renv_encoding_mark <- function(x, encoding = "UTF-8") {
@@ -9477,7 +9334,7 @@ renv_encoding_mark <- function(x, encoding = "UTF-8") {
 }
 
 
-# ensure.R ===================================================================
+# ensure.R -------------------------------------------------------------------
 
 
 ensure_existing_path <- function(path) {
@@ -9531,7 +9388,7 @@ ensure_parent_directory <- function(path) {
 
 
 
-# envir.R ====================================================================
+# envir.R --------------------------------------------------------------------
 
 
 renv_envir_self <- function() {
@@ -9553,29 +9410,8 @@ renv_envir_unwrap <- function(envir) {
 }
 
 
-# envvar.R ===================================================================
+# envvar.R -------------------------------------------------------------------
 
-
-
-renv_envvar_get <- function(key, unset = NA) {
-  Sys.getenv(key, unset = unset)
-}
-
-renv_envvar_set <- function(key, value) {
-
-  # handle NULL / NA values
-  if (is.null(value) || is.na(value))
-    return(Sys.unsetenv(key))
-
-  # otherwise, delegate
-  args <- structure(list(value), names = key)
-  do.call(Sys.setenv, args)
-
-}
-
-renv_envvar_clear <- function(key) {
-  Sys.unsetenv(key)
-}
 
 renv_envvar_path_add <- function(envvar, value, prepend = TRUE) {
 
@@ -9592,8 +9428,12 @@ renv_envvar_path_add <- function(envvar, value, prepend = TRUE) {
 
 }
 
+renv_envvar_exists <- function(key) {
+  !is.na(Sys.getenv(key, unset = NA))
+}
 
-# envvars.R ==================================================================
+
+# envvars.R ------------------------------------------------------------------
 
 
 renv_envvars_list <- function() {
@@ -9683,7 +9523,7 @@ renv_envvars_normalize <- function() {
 }
 
 
-# equip-macos.R ==============================================================
+# equip-macos.R --------------------------------------------------------------
 
 
 renv_equip_macos_specs <- function() {
@@ -9715,9 +9555,7 @@ renv_equip_macos_specs <- function() {
 }
 
 renv_equip_macos_spec <- function(version = getRversion()) {
-  specs <- renv_equip_macos_specs()
-  majmin <- numeric_version(version)[1, 1:2]
-  specs[[format(majmin)]]
+  renv_equip_macos_specs()[[renv_version_maj_min(version)]]
 }
 
 renv_equip_macos <- function() {
@@ -9758,7 +9596,7 @@ renv_equip_macos_toolchain <- function() {
   clang <- file.path(dst, "bin/clang")
   if (file.exists(clang)) {
     fmt <- "* LLVM toolchain for R %s is already installed at %s."
-    vwritef(fmt, getRversion(), shQuote(dst))
+    writef(fmt, getRversion(), shQuote(dst))
     return(TRUE)
   }
 
@@ -9772,8 +9610,7 @@ renv_equip_macos_toolchain <- function() {
   renv_pretty_print(
     command,
     "The R LLVM toolchain has been successfully downloaded. Please execute:",
-    "in a separate terminal to complete installation.",
-    wrap = FALSE
+    "in a separate terminal to complete installation."
   )
 
   TRUE
@@ -9816,8 +9653,7 @@ renv_equip_macos_rstudio <- function(spec, destfile) {
   renv_pretty_print(
     spec$dst,
     "The R LLVM toolchain has been downloaded and installed to:",
-    "This toolchain will be used by renv when installing packages from source.",
-    wrap = FALSE
+    "This toolchain will be used by renv when installing packages from source."
   )
 
   return(TRUE)
@@ -9825,17 +9661,18 @@ renv_equip_macos_rstudio <- function(spec, destfile) {
 }
 
 
-# equip.R ====================================================================
+# equip.R --------------------------------------------------------------------
 
 
-#' Install Required System Libraries
+#' Install required system libraries
 #'
 #' Equip your system with libraries commonly-used during compilation of
-#' \R packages. Currently only supported on Windows.
+#' base and recommended \R packages. This was previously useful with older
+#' versions of R on windows, but is no longer terribly helpful.
 #'
 #' @return This function is normally called for its side effects.
 #' @export
-#'
+#' @keywords internal
 #' @examples
 #' \dontrun{
 #'
@@ -9866,7 +9703,7 @@ renv_equip_linux <- function() {
 }
 
 
-# errors.R ===================================================================
+# errors.R -------------------------------------------------------------------
 
 
 renv_error_format_srcref <- function(call, srcref) {
@@ -9919,11 +9756,7 @@ renv_error_simplify_function <- function(object) {
 
 renv_error_simplify_recursive <- function(object) {
 
-  longcall <-
-    is.call(object) &&
-    is.symbol(object[[1]]) &&
-    object[[1]] == as.name("{") &&
-    length(object) >= 8
+  longcall <- renv_call_matches(object, name = "{") && length(object) >= 8
 
   if (longcall)
     return(quote(...))
@@ -10007,21 +9840,23 @@ renv_error_handler <- function(...) {
     return(character())
 
   formatted <- renv_error_format(calls, frames)
-  writeLines(formatted, con = stderr())
+  writef(formatted)
 
   formatted
 
 }
 
+`_renv_traceback` <- NULL
+
 renv_error_capture <- function(e) {
   calls <- head(sys.calls(), n = -2L)
   frames <- head(sys.frames(), n = -2L)
   traceback <- renv_error_format(calls, frames)
-  renv_global_set("traceback", traceback)
+  `_renv_traceback` <<- traceback
 }
 
 renv_error_tag <- function(e) {
-  e$traceback <- renv_global_get("traceback")
+  e$traceback <- `_renv_traceback`
   e
 }
 
@@ -10035,7 +9870,7 @@ renv_error_report <- function(error = NULL) {
 }
 
 
-# exports.R ==================================================================
+# exports.R ------------------------------------------------------------------
 
 
 
@@ -10076,7 +9911,7 @@ renv_exports_attach <- function() {
 }
 
 
-# extsoft.R ==================================================================
+# extsoft.R ------------------------------------------------------------------
 
 
 renv_extsoft_curl_version <- function() {
@@ -10105,7 +9940,7 @@ renv_extsoft_install <- function(quiet = FALSE) {
   # check for missing installs
   files <- Filter(renv_extsoft_install_required, files)
   if (empty(files)) {
-    if (!quiet) vwritef("* External software is up to date.")
+    if (!quiet) writef("* External software is up to date.")
     return(TRUE)
   }
 
@@ -10114,8 +9949,7 @@ renv_extsoft_install <- function(quiet = FALSE) {
     renv_pretty_print(
       files,
       "The following external software tools will be installed:",
-      sprintf("Tools will be installed into %s.", renv_path_pretty(extsoft)),
-      wrap = FALSE
+      sprintf("Tools will be installed into %s.", renv_path_pretty(extsoft))
     )
 
     cancel_if(!proceed())
@@ -10166,7 +10000,7 @@ renv_extsoft_install <- function(quiet = FALSE) {
 
   }
 
-  vwritef("* External software successfully updated.")
+  writef("* External software successfully updated.")
   TRUE
 
 }
@@ -10219,16 +10053,15 @@ renv_extsoft_use <- function(quiet = FALSE) {
     renv_pretty_print(
       c(localsoft, libxml, localcpp, locallibs),
       "The following entries will be added to ~/.R/Makevars:",
-      "These tools will be used when compiling R packages from source.",
-      wrap = FALSE
+      "These tools will be used when compiling R packages from source."
     )
 
     cancel_if(!proceed())
 
   }
 
-  if (!quiet) vwritef("* '%s' has been updated.", path)
-  writeLines(contents, path)
+  if (!quiet) writef("* '%s' has been updated.", path)
+  writeLines(contents, con = path)
   TRUE
 
 }
@@ -10239,7 +10072,7 @@ renv_extsoft_manifest_path <- function(file) {
 }
 
 
-# filebacked.R ===============================================================
+# filebacked.R ---------------------------------------------------------------
 
 
 # tools for caching values read from a file, and invalidating those values if
@@ -10318,7 +10151,7 @@ renv_filebacked_get <- function(scope, path) {
 
 renv_filebacked_envir <- function(scope) {
   `_renv_filebacked`[[scope]] <-
-    `_renv_filebacked`[[scope]] %??%
+    `_renv_filebacked`[[scope]] %||%
     new.env(parent = emptyenv())
 }
 
@@ -10343,7 +10176,7 @@ filebacked <- function(scope, path, callback, ...) {
 }
 
 
-# files.R ====================================================================
+# files.R --------------------------------------------------------------------
 
 
 # NOTE: all methods here should either return TRUE if they were able to
@@ -10641,8 +10474,8 @@ renv_file_same <- function(source, target) {
 
   # check to see if they're equal after normalization
   # (e.g. for symlinks pointing to same file)
-  source <- renv_path_normalize(source, mustWork = FALSE)
-  target <- renv_path_normalize(target, mustWork = FALSE)
+  source <- renv_path_normalize(source)
+  target <- renv_path_normalize(target)
   if (identical(source, target))
     return(TRUE)
 
@@ -10674,11 +10507,11 @@ renv_file_backup <- function(path) {
   # by the time the callback is invoked). note that the file may
   # be a broken symlink so construct the path by normalizing the
   # parent directory and building path relative to that
-  parent <- renv_path_normalize(dirname(path), winslash = "/", mustWork = TRUE)
+  parent <- renv_path_normalize(dirname(path), mustWork = TRUE)
   path <- file.path(parent, basename(path))
 
   # attempt to rename the file
-  pattern <- sprintf(".renv-backup-%s", basename(path))
+  pattern <- sprintf(".renv-backup-%i-%s", Sys.getpid(), basename(path))
   tempfile <- tempfile(pattern, tmpdir = dirname(path))
   if (!renv_file_move(path, tempfile))
     return(function() {})
@@ -10751,8 +10584,7 @@ renv_file_list_impl_win32 <- function(path) {
   #
   # change working directory (done just to avoid encoding issues
   # when submitting path to cmd shell)
-  owd <- setwd(path)
-  defer(setwd(owd))
+  renv_scope_wd(path)
 
   # NOTE: a sub-shell is required here in some contexts; e.g. when running
   # tests non-interactively or building in the RStudio pane
@@ -10960,9 +10792,8 @@ renv_file_writable <- function(path) {
     return(FALSE)
 
   # try creating and removing a temporary file in this directory
-  tempfile <- tempfile(".renv-write-test-", tmpdir = path)
+  tempfile <- renv_scope_tempfile(".renv-write-test-", tmpdir = path)
   ok <- dir.create(tempfile, showWarnings = FALSE)
-  defer(unlink(tempfile, recursive = TRUE, force = TRUE))
 
   # return ok if we succeeded
   ok
@@ -10970,7 +10801,7 @@ renv_file_writable <- function(path) {
 }
 
 
-# git.R ======================================================================
+# git.R ----------------------------------------------------------------------
 
 
 renv_git_preflight <- function() {
@@ -10980,7 +10811,7 @@ renv_git_preflight <- function() {
 
 renv_git_root <- function(project) {
 
-  project <- normalizePath(project, winslash = "/", mustWork = FALSE)
+  project <- renv_path_normalize(project)
   renv_file_find(project, function(parent) {
     gitroot <- file.path(parent, ".git")
     if (file.exists(gitroot))
@@ -10990,31 +10821,7 @@ renv_git_root <- function(project) {
 }
 
 
-# globals.R ==================================================================
-
-
-`_renv_globals` <- new.env(parent = emptyenv())
-
-global <- function(name, value) {
-  `_renv_globals`[[name]] <- `_renv_globals`[[name]] %||% value
-}
-
-renv_global_get <- function(name) {
-  `_renv_globals`[[name]]
-}
-
-renv_global_set <- function(name, value) {
-  `_renv_globals`[[name]] <- value
-}
-
-renv_global_clear <- function(name) {
-  if (exists(name, envir = `_renv_globals`, inherits = FALSE))
-    rm(list = name, envir = `_renv_globals`, inherits = FALSE)
-}
-
-
-
-# graph.R ====================================================================
+# graph.R --------------------------------------------------------------------
 
 
 #' Generate a Package Dependency Graph
@@ -11109,7 +10916,7 @@ graph <- function(root = NULL,
   remaining <- intersect(root, names(graph)[ok])
   if (empty(remaining)) {
     fmt <- "* Could not find any relationship between the requested packages."
-    vwritef(fmt)
+    writef(fmt)
     return(invisible(NULL))
   }
 
@@ -11233,7 +11040,7 @@ renv_graph_revdeps_impl <- function(package, envir, revdeps) {
 
 renv_graph_roots <- function(project) {
 
-  deps <- dependencies(project, quiet = TRUE)
+  deps <- renv_dependencies_impl(project, quiet = TRUE)
   sort(unique(deps$Package))
 
 }
@@ -11466,7 +11273,7 @@ renv_graph_renderer <- function(renderer) {
 
 
 
-# hash.R =====================================================================
+# hash.R ---------------------------------------------------------------------
 
 
 renv_hash_text <- function(text) {
@@ -11556,10 +11363,10 @@ renv_hash_description_remotes <- function(dcf) {
 }
 
 
-# history.R ==================================================================
+# history.R ------------------------------------------------------------------
 
 
-#' View and Revert to a Historical Lockfile
+#' View and revert to a historical lockfile
 #'
 #' @description
 #' `history()` uses your version control system to show prior versions of the
@@ -11601,8 +11408,7 @@ history <- function(project = NULL) {
 
   renv_git_preflight()
 
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
 
   args <- c("log", "--pretty=format:%H\031%at\031%ct\031%s", renv_shell_path(lockpath))
   data <- renv_system_exec("git", args, action = "retrieving git log")
@@ -11630,21 +11436,20 @@ revert <- function(commit = "HEAD", ..., project = NULL) {
 
   renv_git_preflight()
 
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
 
   lockpath <- renv_lockfile_path(project = project)
   system2("git", c("checkout", commit, "--", renv_shell_path(lockpath)))
   system2("git", c("reset", "HEAD", renv_shell_path(lockpath)), stdout = FALSE, stderr = FALSE)
   system2("git", c("diff", "--", renv_shell_path(lockpath)))
 
-  vwritef("* renv.lock from commit %s has been checked out.", commit)
+  writef("* renv.lock from commit %s has been checked out.", commit)
   invisible(commit)
 
 }
 
 
-# homebrew.R =================================================================
+# homebrew.R -----------------------------------------------------------------
 
 
 renv_homebrew_root <- function() {
@@ -11664,7 +11469,7 @@ renv_homebrew_root <- function() {
 }
 
 
-# http.R =====================================================================
+# http.R ---------------------------------------------------------------------
 
 
 renv_http_useragent <- function() {
@@ -11679,46 +11484,27 @@ renv_http_useragent_default <- function() {
 }
 
 
-# hydrate.R ==================================================================
+# hydrate.R ------------------------------------------------------------------
 
 
-#' Hydrate a Project
+#' Copy packages from user libraries to a project library
 #'
-#' Discover the \R packages used within a project, and then install those
-#' packages into the active library. This effectively allows you to fork the
-#' state of your default \R libraries for use within a project library.
+#' @description
+#' `hydrate()` installs missing packages from a user library into the project
+#' library. `hydrate()` is called automatically by [init()], and it is rare
+#' that you should need it otherwise, as it can easily get your project into
+#' an inconsistent state.
 #'
-#' It may occasionally be useful to use `renv::hydrate()` to update the packages
-#' used within a project that has already been initialized. However, be aware
-#' that it's possible that the packages pulled in may not actually be compatible
-#' with the packages already installed in the project library, so you should
-#' exercise caution when doing so.
-#'
-#' @section Sources:
-#'
-#' `hydrate()` attempts to re-use packages already installed on your system,
-#' to avoid unnecessary attempts to download and install packages from remote
-#' sources. When `NULL` (the default), `hydrate()` will attempt to discover \R
-#' packages from the following sources (in order):
-#'
-#' - The user library,
-#' - The site library,
-#' - The system library,
-#' - The renv cache.
-#'
-#' If package is discovered in one of these locations, renv will attempt to
-#' copy or link that package into the requested library as appropriate.
-#'
-#' @section Missing Packages:
-#'
-#' If renv discovers that your project depends on \R packages not currently
-#' installed in your user library, then it will attempt to install those
-#' packages from the active R repositories.
+#' It may very occasionally be useful to call `hydate(update = "all")` if you
+#' want to update project packages to match those installed in your global
+#' library (as opposed to using [update()] which will get the latest versions
+#' from CRAN). In this case, you should verify that your code continues to work,
+#' then call [snapshot()] to record updated package versions in the lockfile.
 #'
 #' @inherit renv-params
 #'
 #' @param packages The set of \R packages to install. When `NULL`, the
-#'   set of packages as reported by [dependencies()] is used.
+#'   packages found by [dependencies()] are used.
 #'
 #' @param library The \R library to be hydrated. When `NULL`, the active
 #'   library as reported by `.libPaths()` is used.
@@ -11728,8 +11514,13 @@ renv_http_useragent_default <- function() {
 #'   library? Set this to `"all"` if you'd like _all_ packages to be refreshed
 #'   from the source library if possible.
 #'
-#' @param sources A set of library paths from which renv should attempt to
-#'   draw packages. See **Sources** for more details.
+#' @param sources A vector of library paths where renv should look for packages.
+#'   When `NULL` (the default), `hydrate()` will look in the system libraries
+#'   (the user library, the site library and the default library) then the
+#'   renv cache.
+#'
+#'   If a package is not found in any of these locations, `hydrate()`
+#'   will try to install it from the active R repositories.
 #'
 #' @param prompt Boolean; prompt the user before taking any action? Ignored
 #'   when `report = FALSE`.
@@ -11741,6 +11532,8 @@ renv_http_useragent_default <- function() {
 #'   as well as the set of packages which were not found.
 #'
 #' @export
+#'
+#' @keywords internal
 #'
 #' @examples
 #' \dontrun{
@@ -11800,7 +11593,7 @@ hydrate <- function(packages = NULL,
   # check for nothing to be done
   if (empty(packages) && empty(na)) {
     if (report)
-      vwritef("* No new packages were discovered in this project; nothing to do.")
+      writef("* No new packages were discovered in this project; nothing to do.")
     return(invisible(list(packages = list(), missing = list())))
   }
 
@@ -11817,7 +11610,7 @@ hydrate <- function(packages = NULL,
   if (report) {
     time <- difftime(after, before, units = "auto")
     fmt <- "* Hydrated %s packages in %s."
-    vwritef(fmt, length(packages), renv_difftime_format(time))
+    writef(fmt, length(packages), renv_difftime_format(time))
   }
 
   # attempt to install missing packages (if any)
@@ -11914,12 +11707,12 @@ renv_hydrate_dependencies <- function(project,
                                       packages = NULL,
                                       libpaths = NULL)
 {
-  vprintf("* Discovering package dependencies ... ")
+  printf("* Discovering package dependencies ... ")
   ignored <- renv_project_ignored_packages(project = project)
   packages <- renv_vector_diff(packages, ignored)
   libpaths <- libpaths %||% renv_hydrate_libpaths()
   all <- renv_package_dependencies(packages, project = project, libpaths = libpaths)
-  vwritef("Done!")
+  writef("Done!")
 
   all
 }
@@ -11934,7 +11727,7 @@ renv_hydrate_libpaths <- function() {
     conf <- unlist(strsplit(conf, ":", fixed = TRUE))
 
   libpaths <- case(
-    renv_tests_running() ~ renv_libpaths_all(),
+    renv_tests_running() ~ character(),
     length(conf) ~ conf,
     ~ c(
       renv_libpaths_default(),
@@ -11975,15 +11768,14 @@ renv_hydrate_link_package <- function(package, location, library) {
 
 renv_hydrate_link_packages <- function(packages, library, project) {
 
-  header <- if (renv_path_same(library, renv_paths_library(project = project)))
-    "* Linking packages into the project library ... "
+  if (renv_path_same(library, renv_paths_library(project = project)))
+    printf("* Linking packages into the project library ... ")
   else
-    sprintf("* Linking packages into %s ... ", renv_path_pretty(library))
+    printf("* Linking packages into %s ... ", renv_path_pretty(library))
 
-  vprintf(header)
   callback <- renv_progress_callback(renv_hydrate_link_package, length(packages))
   cached <- enumerate(packages, callback, library = library)
-  vwritef("Done!")
+  writef("Done!")
   cached
 
 }
@@ -11997,15 +11789,14 @@ renv_hydrate_copy_package <- function(package, location, library) {
 
 renv_hydrate_copy_packages <- function(packages, library, project) {
 
-  header <- if (renv_path_same(library, renv_paths_library(project = project)))
-    "* Copying packages into the project library ... "
+  if (renv_path_same(library, renv_paths_library(project = project)))
+    printf("* Copying packages into the project library ... ")
   else
-    sprintf("* Copying packages into %s ... ", renv_path_pretty(library))
+    printf("* Copying packages into %s ... ", renv_path_pretty(library))
 
-  vprintf(header)
   callback <- renv_progress_callback(renv_hydrate_copy_package, length(packages))
   copied <- enumerate(packages, callback, library = library)
-  vwritef("Done!")
+  writef("Done!")
   copied
 }
 
@@ -12027,7 +11818,7 @@ renv_hydrate_resolve_missing <- function(project, library, na) {
   if (all(packages %in% installed$Package))
     return()
 
-  vwritef("* Resolving missing dependencies ... ")
+  writef("* Resolving missing dependencies ... ")
 
   # define a custom error handler for packages which
   # we failed to retrieve
@@ -12066,8 +11857,7 @@ renv_hydrate_resolve_missing <- function(project, library, na) {
     renv_pretty_print(
       text,
       "The following package(s) were not installed successfully:",
-      "You may need to manually download and install these packages.",
-      wrap = FALSE
+      "You may need to manually download and install these packages."
     )
 
   }
@@ -12124,7 +11914,7 @@ renv_hydrate_report <- function(packages, na, linkable) {
 }
 
 
-# id.R =======================================================================
+# id.R -----------------------------------------------------------------------
 
 
 renv_id_path <- function(project) {
@@ -12190,13 +11980,11 @@ renv_id_generate_cscript <- function() {
   }
 
   # create temporary directory
-  dir <- tempfile("renv-id-")
+  dir <- renv_scope_tempfile("renv-id-")
   dir.create(dir)
-  defer(unlink(dir, recursive = TRUE))
 
   # move to it
-  owd <- setwd(dir)
-  defer(setwd(owd))
+  renv_scope_wd(dir)
 
   # write helper script
   script <- c(
@@ -12299,7 +12087,7 @@ class GenerateUUID {
 }
 
 
-# imbue.R ====================================================================
+# imbue.R --------------------------------------------------------------------
 
 
 #' Imbue an renv Installation
@@ -12329,9 +12117,9 @@ imbue <- function(project = NULL,
   renv_scope_options(renv.verbose = !quiet)
 
   vtext <- version %||% renv_metadata_version()
-  vwritef("Installing renv [%s] ...", vtext)
+  writef("Installing renv [%s] ...", vtext)
   status <- renv_imbue_impl(project, version)
-  vwritef("* Done! renv has been successfully installed.")
+  writef("* Done! renv has been successfully installed.")
 
   invisible(status)
 
@@ -12370,12 +12158,12 @@ renv_imbue_impl <- function(project, version = NULL, force = FALSE) {
   ensure_directory(library)
   renv_scope_libpaths(library)
 
-  vwritef("Installing renv [%s] ...", version)
+  writef("Installing renv [%s] ...", version)
   before <- Sys.time()
   with(record, r_cmd_install(Package, Path, library))
   after <- Sys.time()
   elapsed <- difftime(after, before, units = "auto")
-  vwritef("\tOK [built source in %s]", renv_difftime_format(elapsed))
+  writef("\tOK [built source in %s]", renv_difftime_format(elapsed))
 
   invisible(record)
 
@@ -12425,7 +12213,7 @@ renv_imbue_self_binary <- function(source, target) {
 }
 
 
-# imports.R ==================================================================
+# imports.R ------------------------------------------------------------------
 
 
 #' @importFrom utils
@@ -12437,7 +12225,7 @@ renv_imbue_self_binary <- function(source, target) {
 NULL
 
 
-# index.R ====================================================================
+# index.R --------------------------------------------------------------------
 
 
 `_renv_index` <- new.env(parent = emptyenv())
@@ -12545,7 +12333,7 @@ renv_index_get <- function(root, scope, index, key, now, limit) {
 
   # add to in-memory cache
   `_renv_index`[[scope]] <-
-    `_renv_index`[[scope]] %??%
+    `_renv_index`[[scope]] %||%
     new.env(parent = emptyenv())
 
   `_renv_index`[[scope]][[key]] <- value
@@ -12644,8 +12432,15 @@ renv_index_writable <- function(root) {
   )
 }
 
+# in case of emergency, break glass
+renv_index_reset <- function(root = NULL) {
+  root <- root %||% renv_paths_index()
+  lockfiles <- list.files(root, pattern = "^index\\.lock$", full.names = TRUE)
+  unlink(lockfiles)
+}
 
-# infrastructure.R ===========================================================
+
+# infrastructure.R -----------------------------------------------------------
 
 
 # tools for writing / removing renv-related infrastructure
@@ -12781,7 +12576,7 @@ renv_infrastructure_write_entry_impl <- function(add, remove, file, create) {
 
     # otherwise, write the file
     ensure_parent_directory(file)
-    writeLines(add, file)
+    writeLines(add, con = file)
     return(TRUE)
 
   }
@@ -12817,7 +12612,7 @@ renv_infrastructure_write_entry_impl <- function(add, remove, file, create) {
 
   # write to file if we have changes
   if (!identical(before, after))
-    writeLines(after, file)
+    writeLines(after, con = file)
 
   TRUE
 
@@ -12881,7 +12676,7 @@ renv_infrastructure_remove_entry_impl <- function(line, file, removable) {
   # otherwise, just mutate the file
   replacement <- gsub("^(\\s*)", "\\1# ", contents[matches], perl = TRUE)
   contents[matches] <- replacement
-  writeLines(contents, file)
+  writeLines(contents, con = file)
 
   TRUE
 
@@ -12890,7 +12685,7 @@ renv_infrastructure_remove_entry_impl <- function(line, file, removable) {
 
 
 
-# init.R =====================================================================
+# init.R ---------------------------------------------------------------------
 
 
 #' Use renv in a project
@@ -12914,9 +12709,19 @@ renv_infrastructure_remove_entry_impl <- function(line, file, removable) {
 #' to do the right thing: it will restore the project library if it's missing,
 #' or otherwise ask you what to do.
 #'
+#' # Repositories
+#'
+#' If the default \R repositories have not already been set, renv will use
+#' the [Posit Public Package Manager](https://packagemanager.posit.co/) CRAN
+#' mirror for package installation. The primary benefit to using this mirror is
+#' that it can provide pre-built binaries for \R packages on a variety of
+#' commonly-used Linux distributions. This behavior can be configured or
+#' disabled if desired -- see the options in [renv::config()] for more details.
+#'
 #' @inherit renv-params
 #'
-#' @param project The project directory. The \R working directory will be
+#' @param project The project directory. When `NULL` (the default), the current
+#'   working directory will be used. The \R working directory will be
 #'   changed to match the requested project directory.
 #'
 #' @param settings A list of [settings] to be used with the newly-initialized
@@ -12929,8 +12734,8 @@ renv_infrastructure_remove_entry_impl <- function(line, file, removable) {
 #'   to initialize the home directory as a project, to defend against accidental
 #'   mis-usages of `init()`.
 #'
-#' @param repos The \R repositories to be used in this project. By default,
-#'   the active repositories (as determined by `getOption("repos")`) are used.
+#' @param repos The \R repositories to be used in this project.
+#'   See **Repositories** for more details.
 #'
 #' @param bioconductor The version of Bioconductor to be used with this project.
 #'   Setting this may be appropriate if renv is unable to determine that your
@@ -12967,7 +12772,7 @@ init <- function(project = NULL,
     renv_profile_set(profile)
 
   # normalize repos
-  repos <- renv_repos_normalize(repos %||% getOption("repos"))
+  repos <- renv_repos_normalize(repos %||% renv_init_repos())
   options(repos = repos)
 
   # form path to lockfile, library
@@ -12986,7 +12791,7 @@ init <- function(project = NULL,
     options(repos = biocrepos)
 
     # notify user
-    vwritef("* Using Bioconductor version '%s'.", biocver)
+    writef("* Using Bioconductor version '%s'.", biocver)
     settings[["bioconductor.version"]] <- biocver
 
   }
@@ -13002,7 +12807,7 @@ init <- function(project = NULL,
 
   # for bare inits, just activate the project
   if (bare)
-    return(renv_init_fini(project, profile, version, restart, quiet))
+    return(renv_init_fini(project, profile, restart, quiet))
 
   # collect dependencies
   renv_dependencies_scope(project, action = "init")
@@ -13025,18 +12830,16 @@ init <- function(project = NULL,
   }
 
   # activate the newly-hydrated project
-  renv_init_fini(project, profile, version, restart, quiet)
+  renv_init_fini(project, profile, restart, quiet)
 
 }
 
-renv_init_fini <- function(project, profile, version, restart, quiet) {
-
-  version <- renv_metadata_version()
+renv_init_fini <- function(project, profile, restart, quiet) {
 
   renv_activate_impl(
     project = project,
     profile = profile,
-    version = version,
+    version = renv_metadata_version(),
     restart = restart,
     quiet   = quiet
   )
@@ -13168,11 +12971,43 @@ renv_init_bioconductor <- function(bioconductor, project) {
 
 }
 
+renv_init_repos <- function() {
 
-# install.R ==================================================================
+  # if PPM is disabled, just use default repositories
+  repos <- convert(getOption("repos"), "list")
+  if (!renv_ppm_enabled())
+    return(repos)
+
+  enabled <- config$ppm.default()
+  if (!enabled)
+    return(repos)
+
+  # if we're using the global CDN from RStudio, use PPM instead
+  rstudio <- attr(repos, "RStudio", exact = TRUE)
+  if (identical(rstudio, TRUE)) {
+    cran <- repos[["CRAN"]]
+    if (startswith(cran, "https://cran.rstudio.") ||
+        startswith(cran, "https://cran.posit."))
+    {
+      repos[["CRAN"]] <- config$ppm.url()
+      return(repos)
+    }
+  }
+
+  # if no repository was set, use PPM
+  if (identical(repos, list(CRAN = "@CRAN@")))
+    return(config$ppm.url())
+
+  # repos appears to have been configured separately; just use it
+  repos
+
+}
 
 
-#' Install Packages
+# install.R ------------------------------------------------------------------
+
+
+#' Install packages
 #'
 #' @description
 #' Install one or more \R packages, from a variety of remote sources.
@@ -13184,7 +13019,7 @@ renv_init_bioconductor <- function(bioconductor, project) {
 #'
 #' See `vignette("package-install")` for more details.
 #'
-#' @section Project DESCRIPTION Files:
+#' # Project `DESCRIPTION` files
 #'
 #' If your project contains a `DESCRIPTION` file, then calling `install()`
 #' without any arguments will instruct renv to install the latest versions of
@@ -13204,7 +13039,7 @@ renv_init_bioconductor <- function(bioconductor, project) {
 #' Otherwise, you can declare the package sources in your `DESCRIPTION`'s
 #' `Remotes:` field.
 #'
-#' @section Bioconductor:
+#' # Bioconductor
 #'
 #' Packages from Bioconductor can be installed by using the `bioc::` prefix.
 #' For example,
@@ -13289,6 +13124,7 @@ install <- function(packages = NULL,
 
     packages <- c(packages, dots[!nzchar(names(dots))])
   }
+  install_all <- is.null(packages)
 
   project <- renv_project_resolve(project)
   renv_project_lock(project = project)
@@ -13315,24 +13151,30 @@ install <- function(packages = NULL,
     return(renv_pak_install(packages, libpaths, project))
   }
 
-  # get and resolve the packages / remotes to be installed
-  remotes <- packages %??% renv_project_remotes(project, dependencies)
-  if (empty(remotes)) {
-    vwritef("* There are no packages to install.")
+  packages <- packages %||% renv_snapshot_dependencies(project, dev = TRUE)
+  if (empty(packages)) {
+    writef("* There are no packages to install.")
     return(invisible(list()))
   }
 
-  # resolve remotes
-  remotes <- lapply(remotes, renv_remotes_resolve)
+  # retrieve currently installed packages
+  records <- renv_snapshot_libpaths(libpaths = libpaths, project = project)
+
+  # generate package records to install
+  remotes <- lapply(packages, renv_remotes_resolve)
   names(remotes) <- extract_chr(remotes, "Package")
 
-  # update records with requested remotes
-  records <- renv_snapshot_libpaths(libpaths = libpaths, project = project)
-  records[names(remotes)] <- remotes
+  if (install_all) {
+    # apply version specifications and Remotes from DESCRIPTION
+    pkg_remotes <- renv_project_remotes(project)
+    remotes <- c(exclude(remotes, names(pkg_remotes)), pkg_remotes)
 
-  # read remotes from the package DESCRIPTION file and use those to
-  # update non-specific package requests
-  records <- renv_install_remotes_update(records, project)
+    # only install packages that aren't already installed
+    remotes <- exclude(remotes, names(records))
+  }
+
+  # update existing records with requested remotes
+  records[names(remotes)] <- remotes
 
   # run install preflight checks
   if (!renv_install_preflight(project, libpaths, remotes))
@@ -13353,29 +13195,23 @@ install <- function(packages = NULL,
   # retrieve packages
   records <- retrieve(names(remotes))
   if (empty(records)) {
-    vwritef("* There are no packages to install.")
+    writef("* There are no packages to install.")
     return(invisible(list()))
   }
+
+  libpath <- renv_path_pretty(renv_libpaths_active())
+  writef(header(sprintf("Installing packages into %s", libpath)))
+  if (prompt || renv_verbose())
+    renv_install_report(records)
+  cancel_if(prompt && !proceed())
 
   # install retrieved records
   renv_install_impl(records)
 
   after <- Sys.time()
-  if (!renv_tests_running()) {
-    time <- renv_difftime_format(difftime(after, before))
-    n <- length(records)
-    vwritef("* Installed %s in %s.", nplural("package", n), time)
-  }
-
-  # a bit of extra test reporting
-  if (renv_tests_running()) {
-    fmt <- "Installed %s into library at path %s."
-    vwritef(
-      fmt,
-      nplural("package", length(records)),
-      renv_path_pretty(renv_libpaths_active())
-    )
-  }
+  time <- renv_difftime_format(difftime(after, before))
+  n <- length(records)
+  writef("Installed %s in %s.", nplural("package", n), time)
 
   # check loaded packages and inform user if out-of-sync
   renv_install_postamble(names(records))
@@ -13507,6 +13343,10 @@ renv_install_staged_library_path <- function() {
 renv_install_default <- function(records) {
   state <- renv_restore_state()
   handler <- state$handler
+
+  pkg_width <- max(nchar(map_chr(records, function(x) x$Package)), 1)
+  renv_scope_options(renv.package.width = pkg_width)
+
   for (record in records) {
     package <- record$Package
     handler(package, renv_install_package(record))
@@ -13545,7 +13385,7 @@ renv_install_package <- function(record) {
   withCallingHandlers(
     renv_install_package_impl(record),
     error = function(e) {
-      vwritef("\tFAILED")
+      writef(" FAILED")
       writef(e$output)
     }
   )
@@ -13556,7 +13396,7 @@ renv_install_package <- function(record) {
   feedback <- renv_install_package_feedback(path, type)
 
   elapsed <- difftime(after, before, units = "auto")
-  vwritef("\tOK [%s in %s]", feedback, renv_difftime_format(elapsed))
+  renv_install_step_ok(feedback, time = elapsed)
 
   # link into cache
   if (renv_cache_config_enabled(project = project))
@@ -13589,20 +13429,19 @@ renv_install_package_cache <- function(record, cache, linker) {
   defer(callback())
 
   # report successful link to user
-  fmt <- "Installing %s [%s] ..."
-  with(record, vwritef(fmt, Package, Version))
+  renv_install_step_start("Installing", record$Package)
 
   before <- Sys.time()
   linker(cache, target)
   after <- Sys.time()
 
   type <- case(
-    identical(linker, renv_file_copy) ~ "copied",
-    identical(linker, renv_file_link) ~ "linked"
+    identical(linker, renv_file_copy) ~ "copied from cache",
+    identical(linker, renv_file_link) ~ "linked from cache"
   )
 
   elapsed <- difftime(after, before, units = "auto")
-  vwritef("\tOK [%s cache in %s]", type, renv_difftime_format(elapsed))
+  renv_install_step_ok(type, time = elapsed)
 
   return(TRUE)
 
@@ -13620,11 +13459,6 @@ renv_install_package_cache_skip <- function(record, cache) {
 
   renv_file_same(cache, target)
 
-}
-
-renv_install_package_preamble <- function(record) {
-  fmt <- "Installing %s [%s] ..."
-  with(record, vwritef(fmt, Package, Version))
 }
 
 renv_install_package_impl_prebuild <- function(record, path, quiet) {
@@ -13655,8 +13489,7 @@ renv_install_package_impl_prebuild <- function(record, path, quiet) {
     path <- file.path(exdir, pkgpath)
 
     # and ensure we build in this directory
-    owd <- setwd(path)
-    defer(setwd(owd))
+    renv_scope_wd(path)
 
   }
 
@@ -13667,12 +13500,11 @@ renv_install_package_impl_prebuild <- function(record, path, quiet) {
   builder <- desc[["VignetteBuilder"]]
   if (!is.null(builder) && !renv_package_installed(builder)) {
     fmt <- "Skipping package build: vignette builder '%s' is not installed"
-    vwritef(fmt, builder)
+    writef(fmt, builder)
     return(path)
   }
 
-  fmt <- "Building %s [%s] ..."
-  with(record, vwritef(fmt, Package, Version))
+  renv_install_step_start("Building", record$Package)
 
   before <- Sys.time()
   package <- record$Package
@@ -13680,8 +13512,7 @@ renv_install_package_impl_prebuild <- function(record, path, quiet) {
   after <- Sys.time()
   elapsed <- difftime(after, before, units = "auto")
 
-  fmt <- "\tOK [built package in %s]"
-  vwritef(fmt, renv_difftime_format(elapsed))
+  renv_install_step_ok("from source", time = elapsed)
 
   newpath
 
@@ -13711,9 +13542,7 @@ renv_install_package_impl <- function(record, quiet = TRUE) {
 
   # check whether we should build before install
   path <- renv_install_package_impl_prebuild(record, path, quiet)
-
-  # report that we're about to start installation
-  renv_install_package_preamble(record)
+  renv_install_step_start("Installing", record$Package)
 
   # run user-defined hooks before, after install
   options <- renv_install_package_options(package)
@@ -13730,7 +13559,7 @@ renv_install_package_impl <- function(record, quiet = TRUE) {
   defer(callback())
 
   # normalize paths
-  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+  path <- renv_path_normalize(path, mustWork = TRUE)
 
   # get library path
   library <- renv_libpaths_active()
@@ -13750,9 +13579,9 @@ renv_install_package_impl <- function(record, quiet = TRUE) {
 
   # if this is the path to an unpacked binary archive,
   # we can just copy the folder over
-  copyable <-
-    renv_file_type(path, symlinks = FALSE) == "directory" &&
-    renv_package_type(path, quiet = TRUE) == "binary"
+  isdir <- renv_file_type(path, symlinks = FALSE) == "directory"
+  isbin <- renv_package_type(path, quiet = TRUE) == "binary"
+  copyable <- isdir && isbin
 
   # shortcut via copying a binary directory if possible,
   # otherwise, install the package
@@ -13761,11 +13590,68 @@ renv_install_package_impl <- function(record, quiet = TRUE) {
   else
     r_cmd_install(package, path)
 
+  # if we just installed a binary package, check that it can be loaded
+  # (source packages are checked by default on install)
+  withCallingHandlers(
+    if (isbin) renv_install_test(package),
+    error = function(err) unlink(installpath, recursive = TRUE)
+  )
+
   # augment package metadata after install
   renv_package_augment(installpath, record)
 
   # return the path to the package
   invisible(installpath)
+
+}
+
+renv_install_test <- function(package) {
+
+  # add escape hatch, just in case
+  # (test binaries by default on Linux, but not Windows or macOS)
+  enabled <- Sys.getenv("RENV_INSTALL_TEST_LOAD", unset = renv_platform_linux())
+  if (!truthy(enabled))
+    return(TRUE)
+
+  # check whether we should skip installation testing
+  opts <- r_cmd_install_option(package, c("install.opts", "INSTALL_opts"), FALSE)
+  if (is.character(opts)) {
+    flags <- unlist(strsplit(opts, "\\s+", perl = TRUE))
+    if ("--no-test-load" %in% flags)
+      return(TRUE)
+  }
+
+  # make sure we use the current library paths in the launched process
+  rlibs <- paste(renv_libpaths_all(), collapse = .Platform$path.sep)
+  renv_scope_envvars(R_LIBS = rlibs, R_LIBS_USER = "NULL", R_LIBS_SITE = "NULL")
+
+  # also hide from user .Renviron files
+  # https://github.com/wch/r-source/blob/1c0a2dc8ce6c05f68e1959ffbe6318a309277df3/src/library/tools/R/check.R#L273-L276
+  renv_scope_envvars(R_ENVIRON_USER = "NULL")
+
+  # make sure R_TESTS is unset here, just in case
+  # https://github.com/wch/r-source/blob/1c0a2dc8ce6c05f68e1959ffbe6318a309277df3/src/library/tools/R/install.R#L76-L79
+  renv_scope_envvars(R_TESTS = NULL)
+
+  # the actual code we'll run in the other process
+  code <- substitute({
+    options(warn = 1L)
+    library(package)
+  }, list(package = package))
+
+  # write it to a tempfile
+  script <- renv_scope_tempfile("renv-install-")
+  writeLines(deparse(code), con = script)
+
+  # check that the package can be loaded in a separate process
+  renv_system_exec(
+    command = R(),
+    args    = c("--vanilla", "-s", "-f", renv_shell_path(script)),
+    action  = sprintf("testing if '%s' can be loaded", package)
+  )
+
+  # return TRUE to indicate successful validation
+  TRUE
 
 }
 
@@ -13824,8 +13710,7 @@ renv_install_preflight_requirements <- function(records) {
     renv_pretty_print(
       text,
       "The following issues were discovered while preparing for installation:",
-      "Installation of these packages may not succeed.",
-      wrap = FALSE
+      "Installation of these packages may not succeed."
     )
   }
 
@@ -13841,49 +13726,15 @@ renv_install_postamble <- function(packages) {
 
   # only diagnose packages currently loaded
   packages <- renv_vector_intersect(packages, loadedNamespaces())
-  if (empty(packages))
-    return(TRUE)
 
-  # get version of package in library
   installed <- map_chr(packages, renv_package_version)
-
-  # get version of package currently loaded
   loaded <- map_chr(packages, renv_namespace_version)
 
-  # collect into data.frame
-  data <- data.frame(
-    Package   = packages,
-    Installed = installed,
-    Loaded    = loaded,
-    stringsAsFactors = FALSE
+  renv_pretty_print(
+    packages[installed != loaded],
+    c("", "The following loaded package(s) have been updated:"),
+    "Restart your R session to use the new versions."
   )
-
-  # only keep mismatches
-  mismatches <- data[data$Installed != data$Loaded, ]
-  if (nrow(mismatches) == 0)
-    return(TRUE)
-
-  # format and print
-  text <- with(mismatches, {
-    fmt <- "%s [installed version %s != loaded version %s]"
-    sprintf(fmt, format(Package), format(Installed), format(Loaded))
-  })
-
-  if (renv_tests_running()) {
-    condition <- "renv.install.restart_required"
-    renv_condition_signal(condition)
-  }
-
-  # nocov start
-  if (renv_verbose()) {
-    renv_pretty_print(
-      text,
-      "The following package(s) have been updated:",
-      "Consider restarting the R session and loading the newly-installed packages.",
-      wrap = FALSE
-    )
-  }
-  # nocov end
 
   TRUE
 
@@ -13896,9 +13747,8 @@ renv_install_preflight_unknown_source <- function(records) {
 renv_install_preflight_permissions <- function(library) {
 
   # try creating and deleting a directory in the library folder
-  file <- tempfile(".renv-write-test-", tmpdir = library)
+  file <- renv_scope_tempfile(".renv-write-test-", tmpdir = library)
   dir.create(file, recursive = TRUE, showWarnings = FALSE)
-  defer(unlink(file, recursive = TRUE))
 
   # check if we created the directory successfully
   info <- renv_file_info(file)
@@ -13920,8 +13770,7 @@ renv_install_preflight_permissions <- function(library) {
     renv_pretty_print(
       values = library,
       preamble = preamble,
-      postamble = postamble,
-      wrap = FALSE
+      postamble = postamble
     )
 
   }
@@ -13942,46 +13791,38 @@ renv_install_preflight <- function(project, libpaths, records) {
 
 }
 
-renv_install_remotes_update <- function(records, project) {
+renv_install_report <- function(records) {
+  renv_pretty_print_records(
+    records,
+    preamble = "The following package(s) will be installed:"
+  )
+}
 
-  # check for DESCRIPTION file
-  descpath <- file.path(project, "DESCRIPTION")
-  if (!file.exists(descpath))
-    return(records)
+renv_install_step_start <- function(action, package) {
+  printf(
+    "%s %s ... ",
+    format(action, width = nchar("Installing")),
+    format(package, width = getOption("renv.package.width"))
+  )
+}
 
-  # read Remotes field (if any)
-  remotes <- renv_description_remotes(descpath)
-  if (empty(remotes))
-    return(records)
-
-  # update records as appropriate
-  enumerate(remotes, function(package, remote) {
-
-    record <- records[[package]]
-
-    update <-
-      is.null(record) ||
-      identical(record, list(Package = package, Source = "Repository"))
-
-    if (update)
-      records[[package]] <<- remote
-
-  })
-
-  # return updated set of records
-  records
-
+renv_install_step_ok <- function(..., time = NULL) {
+  writef(
+    "OK [%s%s]",
+    paste(..., collapse = ""),
+    renv_difftime_format_slow(time, prefix = " in ")
+  )
 }
 
 
-# installed-packages.R =======================================================
+# installed-packages.R -------------------------------------------------------
 
 
 installed_packages <- function(lib.loc = NULL,
                                priority = NULL,
                                field = NULL)
 {
-  lib.loc <- lib.loc %??% .libPaths()
+  lib.loc <- lib.loc %||% .libPaths()
 
   result <- dynamic(
     key = list(lib.loc = lib.loc, priority = priority),
@@ -13996,10 +13837,10 @@ installed_packages <- function(lib.loc = NULL,
 }
 
 
-# isolate.R ==================================================================
+# isolate.R ------------------------------------------------------------------
 
 
-#' Isolate a Project
+#' Isolate a project
 #'
 #' Copy packages from the renv cache directly into the project library, so
 #' that the project can continue to function independently of the renv cache.
@@ -14061,11 +13902,11 @@ renv_isolate_unix <- function(project) {
   names(targets) <- sources
 
   if (length(targets)) {
-    vprintf("* Copying packages into the private library ... ")
+    printf("* Copying packages into the private library ... ")
     unlink(targets)
     copy <- renv_progress_callback(renv_file_copy, length(targets))
     enumerate(targets, copy, overwrite = TRUE)
-    vwritef("Done!")
+    writef("Done!")
   }
 
   writef("* This project has been isolated from the cache.")
@@ -14082,12 +13923,12 @@ renv_isolate_windows <- function(project) {
   names(targets) <- sources
 
   if (length(targets)) {
-    vprintf("* Copying packages into the private library ... ")
+    printf("* Copying packages into the private library ... ")
     targets <- targets[file.exists(sources)]
     unlink(targets)
     copy <- renv_progress_callback(renv_file_copy, length(targets))
     enumerate(targets, copy, overwrite = TRUE)
-    vwritef("Done!")
+    writef("Done!")
   }
 
   writef("* This project has been isolated from the cache.")
@@ -14096,7 +13937,7 @@ renv_isolate_windows <- function(project) {
 }
 
 
-# json-read.R ================================================================
+# json-read.R ----------------------------------------------------------------
 
 
 renv_json_read <- function(file = NULL, text = NULL) {
@@ -14226,7 +14067,7 @@ renv_json_remap <- function(json, map) {
 }
 
 
-# json-write.R ===============================================================
+# json-write.R ---------------------------------------------------------------
 
 
 # @param box A vector of names, whose values should be boxed. By default,
@@ -14314,7 +14155,7 @@ renv_json_convert_indent <- function(level) {
 }
 
 
-# json.R =====================================================================
+# json.R ---------------------------------------------------------------------
 
 
 renv_json_quote <- function(text) {
@@ -14322,7 +14163,7 @@ renv_json_quote <- function(text) {
 }
 
 
-# knitr.R ====================================================================
+# knitr.R --------------------------------------------------------------------
 
 
 renv_knitr_options_header <- function(text, type) {
@@ -14500,7 +14341,7 @@ renv_knitr_patterns <- function() {
 }
 
 
-# l10n.R =====================================================================
+# l10n.R ---------------------------------------------------------------------
 
 
 renv_l10n_mbcs <- function() {
@@ -14519,7 +14360,7 @@ renv_l10n_latin1 <- function() {
 }
 
 
-# libpaths.R =================================================================
+# libpaths.R -----------------------------------------------------------------
 
 
 `_renv_libpaths` <- new.env(parent = emptyenv())
@@ -14617,7 +14458,7 @@ renv_libpaths_safe_impl <- function(libpath) {
 }
 
 renv_libpaths_safe_tempdir <- function(libpath) {
-  safelib <- tempfile("renv-library-")
+  safelib <- tempfile("renv-safelib-")
 
   if (renv_platform_windows())
     renv_file_junction(libpath, safelib)
@@ -14714,7 +14555,7 @@ renv_libpaths_resolve <- function(library) {
 }
 
 
-# library.R ==================================================================
+# library.R ------------------------------------------------------------------
 
 
 # check for problems in the project's private library (e.g. broken symlinks
@@ -14743,8 +14584,7 @@ renv_library_diagnose <- function(project, libpath) {
     renv_pretty_print(
       basename(children[missing]),
       "The following package(s) are missing entries in the cache:",
-      "These packages will need to be reinstalled.",
-      warningf
+      "These packages will need to be reinstalled."
     )
 
     return(FALSE)
@@ -14756,14 +14596,14 @@ renv_library_diagnose <- function(project, libpath) {
 }
 
 
-# license.R ==================================================================
+# license.R ------------------------------------------------------------------
 
 
 # used to generate the CRAN-compatible license file in R CMD build
 renv_license_generate <- function() {
 
   isbuild <-
-    !is.na(Sys.getenv("R_CMD", unset = NA)) &&
+    renv_envvar_exists("R_CMD") &&
     grepl("Rbuild", basename(dirname(getwd())))
 
   if (!isbuild)
@@ -14784,10 +14624,10 @@ if (identical(.packageName, "renv"))
   renv_license_generate()
 
 
-# load.R =====================================================================
+# load.R ---------------------------------------------------------------------
 
 
-#' Load a Project
+#' Load a project
 #'
 #' @description
 #' `renv::load()` sets the library paths to use a project-local library,
@@ -14840,9 +14680,8 @@ load <- function(project = NULL, quiet = FALSE) {
 
   renv_scope_error_handler()
 
-  project <- normalizePath(
-    project %??% renv_project_find(project),
-    winslash = "/",
+  project <- renv_path_normalize(
+    project %||% renv_project_find(project),
     mustWork = TRUE
   )
 
@@ -14872,9 +14711,11 @@ load <- function(project = NULL, quiet = FALSE) {
 
   # if we're loading a project different from the one currently loaded,
   # then unload the current project and reload the requested one
-  switch <- !renv_metadata_embedded() &&
+  switch <-
+    !renv_metadata_embedded() &&
     !is.null(`_renv_project_path`) &&
     !identical(project, `_renv_project_path`)
+
   if (switch)
     return(renv_load_switch(project))
 
@@ -14976,6 +14817,7 @@ renv_load_minimal <- function(project) {
   if (length(lockfile))
     renv_load_python(project, lockfile$Python)
 
+  renv_project_set(project)
   invisible(project)
 
 }
@@ -14998,14 +14840,14 @@ renv_load_r <- function(project, fields) {
     return(NULL)
   }
 
-  # normalize versions as plain old vectors
-  requested <- unclass(numeric_version(version))[[1]]
-  current <- unclass(numeric_version(getRversion()))[[1]]
+  # normalize versions as strings
+  requested <- renv_version_maj_min(version)
+  current <- renv_version_maj_min(getRversion())
 
   # only compare major, minor versions
-  if (!identical(requested[1:2], current[1:2])) {
-    fmt <- "Using R %s (lockfile was generated with R %s)"
-    infof(fmt, getRversion(), version)
+  if (!identical(requested, current)) {
+    fmt <- "%s Using R %s (lockfile was generated with R %s)"
+    writef(fmt, info_bullet(), getRversion(), version)
   }
 
 }
@@ -15021,8 +14863,8 @@ renv_load_r_repos <- function(repos) {
   names(repos) <- nms
 
   # convert to rspm if enabled
-  if (renv_rspm_enabled())
-    repos <- renv_rspm_transform(repos)
+  if (renv_ppm_enabled())
+    repos <- renv_ppm_transform(repos)
 
   # normalize option
   repos <- renv_repos_normalize(repos)
@@ -15065,7 +14907,7 @@ renv_load_path <- function(project) {
   if (renv_platform_macos()) {
 
     # read the current PATH
-    old <- renv_envvar_get("PATH", unset = "") %>%
+    old <- Sys.getenv("PATH", unset = "") %>%
       strsplit(split = .Platform$path.sep, fixed = TRUE) %>%
       unlist()
 
@@ -15139,7 +14981,7 @@ renv_load_project <- function(project) {
 
   # update project list if enabled
   if (renv_cache_config_enabled(project = project)) {
-    project <- renv_path_normalize(project, winslash = "/")
+    project <- renv_path_normalize(project)
     renv_load_project_projlist(project)
   }
 
@@ -15164,7 +15006,7 @@ renv_load_project_projlist <- function(project) {
 
   # update the project list
   ensure_parent_directory(projects)
-  catchall(writeLines(enc2utf8(projlist), projects, useBytes = TRUE))
+  catchall(writeLines(enc2utf8(projlist), con = projects, useBytes = TRUE))
 
   TRUE
 
@@ -15401,6 +15243,10 @@ renv_load_bioconductor_validate <- function(project, version) {
 
 renv_load_switch <- function(project) {
 
+  # skip when testing
+  if (is_testing())
+    return(project)
+
   # safety check: avoid recursive unload attempts
   unloading <- getOption("renv.unload.project")
   if (!is.null(unloading)) {
@@ -15412,8 +15258,8 @@ renv_load_switch <- function(project) {
   # unset the RENV_PATHS_RENV environment variable
   # TODO: is there a path forward if different projects use
   # different RENV_PATHS_RENV paths?
-  renvpath <- renv_envvar_get("RENV_PATHS_RENV")
-  renv_envvar_clear("RENV_PATHS_RENV")
+  renvpath <- Sys.getenv("RENV_PATHS_RENV", unset = NA)
+  Sys.unsetenv("RENV_PATHS_RENV")
 
   # validate that this project has an activate script
   script <- renv_paths_activate(project = project)
@@ -15435,8 +15281,7 @@ renv_load_switch <- function(project) {
   unloadNamespace("renv")
 
   # move to new project directory
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
 
   # source the activate script
   source(script)
@@ -15446,7 +15291,7 @@ renv_load_switch <- function(project) {
     fmt <- "could not load renv from project %s; reloading previously-loaded renv"
     warningf(fmt, renv_path_pretty(project))
     loadNamespace("renv", lib.loc = dirname(path))
-    renv_envvar_set("RENV_PATHS_RENV", renvpath)
+    Sys.setenv(RENV_PATHS_RENV = renvpath)
     if (!is.na(pos)) {
       args <- list(package = "renv", pos = pos, character.only = TRUE)
       do.call(base::library, args)
@@ -15469,8 +15314,7 @@ renv_load_cache <- function(project) {
     "* The cache version has been updated in this version of renv.",
     "* Use `renv::rehash()` to migrate packages from the old renv cache."
   )
-
-  vmessagef(msg)
+  printf(msg)
 
 }
 
@@ -15501,8 +15345,7 @@ renv_load_check_description <- function(project) {
     postamble = c(
       "DESCRIPTION files cannot contain blank lines between fields.",
       "Please remove these blank lines from the file."
-    ),
-    wrap = FALSE
+    )
   )
 
   return(FALSE)
@@ -15538,10 +15381,10 @@ renv_load_report_project <- function(project) {
 
   if (length(profile)) {
     fmt <- "* (%s) Project '%s' loaded. [renv %s]"
-    vwritef(fmt, profile, renv_path_aliased(project), version)
+    writef(fmt, profile, renv_path_aliased(project), version)
   } else {
     fmt <- "* Project '%s' loaded. [renv %s]"
-    vwritef(fmt, renv_path_aliased(project), version)
+    writef(fmt, renv_path_aliased(project), version)
   }
 
 }
@@ -15553,7 +15396,7 @@ renv_load_report_python <- function(project) {
     return(FALSE)
 
   # fmt <- "* Using Python %s. [%s]"
-  # vwritef(fmt, renv_python_version(python), renv_python_type(python))
+  # writef(fmt, renv_python_version(python), renv_python_type(python))
 
 }
 
@@ -15582,7 +15425,7 @@ renv_load_report_updates_impl <- function(project) {
   if (!available)
     return(FALSE)
 
-  vwritef("* Use `renv::update()` to install updated packages.")
+  writef("* Use `renv::update()` to install updated packages.")
   if (!interactive())
     print(status)
 
@@ -15623,7 +15466,7 @@ renv_load_invoke <- function(callback) {
 
 
 
-# lock.R =====================================================================
+# lock.R ---------------------------------------------------------------------
 
 
 `_renv_lock` <- new.env(parent = emptyenv())
@@ -15740,14 +15583,14 @@ renv_lock_init <- function() {
 renv_lock_path <- function(path) {
 
   file.path(
-    normalizePath(dirname(path), winslash = "/", mustWork = TRUE),
+    renv_path_normalize(dirname(path), mustWork = TRUE),
     basename(path)
   )
 
 }
 
 
-# lockfile-api.R =============================================================
+# lockfile-api.R -------------------------------------------------------------
 
 
 renv_lockfile_resolve <- function(lockfile) {
@@ -15901,7 +15744,7 @@ lockfile <- function(file = NULL, project = NULL) {
 }
 
 
-# lockfile-diff.R ============================================================
+# lockfile-diff.R ------------------------------------------------------------
 
 
 renv_lockfile_diff <- function(old, new, compare = NULL) {
@@ -15912,7 +15755,7 @@ renv_lockfile_diff <- function(old, new, compare = NULL) {
 
   # ensure both lists have the same names, inserting missing
   # entries for those without any value
-  nms <- union(names(old), names(new)) %??% character()
+  nms <- union(names(old), names(new)) %||% character()
   if (length(nms)) {
 
     nms <- sort(nms)
@@ -16026,7 +15869,7 @@ renv_lockfile_repair <- function(lockfile) {
 }
 
 
-# lockfile-read.R ============================================================
+# lockfile-read.R ------------------------------------------------------------
 
 
 renv_lockfile_read_finish_impl <- function(key, val) {
@@ -16090,9 +15933,7 @@ renv_lockfile_read_preflight <- function(contents) {
     renv_pretty_print(
       values    = head(all, n = -1L),
       preamble  = "The lockfile contains one or more merge conflict markers:",
-      postamble = "You will need to resolve these merge conflicts before the file can be read.",
-      emitter   = message,
-      wrap      = FALSE
+      postamble = "You will need to resolve these merge conflicts before the file can be read."
     )
 
     stop("lockfile contains merge conflict markers; cannot proceed", call. = FALSE)
@@ -16111,13 +15952,19 @@ renv_lockfile_read <- function(file = NULL, text = NULL) {
 
   # check and report some potential errors (e.g. merge conflicts)
   renv_lockfile_read_preflight(contents)
-  json <- renv_json_read(text = contents)
+  withCallingHandlers(
+    json <- renv_json_read(text = contents),
+    error = function(err) {
+      stop("Failed to parse 'renv.lock':\n", conditionMessage(err))
+    }
+  )
+
   renv_lockfile_read_finish(json)
 
 }
 
 
-# lockfile-write.R ===========================================================
+# lockfile-write.R -----------------------------------------------------------
 
 
 `_renv_lockfile_state` <- new.env(parent = emptyenv())
@@ -16151,6 +15998,14 @@ renv_lockfile_write_preflight <- function(old, new) {
     spurious <-
       identical(changes, list(Repository = list(before = "CRAN", after = "RSPM"))) ||
       identical(changes, list(Repository = list(before = "RSPM", after = "CRAN")))
+
+    if (spurious)
+      new$Packages[[package]]$Repository <<- old$Packages[[package]]$Repository
+
+    # avoid spurious changes between CRAN and PPM
+    spurious <-
+      identical(changes, list(Repository = list(before = "CRAN", after = "PPM"))) ||
+      identical(changes, list(Repository = list(before = "PPM", after = "CRAN")))
 
     if (spurious)
       new$Packages[[package]]$Repository <<- old$Packages[[package]]$Repository
@@ -16213,15 +16068,14 @@ renv_lockfile_write_json <- function(lockfile, file = stdout()) {
 
 renv_lockfile_write_internal <- function(lockfile,
                                          file = stdout(),
-                                         delim = "=",
-                                         emitter = NULL)
+                                         delim = "=")
 {
   if (is.character(file)) {
     file <- textfile(file)
     defer(close(file))
   }
 
-  emitter <- emitter %||% function(text) writeLines(text, con = file)
+  emitter <- function(text) writeLines(text, con = file)
 
   renv_lockfile_state_set("delim", delim)
   renv_lockfile_state_set("emitter", emitter)
@@ -16276,7 +16130,7 @@ renv_lockfile_write_emit <- function(text = "") {
 }
 
 
-# lockfile.R =================================================================
+# lockfile.R -----------------------------------------------------------------
 
 
 renv_lockfile_init <- function(project) {
@@ -16294,9 +16148,12 @@ renv_lockfile_init <- function(project) {
 
 renv_lockfile_init_r_version <- function(project) {
 
-  version <-
-    settings$r.version(project = project) %||%
-    getRversion()
+  # NOTE: older versions of renv may have written out an empty array
+  # for the R version in some cases, so we explicitly check that we
+  # receive a length-one string here.
+  version <- settings$r.version(project = project)
+  if (!pstring(version))
+    version <- getRversion()
 
   format(version)
 
@@ -16321,8 +16178,8 @@ renv_lockfile_init_r_repos <- function(project) {
     "https://cloud.r-project.org"
   )
 
-  # remove RSPM bits from URL
-  if (config$rspm.enabled()) {
+  # remove PPM bits from URL
+  if (renv_ppm_enabled()) {
     pattern <- "/__[^_]+__/[^/]+/"
     repos <- sub(pattern, "/", repos)
   }
@@ -16446,22 +16303,35 @@ renv_lockfile_create <- function(project,
                                  packages = NULL,
                                  exclude = NULL)
 {
-  libpaths <- libpaths %??% renv_libpaths_all()
-  type <- type %??% settings$snapshot.type(project = project)
+  libpaths <- libpaths %||% renv_libpaths_all()
+  type <- type %||% settings$snapshot.type(project = project)
+
+  # use a restart, so we can allow the user to install packages before snapshot
+  lockfile <- withRestarts(
+    renv_lockfile_create_impl(project, libpaths, type, packages, exclude),
+    renv_recompute_records = function() {
+      renv_dynamic_reset()
+      renv_lockfile_create_impl(project, libpaths, type, packages, exclude)
+    }
+  )
+}
+
+renv_lockfile_create_impl <- function(project, libpaths, type, packages, exclude) {
 
   lockfile <- renv_lockfile_init(project)
 
-  renv_lockfile_records(lockfile) <-
+  records <- renv_snapshot_libpaths(libpaths = libpaths, project = project)
 
-    renv_snapshot_libpaths(libpaths = libpaths,
-                           project  = project) %>%
+  records <- renv_snapshot_filter(
+    project  = project,
+    records  = records,
+    type     = type,
+    packages = packages,
+    exclude  = exclude
+  )
 
-    renv_snapshot_filter(project  = project,
-                         type     = type,
-                         packages = packages,
-                         exclude  = exclude) %>%
-
-    renv_snapshot_fixup()
+  records <- renv_snapshot_fixup(records)
+  renv_lockfile_records(lockfile) <- records
 
   lockfile <- renv_lockfile_fini(lockfile, project)
 
@@ -16470,6 +16340,7 @@ renv_lockfile_create <- function(project,
 
   class(lockfile) <- "renv_lockfile"
   lockfile
+
 }
 
 renv_lockfile_modify <- function(lockfile, records) {
@@ -16498,7 +16369,7 @@ renv_lockfile_compact <- function(lockfile) {
 }
 
 renv_lockfile_records <- function(lockfile) {
-  as.list(lockfile$Packages %??% lockfile)
+  as.list(lockfile$Packages %||% lockfile)
 }
 
 `renv_lockfile_records<-` <- function(x, value) {
@@ -16510,7 +16381,7 @@ renv_lockfile_records <- function(lockfile) {
 renv_records <- renv_lockfile_records
 
 
-# lockfiles.R ================================================================
+# lockfiles.R ----------------------------------------------------------------
 
 
 #' Lockfiles
@@ -16563,7 +16434,7 @@ renv_records <- renv_lockfile_records
 #'
 #' The sections used within a lockfile are described next.
 #'
-#' @section \[renv\]:
+#' ## renv
 #'
 #' Information about the version of renv used to manage this project.
 #'
@@ -16571,7 +16442,7 @@ renv_records <- renv_lockfile_records
 #' \strong{Version}     \tab The version of the renv package used with this project. \cr
 #' }
 #'
-#' @section \[R\]:
+#' ## R
 #'
 #' Properties related to the version of \R associated with this project.
 #'
@@ -16580,7 +16451,7 @@ renv_records <- renv_lockfile_records
 #' \strong{Repositories} \tab The \R repositories used in this project. \cr
 #' }
 #'
-#' @section \[Packages\]:
+#' ## Packages
 #'
 #' \R package records, capturing the packages used or required by a project
 #' at the time when the lockfile was generated.
@@ -16597,7 +16468,7 @@ renv_records <- renv_lockfile_records
 #' retrieved from its corresponding source, will also be included as
 #' appropriate (e.g. for packages installed from GitHub).
 #'
-#' @section \[Python\]:
+#' ## Python
 #'
 #' Metadata related to the version of Python used with this project (if any).
 #'
@@ -16616,7 +16487,7 @@ renv_records <- renv_lockfile_records
 NULL
 
 
-# log.R ======================================================================
+# log.R ----------------------------------------------------------------------
 
 
 log <- function(level, scope, fmt, ...) {
@@ -16693,7 +16564,7 @@ renv_log_init_file <- function() {
 }
 
 
-# manifest-convert.R =========================================================
+# manifest-convert.R ---------------------------------------------------------
 
 
 #' Generate `renv.lock` from an RStudio Connect `manifest.json`
@@ -16779,14 +16650,14 @@ renv_lockfile_from_manifest <- function(manifest,
   # otherwise, write to file and report for user
   renv_lockfile_write(lock, file = lockfile)
   fmt <- "* Lockfile written to %s."
-  vwritef(fmt, renv_path_pretty(lockfile))
+  writef(fmt, renv_path_pretty(lockfile))
 
   invisible(lock)
 
 }
 
 
-# memoize.R ==================================================================
+# memoize.R ------------------------------------------------------------------
 
 
 `_renv_memoize` <- new.env(parent = emptyenv())
@@ -16804,7 +16675,7 @@ memoize <- function(key, value, scope = NULL) {
   # initialize memoized environment
   envir <-
     `_renv_memoize`[[scope]] <-
-    `_renv_memoize`[[scope]] %??%
+    `_renv_memoize`[[scope]] %||%
     new.env(parent = emptyenv())
 
   # retrieve, or compute, memoized value
@@ -16813,11 +16684,19 @@ memoize <- function(key, value, scope = NULL) {
 }
 
 
-# metadata.R =================================================================
+# metadata.R -----------------------------------------------------------------
 
 
 renv_metadata_version <- function() {
-  `_renv_metadata`[["version"]]
+  `_renv_metadata`$sha %||% `_renv_metadata`$version
+}
+
+renv_metadata_is_dev <- function(metadata = `_renv_metadata`) {
+  if (!is.null(metadata$sha)) {
+    TRUE
+  } else {
+    renv_version_length(metadata$version) != 3L
+  }
 }
 
 renv_metadata_embedded <- function() {
@@ -16833,7 +16712,8 @@ renv_metadata_init <- function() {
   # set up metadata
   metadata <- list(
     embedded = FALSE,
-    version  = renv_namespace_version("renv")
+    version  = renv_namespace_version("renv"),
+    sha = packageDescription("renv")[["RemoteSha"]]
   )
 
   # create in namespace
@@ -16846,7 +16726,7 @@ renv_metadata_init <- function() {
 }
 
 
-# methods.R ==================================================================
+# methods.R ------------------------------------------------------------------
 
 
 renv_methods_map <- function() {
@@ -16902,14 +16782,14 @@ renv_methods_error <- function() {
 }
 
 
-# migrate.R ==================================================================
+# migrate.R ------------------------------------------------------------------
 
 
-#' Migrate a Project from Packrat to renv
+#' Migrate a project from packrat to renv
 #'
-#' Migrate a project's infrastructure from Packrat to renv.
+#' Migrate a project's infrastructure from packrat to renv.
 #'
-#' @section Migration:
+#' # Migration
 #'
 #' When migrating Packrat projects to renv, the set of components migrated
 #' can be customized using the `packrat` argument. The set of components that
@@ -16973,7 +16853,7 @@ migrate <- function(
   if (renv_package_checking())
     renv_patch_repos()
 
-  project <- renv_path_normalize(project, winslash = "/", mustWork = TRUE)
+  project <- renv_path_normalize(project, mustWork = TRUE)
   if (file.exists(file.path(project, "packrat/packrat.lock"))) {
     packrat <- match.arg(packrat, several.ok = TRUE)
     renv_migrate_packrat(project, packrat)
@@ -17005,9 +16885,9 @@ renv_migrate_packrat <- function(project = NULL, components = NULL) {
   renv_imbue_impl(project)
 
   fmt <- "* Project '%s' has been migrated from Packrat to renv."
-  vwritef(fmt, renv_path_aliased(project))
+  writef(fmt, renv_path_aliased(project))
 
-  vwritef("* Consider deleting the project 'packrat' folder if it is no longer needed.")
+  writef("* Consider deleting the project 'packrat' folder if it is no longer needed.")
   invisible(TRUE)
 }
 
@@ -17115,13 +16995,13 @@ renv_migrate_packrat_sources <- function(project) {
   keep <- !file.exists(targets)
   sources <- sources[keep]; targets <- targets[keep]
 
-  vprintf("* Migrating package sources from Packrat to renv ... ")
+  printf("* Migrating package sources from Packrat to renv ... ")
   copy <- renv_progress_callback(renv_file_copy, length(targets))
   mapply(sources, targets, FUN = function(source, target) {
     ensure_parent_directory(target)
     copy(source, target)
   })
-  vwritef("Done!")
+  writef("Done!")
 
   TRUE
 
@@ -17144,24 +17024,24 @@ renv_migrate_packrat_library <- function(project) {
   names(targets) <- sources
   targets <- targets[!file.exists(targets)]
   if (empty(targets)) {
-    vwritef("* The renv library is already synchronized with the Packrat library.")
+    writef("* The renv library is already synchronized with the Packrat library.")
     return(TRUE)
   }
 
   # copy packages from Packrat to renv private library
-  vprintf("* Migrating library from Packrat to renv ... ")
+  printf("* Migrating library from Packrat to renv ... ")
   ensure_parent_directory(targets)
   copy <- renv_progress_callback(renv_file_copy, length(targets))
   enumerate(targets, copy)
-  vwritef("Done!")
+  writef("Done!")
 
   # move packages into the cache
   if (renv_cache_config_enabled(project = project)) {
-    vprintf("* Moving packages into the renv cache ... ")
+    printf("* Moving packages into the renv cache ... ")
     records <- lapply(targets, renv_description_read)
     sync <- renv_progress_callback(renv_cache_synchronize, length(targets))
     lapply(records, sync, linkable = TRUE)
-    vwritef("Done!")
+    writef("Done!")
   }
 
   TRUE
@@ -17197,7 +17077,7 @@ renv_migrate_packrat_cache <- function(project) {
   # only copy to cache target paths that don't exist
   targets <- targets[!file.exists(targets)]
   if (empty(targets)) {
-    vwritef("* The renv cache is already synchronized with the Packrat cache.")
+    writef("* The renv cache is already synchronized with the Packrat cache.")
     return(TRUE)
   }
 
@@ -17212,7 +17092,7 @@ renv_migrate_packrat_cache <- function(project) {
 renv_migrate_packrat_cache_impl <- function(targets) {
 
   # attempt to copy packages from Packrat to renv cache
-  vprintf("* Migrating Packrat cache to renv cache ... ")
+  printf("* Migrating Packrat cache to renv cache ... ")
   ensure_parent_directory(targets)
   copy <- renv_progress_callback(renv_file_copy, length(targets))
 
@@ -17223,7 +17103,7 @@ renv_migrate_packrat_cache_impl <- function(targets) {
     list(source = source, target = target, broken = broken, reason = reason)
   })
 
-  vwritef("Done!")
+  writef("Done!")
 
   # report failures
   status <- bind(result)
@@ -17242,12 +17122,12 @@ renv_migrate_packrat_cache_impl <- function(targets) {
 renv_migrate_packrat_infrastructure <- function(project) {
   unlink(file.path(project, ".Rprofile"))
   renv_infrastructure_write(project)
-  vwritef("* renv support infrastructure has been written.")
+  writef("* renv support infrastructure has been written.")
   TRUE
 }
 
 
-# modify.R ===================================================================
+# modify.R -------------------------------------------------------------------
 
 
 #' Modify a Lockfile
@@ -17306,9 +17186,8 @@ renv_modify_interactive <- function(project) {
     stopf("lockfile '%s' does not exist", renv_path_aliased(lockpath))
 
   # copy the lockfile to a temporary file
-  dir <- tempfile("renv-lockfile-")
+  dir <- renv_scope_tempfile("renv-lockfile-")
   ensure_directory(dir)
-  defer(unlink(dir, recursive = TRUE))
 
   templock <- file.path(dir, "renv.lock")
   file.copy(lockpath, templock)
@@ -17317,19 +17196,16 @@ renv_modify_interactive <- function(project) {
   renv_file_edit(templock)
 
   # check that the new lockfile can be read
-  lockfile <- catch(renv_lockfile_read(file = templock))
-  if (inherits(lockfile, "error")) {
-
-    renv_pretty_print(
-      conditionMessage(lockfile),
-      preamble  = "renv was uanble to parse the modified lockfile:",
-      postamble = "Your changes will be discarded.",
-      wrap = FALSE
-    )
-
-    stop("error modifying lockfile")
-
-  }
+  withCallingHandlers(
+    lockfile <- catch(renv_lockfile_read(file = templock)),
+    error = function(cnd) {
+      stop(lines(
+        "renv was unable to parse the modified lockfile:",
+        conditionMessage(cnd),
+        "Your changes will be discarded"
+      ))
+    }
+  )
 
   lockfile
 
@@ -17349,7 +17225,7 @@ renv_modify_noninteractive <- function(project, changes) {
   merged <- modifyList(lockfile, changes)
 
   # write updated lockfile to a temporary file
-  templock <- tempfile("renv-lock-")
+  templock <- renv_scope_tempfile("renv-lock-")
   renv_lockfile_write(merged, file = templock)
 
   # try reading it once more
@@ -17374,7 +17250,7 @@ renv_modify_fini <- function(lockfile) {
 }
 
 
-# mran.R =====================================================================
+# mran.R ---------------------------------------------------------------------
 
 
 renv_mran_enabled <- function() {
@@ -17522,7 +17398,7 @@ renv_mran_database_update <- function(platform, version, dates = NULL) {
 
   # get reference to entry in database (initialize if not yet created)
   suffix <- renv_mran_database_key(platform, version)
-  database[[suffix]] <- database[[suffix]] %??% new.env(parent = emptyenv())
+  database[[suffix]] <- database[[suffix]] %||% new.env(parent = emptyenv())
   entry <- database[[suffix]]
 
   # rough release dates for R releases
@@ -17540,15 +17416,15 @@ renv_mran_database_update <- function(platform, version, dates = NULL) {
   }
 
   # save at end
-  vprintf("[%s]: saving database ... ", date)
+  printf("[%s]: saving database ... ", date)
   renv_mran_database_save(database)
-  vwritef("DONE")
+  writef("DONE")
 
 }
 
 renv_mran_database_update_impl <- function(date, url, entry) {
 
-  vprintf("[%s]: reading package database ... ", date)
+  printf("[%s]: reading package database ... ", date)
 
   # get date as number of days since epoch
   idate <- as.integer(date)
@@ -17557,7 +17433,7 @@ renv_mran_database_update_impl <- function(date, url, entry) {
   errors <- new.env(parent = emptyenv())
   db <- renv_available_packages_query_impl(url, errors)
   if (is.null(db)) {
-    vwritef("ERROR")
+    writef("ERROR")
     return(FALSE)
   }
 
@@ -17574,7 +17450,7 @@ renv_mran_database_update_impl <- function(date, url, entry) {
 
   }
 
-  vwritef("OK")
+  writef("OK")
   TRUE
 
 }
@@ -17675,10 +17551,10 @@ renv_mran_database_sync <- function(platform, version) {
     return(FALSE)
 
   # invoke update for missing dates
-  vwritef("==> Synchronizing MRAN database (%s/%s)", platform, version)
+  writef("==> Synchronizing MRAN database (%s/%s)", platform, version)
   dates <- as.Date(seq(last + 1L, now, by = 1L), origin = "1970-01-01")
   renv_mran_database_update(platform, version, dates)
-  vwritef("Finished synchronizing MRAN database (%s/%s)", platform, version)
+  writef("Finished synchronizing MRAN database (%s/%s)", platform, version)
 
   # return TRUE to indicate update occurred
   return(TRUE)
@@ -17724,7 +17600,7 @@ renv_mran_database_sync_all <- function() {
 }
 
 
-# namespace.R ================================================================
+# namespace.R ----------------------------------------------------------------
 
 
 renv_namespace_spec <- function(package) {
@@ -17761,7 +17637,7 @@ renv_namespace_parse <- function(package) {
 }
 
 
-# new.R ======================================================================
+# new.R ----------------------------------------------------------------------
 
 
 new <- function(expr) {
@@ -17771,10 +17647,7 @@ new <- function(expr) {
 
   for (expr in as.list(substitute(expr))[-1L]) {
 
-    assigning <-
-      is.call(expr) &&
-      is.symbol(expr[[1L]]) &&
-      as.character(expr[[1L]]) %in% c("=", "<-")
+    assigning <- renv_call_matches(expr, name = c("=", "<-"))
 
     if (!assigning)
       return(eval(expr, envir = public))
@@ -17792,7 +17665,7 @@ new <- function(expr) {
 }
 
 
-# nexus.R ====================================================================
+# nexus.R --------------------------------------------------------------------
 
 
 renv_nexus_enabled <- function(repo) {
@@ -17809,7 +17682,7 @@ renv_nexus_enabled <- function(repo) {
 }
 
 
-# once.R =====================================================================
+# once.R ---------------------------------------------------------------------
 
 
 # mechanism for running a block of code only once
@@ -17828,7 +17701,7 @@ once <- function() {
 }
 
 
-# options.R ==================================================================
+# options.R ------------------------------------------------------------------
 
 
 renv_options_set <- function(key, value) {
@@ -17868,7 +17741,7 @@ renv_options_override <- function(scope, key, default = NULL, extra = NULL) {
 }
 
 
-# package.R ==================================================================
+# package.R ------------------------------------------------------------------
 
 
 # NOTE: intentionally checks library paths before checking loaded namespaces
@@ -17890,7 +17763,7 @@ renv_package_find_impl <- function(package,
 {
   # if we've been given the path to an existing package, use it as-is
   if (file.exists(file.path(package, "DESCRIPTION")))
-    return(normalizePath(package, winslash = "/", mustWork = TRUE))
+    return(renv_path_normalize(package, mustWork = TRUE))
 
   # first, look in the library paths
   for (libpath in lib.loc) {
@@ -18148,7 +18021,7 @@ renv_package_dependencies_impl <- function(package,
   assign(package, location, envir = visited, inherits = FALSE)
 
   # find its dependencies from the DESCRIPTION file
-  deps <- renv_dependencies_discover_description(location, fields)
+  deps <- renv_dependencies_discover_description(location, fields = "strong")
   subpackages <- deps$Package
   for (subpackage in subpackages)
     renv_package_dependencies_impl(subpackage, visited, libpaths, fields)
@@ -18276,8 +18149,8 @@ renv_package_checking_impl <- function() {
   # otherwise, check other things
   is_testing() ||
     "CheckExEnv" %in% search()
-    !is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", unset = NA)) ||
-    !is.na(Sys.getenv("_R_CHECK_SIZE_OF_TARBALL_", unset = NA))
+    renv_envvar_exists("_R_CHECK_PACKAGE_NAME_") ||
+    renv_envvar_exists("_R_CHECK_SIZE_OF_TARBALL_")
 }
 
 renv_package_unpack <- function(package, path, subdir = "", force = FALSE) {
@@ -18315,8 +18188,8 @@ renv_package_unpack <- function(package, path, subdir = "", force = FALSE) {
   }
 
   # create extraction directory
-  old <- tempfile("renv-package-old-")
-  new <- tempfile("renv-package-new-")
+  old <- renv_scope_tempfile("renv-package-old-")
+  new <- renv_scope_tempfile("renv-package-new-", envir = parent.frame())
   ensure_directory(c(old, new))
 
   # decompress archive to dir
@@ -18333,7 +18206,7 @@ renv_package_unpack <- function(package, path, subdir = "", force = FALSE) {
 }
 
 
-# packages.R =================================================================
+# packages.R -----------------------------------------------------------------
 
 
 `_renv_packages_base` <- NULL
@@ -18358,14 +18231,15 @@ renv_packages_recommended <- function() {
 }
 
 
-# pak.R ======================================================================
+# pak.R ----------------------------------------------------------------------
 
 
-`_renv_pak_version` <- numeric_version("0.5.1")
+# the minimum-required version of 'pak' for renv integration
+`_renv_pak_minver` <- numeric_version("0.5.1")
 
 renv_pak_init <- function(stream = NULL, force = FALSE) {
 
-  stream <- stream %??% renv_pak_stream()
+  stream <- stream %||% renv_pak_stream()
   if (force || !renv_pak_available())
     renv_pak_init_impl(stream)
 
@@ -18381,25 +18255,32 @@ renv_pak_stream <- function() {
     repos <- renv_pak_repos(stream)
     latest <- renv_available_packages_latest("pak", repos = repos)
     version <- numeric_version(latest$Version)
-    if (version >= `_renv_pak_version`)
+    if (version >= `_renv_pak_minver`)
       return(stream)
   }
 
   fmt <- "internal error: pak (>= %s) is not available"
-  stopf(fmt, format(`_renv_pak_version`))
+  stopf(fmt, format(`_renv_pak_minver`))
 
 }
 
 renv_pak_available <- function() {
   tryCatch(
-    packageVersion("pak") >= `_renv_pak_version`,
+    packageVersion("pak") >= `_renv_pak_minver`,
     error = function(e) FALSE
   )
 }
 
 renv_pak_repos <- function(stream) {
+
+  # on macOS, we can only use pak binaries with CRAN R
+  if (renv_platform_macos() && .Platform$pkgType == "source")
+    return(getOption("repos"))
+
+  # otherwise, use pre-built pak binaries
   fmt <- "https://r-lib.github.io/p/pak/%s/%s/%s/%s"
   sprintf(fmt, stream, .Platform$pkgType, version$os, version$arch)
+
 }
 
 renv_pak_init_impl <- function(stream) {
@@ -18412,8 +18293,8 @@ renv_pak_install <- function(packages, library, project) {
   lib <- library[[1L]]
 
   # transform repositories
-  if (renv_rspm_enabled())
-    renv_scope_options(repos = renv_rspm_transform())
+  if (renv_ppm_enabled())
+    renv_scope_options(repos = renv_ppm_transform())
 
   # make sure pak::pkg_install() still works even if we're
   # running in renv with devtools::load_all()
@@ -18453,7 +18334,7 @@ renv_pak_restore <- function(lockfile,
 
   # get records to install
   records <- renv_lockfile_records(lockfile)
-  packages <- setdiff(packages %??% names(records), c(exclude, "pak", "renv"))
+  packages <- setdiff(packages %||% names(records), c(exclude, "pak", "renv"))
   records <- records[packages]
 
   # attempt to link packages that have cache entries
@@ -18476,7 +18357,7 @@ renv_pak_restore <- function(lockfile,
 
 
 
-# parallel.R =================================================================
+# parallel.R -----------------------------------------------------------------
 
 
 renv_parallel_cores <- function() {
@@ -18502,7 +18383,7 @@ renv_parallel_exec <- function(data, callback) {
 }
 
 
-# parse.R ====================================================================
+# parse.R --------------------------------------------------------------------
 
 
 renv_parse_file <- function(file = "", ...) {
@@ -18574,7 +18455,7 @@ renv_parse_impl_utf8 <- function(text, ...) {
 
 
 
-# patch.R ====================================================================
+# patch.R --------------------------------------------------------------------
 
 
 renv_patch_init <- function() {
@@ -18651,7 +18532,10 @@ renv_patch_tar <- function() {
 
   # TAR appears to be set but invalid; override it
   # and warn the user
-  newtar <- Sys.which("tar") %""% "internal"
+  newtar <- Sys.which("tar")
+  if (!nzchar(newtar))
+    newtar <- "internal"
+
   Sys.setenv(TAR = newtar)
 
   # report to the user
@@ -18749,6 +18633,11 @@ renv_patch_repos <- function() {
   if (identical(name, "renv"))
     return()
 
+  # presumably this will never happen when the dev version of renv is
+  # installed, so we skip to avoid parsing a sha as version
+  if (renv_metadata_is_dev())
+    return()
+
   # nothing to do if this version of 'renv' is already available
   version <- renv_metadata_version()
   entry <- catch(renv_available_packages_entry("renv", filter = version, quiet = TRUE))
@@ -18779,7 +18668,7 @@ renv_patch_repos <- function() {
 }
 
 
-# path.R =====================================================================
+# path.R ---------------------------------------------------------------------
 
 
 `_renv_alpha` <- c(letters, LETTERS)
@@ -18795,10 +18684,7 @@ renv_path_absolute <- function(path) {
 
 renv_path_aliased <- function(path) {
 
-  home <-
-    Sys.getenv("HOME") %""%
-    Sys.getenv("R_USER")
-
+  home <- Sys.getenv("HOME", unset = Sys.getenv("R_USER"))
   if (!nzchar(home))
     return(path)
 
@@ -18891,7 +18777,18 @@ renv_path_normalize_win32_impl <- function(path,
                                            winslash = "/",
                                            mustWork = FALSE)
 {
-  short <- utils::shortPathName(path.expand(path))
+  # get short path
+  expanded <- path.expand(path)
+  short <- utils::shortPathName(expanded)
+
+  # if a UTF-8 string is passed to utils::shortPathName(), it seems that
+  # the string might be latin1-encoded, even though it's marked as UTF-8?
+  if (!identical(R.version$crt, "ucrt")) {
+    utf8 <- Encoding(short) == "UTF-8"
+    Encoding(short[utf8]) <- "latin1"
+  }
+
+  # normalize
   normalizePath(short, winslash, mustWork)
 }
 
@@ -18899,7 +18796,7 @@ renv_path_normalize_win32_impl <- function(path,
 # don't use this for paths that need to be uniquely resolved!
 renv_path_canonicalize <- function(path) {
   parent <- dirname(path)
-  root <- renv_path_normalize(parent, winslash = "/", mustWork = FALSE)
+  root <- renv_path_normalize(parent)
   trimmed <- sub("/+$", "", root)
   file.path(trimmed, basename(path))
 }
@@ -18926,7 +18823,7 @@ renv_path_relative <- function(path, root) {
 
 
 
-# paths.R ====================================================================
+# paths.R --------------------------------------------------------------------
 
 
 `_renv_root` <- NULL
@@ -19359,7 +19256,7 @@ paths <- list(
 )
 
 
-# pip.R ======================================================================
+# pip.R ----------------------------------------------------------------------
 
 
 pip_freeze <- function(..., python = NULL) {
@@ -19410,7 +19307,7 @@ pip_uninstall <- function(modules, ..., python = NULL) {
 }
 
 
-# platform.R =================================================================
+# platform.R -----------------------------------------------------------------
 
 
 `_renv_sysinfo` <- NULL
@@ -19467,7 +19364,258 @@ renv_platform_machine <- function() {
 }
 
 
-# predicate.R ================================================================
+# ppm.R ----------------------------------------------------------------------
+
+
+renv_ppm_normalize <- function(url) {
+  sub("/__[^_]+__/[^/]+/", "/", url)
+}
+
+renv_ppm_transform <- function(repos = getOption("repos")) {
+  map_chr(repos, function(url) {
+    tryCatch(
+      renv_ppm_transform_impl(url),
+      error = function(e) url
+    )
+  })
+}
+
+renv_ppm_transform_impl <- function(url) {
+
+  # repository URL transformation is only necessary on Linux
+  os <- renv_ppm_os()
+  if (!identical(os, "__linux__"))
+    return(url)
+
+  # check for a known platform
+  platform <- renv_ppm_platform()
+  if (is.null(platform))
+    return(url)
+
+  # don't transform non-https URLs
+  if (!grepl("^https?://", url))
+    return(url)
+
+  # if this already appears to be a binary URL, then avoid
+  # transforming it
+  if (grepl("/__[^_]+__/", url))
+    return(url)
+
+  # only attempt to transform URLs that are formatted like PPM urls:
+  #
+  #   https://ppm.company.org/cran/checkpoint/id
+  #
+  # in particular, there should be at least two trailing
+  # alphanumeric path components
+  pattern <- "/[^/]+/[^/]+/"
+  if (!grepl(pattern, url))
+    return(url)
+
+  # begin building list of URLs
+  urls <- character()
+
+  # ignore some known CRAN mirrors
+  # (note that getCRANmirrors can fail if R is not installed with
+  # any local knowledge of available CRAN repositories)
+  mirrors <- catch(getCRANmirrors(local.only = TRUE))
+  urls <- c(urls, mirrors$URL)
+
+  # also ignore some RStudio URLs
+  rstudio <- c(
+    "http://cran.rstudio.com",
+    "http://cran.rstudio.org",
+    "https://cran.rstudio.com",
+    "https://cran.rstudio.org"
+  )
+  urls <- c(urls, rstudio)
+
+  if (sub("/+$", "", url) %in% sub("/+$", "", urls))
+    return(url)
+
+  # try to query the status endpoint
+  # TODO: this could fail if the URL is a proxy back to PPM?
+  base <- dirname(dirname(url))
+  status <- catch(renv_ppm_status(base))
+  if (inherits(status, "error"))
+    return(url)
+
+  # iterate through distros and check for a match
+  for (distro in status$distros) {
+
+    ok <-
+      identical(distro$binaryURL, platform) &&
+      identical(distro$binaries, TRUE)
+
+    if (ok) {
+      parts <- c(dirname(url), "__linux__", platform, basename(url))
+      binurl <- paste(parts, collapse = "/")
+      return(binurl)
+    }
+
+  }
+
+  # no match; return url as-is
+  url
+
+}
+
+renv_ppm_status <- function(base) {
+  memoize(
+    key   = base,
+    value = catch(renv_ppm_status_impl(base))
+  )
+}
+
+renv_ppm_status_impl <- function(base) {
+
+  # use a shorter delay to avoid hanging a session
+  renv_scope_options(
+    renv.config.connect.timeout = 10L,
+    renv.config.connect.retry   = 1L
+  )
+
+  # attempt the download
+  endpoint <- file.path(base, "__api__/status")
+  destfile <- renv_scope_tempfile("renv-ppm-status-", fileext = ".json")
+  quietly(download(endpoint, destfile))
+
+  # read the downloaded JSON
+  renv_json_read(destfile)
+
+}
+
+renv_ppm_platform <- function(file = "/etc/os-release") {
+
+  platform <- Sys.getenv("RENV_PPM_PLATFORM", unset = NA)
+  if (!is.na(platform))
+    return(platform)
+
+  platform <- Sys.getenv("RENV_RSPM_PLATFORM", unset = NA)
+  if (!is.na(platform))
+    return(platform)
+
+  if (renv_platform_windows())
+    return("windows")
+
+  if (renv_platform_macos())
+    return("macos")
+
+  renv_ppm_platform_impl(file)
+
+}
+
+renv_ppm_platform_impl <- function(file = "/etc/os-release") {
+
+  if (file.exists(file)) {
+
+    properties <- renv_properties_read(
+      path      = file,
+      delimiter = "=",
+      dequote   = TRUE
+    )
+
+    id <- properties$ID %||% ""
+
+    case(
+      identical(id, "ubuntu") ~ renv_ppm_platform_ubuntu(properties),
+      identical(id, "centos") ~ renv_ppm_platform_centos(properties),
+      identical(id, "rhel")   ~ renv_ppm_platform_rhel(properties),
+      grepl("\\bsuse\\b", id) ~ renv_ppm_platform_suse(properties)
+    )
+
+  }
+
+}
+
+renv_ppm_platform_ubuntu <- function(properties) {
+
+  codename <- properties$VERSION_CODENAME
+  if (is.null(codename))
+    return(NULL)
+
+  codename
+
+}
+
+renv_ppm_platform_centos <- function(properties) {
+
+  id <- properties$VERSION_ID
+  if (is.null(id))
+    return(NULL)
+
+  paste0("centos", substring(id, 1L, 1L))
+
+}
+
+renv_ppm_platform_rhel <- function(properties) {
+
+  id <- properties$VERSION_ID
+  if (is.null(id))
+    return(NULL)
+
+  paste0("centos", substring(id, 1L, 1L))
+
+}
+
+
+renv_ppm_platform_suse <- function(properties) {
+
+  id <- properties$VERSION_ID
+  if (is.null(id))
+    return(NULL)
+
+  parts <- strsplit(id, ".", fixed = TRUE)[[1L]]
+  paste0("opensuse", parts[[1L]])
+
+}
+
+renv_ppm_os <- function() {
+
+  os <- Sys.getenv("RENV_PPM_OS", unset = NA)
+  if (!is.na(os))
+    return(os)
+
+  os <- Sys.getenv("RENV_RSPM_OS", unset = NA)
+  if (!is.na(os))
+    return(os)
+
+  if (renv_platform_windows())
+    "__windows__"
+  else if (renv_platform_macos())
+    "__macos__"
+  else if (renv_platform_linux())
+    "__linux__"
+
+}
+
+
+renv_ppm_enabled <- function() {
+
+  # allow environment variable override
+  enabled <- Sys.getenv("RENV_PPM_ENABLED", unset = NA)
+  if (!is.na(enabled))
+    return(truthy(enabled, default = TRUE))
+
+  enabled <- Sys.getenv("RENV_RSPM_ENABLED", unset = NA)
+  if (!is.na(enabled))
+    return(truthy(enabled, default = TRUE))
+
+  # TODO: can we remove this check?
+  # https://github.com/rstudio/renv/issues/1132
+  disabled <-
+    renv_platform_linux() &&
+    identical(renv_platform_machine(), "aarch64")
+
+  if (disabled)
+    return(FALSE)
+
+  # otherwise, use configuration option
+  config$ppm.enabled()
+
+}
+
+
+# predicate.R ----------------------------------------------------------------
 
 
 pscalar <- function(x) {
@@ -19480,7 +19628,7 @@ pstring <- function(x) {
 
 
 
-# preflight.R ================================================================
+# preflight.R ----------------------------------------------------------------
 
 
 # returns TRUE if problems detected
@@ -19505,7 +19653,7 @@ renv_preflight <- function(lockfile) {
       "The environment may not be restored correctly."
     )
 
-    vwritef(feedback)
+    writef(feedback)
 
   }
 
@@ -19592,14 +19740,12 @@ renv_preflight_java_unix <- function(problems) {
 }
 
 
-# pretty.R ===================================================================
+# pretty.R -------------------------------------------------------------------
 
 
 renv_pretty_print <- function(values,
                               preamble  = NULL,
-                              postamble = NULL,
-                              emitter   = NULL,
-                              wrap      = TRUE)
+                              postamble = NULL)
 {
   if (!renv_verbose())
     return()
@@ -19613,12 +19759,7 @@ renv_pretty_print <- function(values,
     msg$push("")
   }
 
-  formatted <- if (wrap)
-    strwrap(paste(values, collapse = ", "), width = 60)
-  else
-    values
-
-  msg$push(paste("\t", formatted, sep = "", collapse = "\n"))
+  msg$push(paste0("- ", values, collapse = "\n"))
 
   if (!is.null(postamble)) {
     msg$push("")
@@ -19628,14 +19769,12 @@ renv_pretty_print <- function(values,
   msg$push("")
   text <- paste(as.character(msg$data()), collapse = "\n")
 
-  emitter <- emitter %||% renv_pretty_print_emitter()
-  emitter(text)
+  writef(text)
 }
 
 renv_pretty_print_records <- function(records,
                                       preamble  = NULL,
-                                      postamble = NULL,
-                                      emitter   = NULL)
+                                      postamble = NULL)
 {
   if (empty(records))
     return(invisible(NULL))
@@ -19643,26 +19782,23 @@ renv_pretty_print_records <- function(records,
   if (!renv_verbose())
     return(invisible(NULL))
 
-  names(records) <- names(records) %??% map_chr(records, `[[`, "Package")
-  records <- records[csort(names(records))]
+  names(records) <- names(records) %||% map_chr(records, `[[`, "Package")
+  # NOTE: use 'sort()' rather than 'csort()' here so that
+  # printed output is sorted in the expected way in the users locale
+  # https://github.com/rstudio/renv/issues/1289
+  records <- records[sort(names(records))]
   packages <- names(records)
   descs <- map_chr(records, renv_record_format_short)
 
-  lhs <- paste(" ", format(packages))
-  rhs <- descs
-
-  n <- max(nchar(lhs))
-  header <- paste(c(rep.int(" ", n + 1), "_"), collapse = "")
-  text <- sprintf("%s   [%s]", lhs, rhs)
+  text <- sprintf("- %s [%s]", format(packages), descs)
 
   all <- c(
-    if (length(preamble)) preamble,
-    c(header, text, ""),
-    if (length(postamble)) c(postamble, "")
+    preamble, if (length(preamble)) "",
+    text, "",
+    postamble, if (length(postamble)) ""
   )
 
-  emitter <- emitter %||% renv_pretty_print_emitter()
-  emitter(all)
+  writef(all)
 
   invisible(NULL)
 }
@@ -19671,8 +19807,7 @@ renv_pretty_print_records_pair <- function(old,
                                            new,
                                            preamble  = NULL,
                                            postamble = NULL,
-                                           formatter = NULL,
-                                           emitter   = NULL)
+                                           formatter = NULL)
 {
   formatter <- formatter %||% renv_record_format_pair
 
@@ -19682,8 +19817,7 @@ renv_pretty_print_records_pair <- function(old,
     if (length(postamble)) c(postamble, "")
   )
 
-  emitter <- emitter %||% renv_pretty_print_emitter()
-  emitter(all)
+  writef(all)
 
   invisible(NULL)
 }
@@ -19734,21 +19868,8 @@ renv_pretty_print_records_pair_impl <- function(old, new, formatter) {
 
 }
 
-renv_pretty_print_emitter <- function() {
 
-  emitter <- getOption("renv.pretty.print.emitter", default = NULL)
-  if (!is.null(emitter))
-    return(emitter)
-
-  if (interactive())
-    function(text, ...) writeLines(text, con = stdout(), ...)
-  else
-    function(text, ...) writeLines(text, con = stderr(), ...)
-
-}
-
-
-# profile.R ==================================================================
+# profile.R ------------------------------------------------------------------
 
 
 renv_profile_prefix <- function() {
@@ -19768,7 +19889,7 @@ renv_profile_normalize <- function(profile) {
 }
 
 
-# progress.R =================================================================
+# progress.R -----------------------------------------------------------------
 
 
 renv_progress_create <- function(max, wait = 1.0) {
@@ -19804,14 +19925,14 @@ renv_progress_callback <- function(callback, max, wait = 1.0) {
 }
 
 
-# project.R ==================================================================
+# project.R ------------------------------------------------------------------
 
 
 # The path to the currently-loaded project, if any.
 # NULL when no project is currently loaded.
 `_renv_project_path` <- NULL
 
-#' Retrieve the Active Project
+#' Retrieve the active project
 #'
 #' Retrieve the path to the active project (if any).
 #'
@@ -19834,7 +19955,7 @@ project <- function(default = NULL) {
 }
 
 renv_project_get <- function(default = NULL) {
-  `_renv_project_path` %??% default
+  `_renv_project_path` %||% default
 }
 
 # NOTE: RENV_PROJECT kept for backwards compatibility with RStudio
@@ -19850,8 +19971,8 @@ renv_project_clear <- function() {
 }
 
 renv_project_resolve <- function(project = NULL, default = getwd()) {
-  project <- project %??% renv_project_get(default = default)
-  normalizePath(project, winslash = "/", mustWork = FALSE)
+  project <- project %||% renv_project_get(default = default)
+  renv_path_normalize(project)
 }
 
 renv_project_initialized <- function(project) {
@@ -19909,35 +20030,16 @@ renv_project_type_impl <- function(path) {
 
 renv_project_remotes <- function(project, fields = NULL) {
 
-  # if this project has a DESCRIPTION file, use it to provide records
   descpath <- file.path(project, "DESCRIPTION")
-  if (file.exists(descpath))
-    return(renv_project_remotes_description(project, descpath, fields))
-
-  # otherwise, use the set of (non-base) packages used in the project
-  deps <- dependencies(
-    path     = project,
-    progress = FALSE,
-    errors   = "ignored",
-    dev      = TRUE
-  )
-
-  packages <- sort(unique(deps$Package))
-  ignored <- c("renv", renv_project_ignored_packages(project))
-  setdiff(packages, ignored)
-
-}
-
-renv_project_remotes_description <- function(project, descpath, fields = NULL) {
+  if (!file.exists(descpath))
+    return(NULL)
 
   # first, parse remotes (if any)
-  remotes <- renv_project_remotes_description_remotes(project, descpath)
+  remotes <- renv_project_remotes_field(project, descpath)
 
   # next, find packages mentioned in the DESCRIPTION file
-  fields <- fields %||% c("Depends", "Imports", "LinkingTo", "Suggests")
   deps <- renv_dependencies_discover_description(
     path    = descpath,
-    fields  = fields,
     project = project
   )
 
@@ -19990,7 +20092,7 @@ renv_project_remotes_description <- function(project, descpath, fields = NULL) {
 
 }
 
-renv_project_remotes_description_remotes <- function(project, descpath) {
+renv_project_remotes_field <- function(project, descpath) {
 
   desc <- renv_description_read(descpath)
 
@@ -20100,7 +20202,7 @@ renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
         "* This project contains a lockfile, but none of the recorded packages are installed.",
         "* Use `renv::restore()` to restore the project library."
       )
-      ewritef(msg)
+      writef(msg)
       return(FALSE)
     }
   }
@@ -20112,7 +20214,7 @@ renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
       "* One or more packages recorded in the lockfile are not installed.",
       "* Use `renv::status()` for more details."
     )
-    ewritef(msg)
+    writef(msg)
     return(FALSE)
   }
 
@@ -20129,7 +20231,7 @@ renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
       "* Use `renv::status()` for more details."
     )
 
-    ewritef(msg)
+    writef(msg)
     return(FALSE)
 
   }
@@ -20142,7 +20244,7 @@ renv_project_synchronized_check <- function(project = NULL, lockfile = NULL) {
 # renv places its project-local state ...
 renv_project_find <- function(path = NULL) {
 
-  path <- path %??% getwd()
+  path <- path %||% getwd()
 
   anchors <- c("renv.lock", "renv/activate.R")
   resolved <- renv_file_find(path, function(parent) {
@@ -20181,7 +20283,7 @@ renv_project_loaded <- function(project) {
 }
 
 
-# properties.R ===============================================================
+# properties.R ---------------------------------------------------------------
 
 
 renv_properties_read <- function(path = NULL,
@@ -20227,10 +20329,10 @@ renv_properties_read <- function(path = NULL,
 }
 
 
-# purge.R ====================================================================
+# purge.R --------------------------------------------------------------------
 
 
-#' Purge Packages from the Cache
+#' Purge packages from the cache
 #'
 #' Purge packages from the cache. This can be useful if a package which had
 #' previously been installed in the cache has become corrupted or unusable,
@@ -20286,7 +20388,7 @@ renv_purge_impl <- function(package,
     stop("argument 'package' is not of length one", call. = FALSE)
 
   bail <- function() {
-    vwritef("* The requested package is not installed in the cache -- nothing to do.")
+    writef("* The requested package is not installed in the cache -- nothing to do.")
     character()
   }
 
@@ -20321,8 +20423,7 @@ renv_purge_impl <- function(package,
     renv_pretty_print(
       paths[missing],
       "The following entries were not found in the cache:",
-      "They will be ignored.",
-      wrap = FALSE
+      "They will be ignored."
     )
 
     paths <- paths[!missing]
@@ -20334,8 +20435,7 @@ renv_purge_impl <- function(package,
 
     renv_pretty_print(
       renv_cache_format_path(paths),
-      "The following packages will be purged from the cache:",
-      wrap = FALSE
+      "The following packages will be purged from the cache:"
     )
 
     cancel_if(prompt && !proceed())
@@ -20347,14 +20447,14 @@ renv_purge_impl <- function(package,
   renv_cache_clean_empty()
 
   n <- length(paths)
-  vwritef("* Removed %s from the cache.", nplural("package", n))
+  writef("* Removed %s from the cache.", nplural("package", n))
 
   invisible(paths)
 
 }
 
 
-# pyenv.R ====================================================================
+# pyenv.R --------------------------------------------------------------------
 
 
 renv_pyenv_root <- function() {
@@ -20373,7 +20473,7 @@ renv_pyenv_root_default <- function() {
 
 
 
-# python-conda.R =============================================================
+# python-conda.R -------------------------------------------------------------
 
 
 renv_python_conda_select <- function(name, version = NULL) {
@@ -20415,8 +20515,7 @@ renv_python_conda_export_path <- function(project) {
 # TODO: support prompt
 renv_python_conda_snapshot <- function(project, prompt, python) {
 
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
 
   path <- renv_python_conda_export_path(project = project)
 
@@ -20437,15 +20536,14 @@ renv_python_conda_snapshot <- function(project, prompt, python) {
   output <- if (renv_tests_running()) FALSE else ""
   system2(conda, args, stdout = output, stderr = output)
 
-  vwritef("* Wrote Python packages to '%s'.", renv_path_aliased(path))
+  writef("* Wrote Python packages to '%s'.", renv_path_aliased(path))
   return(TRUE)
 }
 
 # TODO: support prompt
 renv_python_conda_restore <- function(project, prompt, python) {
 
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
 
   path <- renv_python_conda_export_path(project = project)
 
@@ -20472,7 +20570,7 @@ renv_python_conda_restore <- function(project, prompt, python) {
 }
 
 
-# python-virtualenv.R ========================================================
+# python-virtualenv.R --------------------------------------------------------
 
 
 renv_python_virtualenv_home <- function() {
@@ -20502,9 +20600,9 @@ renv_python_virtualenv_validate <- function(path, version) {
 
   # compare requested + actual versions
   if (!is.null(version)) {
-    request <- version
-    current <- renv_python_version(python)
-    if (!renv_version_eq(request, current, 2L)) {
+    request <- renv_version_maj_min(version)
+    current <- renv_version_maj_min(renv_python_version(python))
+    if (request != current) {
       fmt <- "Project requested Python version '%s' but '%s' is currently being used"
       warningf(fmt, request, current)
     }
@@ -20558,8 +20656,7 @@ renv_python_virtualenv_update <- function(python) {
 
 renv_python_virtualenv_snapshot <- function(project, prompt, python) {
 
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
 
   path <- file.path(project, "requirements.txt")
   before <- character()
@@ -20568,14 +20665,13 @@ renv_python_virtualenv_snapshot <- function(project, prompt, python) {
 
   after <- pip_freeze(python = python)
   if (setequal(before, after)) {
-    vwritef("* Python requirements are already up to date.")
+    writef("* Python requirements are already up to date.")
     return(FALSE)
   }
 
   renv_pretty_print(
     values   = after,
-    preamble = "The following will be written to requirements.txt:",
-    wrap     = FALSE
+    preamble = "The following will be written to requirements.txt:"
   )
 
   cancel_if(prompt && !proceed())
@@ -20583,15 +20679,14 @@ renv_python_virtualenv_snapshot <- function(project, prompt, python) {
   writeLines(after, con = path)
 
   fmt <- "* Wrote Python packages to %s."
-  vwritef(fmt, renv_path_pretty(path))
+  writef(fmt, renv_path_pretty(path))
   return(TRUE)
 
 }
 
 renv_python_virtualenv_restore <- function(project, prompt, python) {
 
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
 
   path <- file.path(project, "requirements.txt")
   if (!file.exists(path))
@@ -20601,14 +20696,13 @@ renv_python_virtualenv_restore <- function(project, prompt, python) {
   after <- pip_freeze(python = python)
   diff <- renv_vector_diff(before, after)
   if (empty(diff)) {
-    vwritef("* The Python library is already up to date.")
+    writef("* The Python library is already up to date.")
     return(FALSE)
   }
 
   renv_pretty_print(
     values   = diff,
-    preamble = "The following Python packages will be restored:",
-    wrap     = FALSE
+    preamble = "The following Python packages will be restored:"
   )
 
   cancel_if(prompt && !proceed())
@@ -20619,7 +20713,7 @@ renv_python_virtualenv_restore <- function(project, prompt, python) {
 }
 
 
-# python.R ===================================================================
+# python.R -------------------------------------------------------------------
 
 
 renv_python_resolve <- function(python = NULL) {
@@ -20641,7 +20735,7 @@ renv_python_resolve <- function(python = NULL) {
     python <- renv_python_select()
 
     fmt <- "* Selected %s [Python %s]."
-    vwritef(fmt, renv_path_pretty(python), renv_python_version(python))
+    writef(fmt, renv_path_pretty(python), renv_python_version(python))
 
     return(path.expand(python))
 
@@ -20691,8 +20785,7 @@ renv_python_find_impl <- function(version, path = NULL) {
       "See `?renv::use_python` for more details."
     )
 
-    msg <- sprintf(fmt, version)
-    stop(msg)
+    stopf(fmt, version)
 
   }
 
@@ -20838,9 +20931,7 @@ renv_python_restore_impl <- function(python, type, prompt, project) {
 }
 
 renv_python_envpath_virtualenv <- function(version) {
-  majmin <- paste(renv_version_components(version, 1L:2L), collapse = ".")
-  fmt <- "python/virtualenvs/renv-python-%s"
-  sprintf(fmt, majmin)
+  sprintf("python/virtualenvs/renv-python-%s", renv_version_maj_min(version))
 }
 
 renv_python_envpath_condaenv <- function(version) {
@@ -20957,7 +21048,7 @@ renv_python_discover <- function() {
 
     if (length(dirs)) {
       exes <- file.path(dirs, "python.exe")
-      pythons <- normalizePath(exes, winslash = "/", mustWork = FALSE)
+      pythons <- renv_path_normalize(exes)
       all$push(pythons)
     }
 
@@ -21055,7 +21146,7 @@ renv_python_validate <- function(python) {
 }
 
 
-# r.R ========================================================================
+# r.R ------------------------------------------------------------------------
 
 
 R <- function() {
@@ -21205,16 +21296,44 @@ r_exec_error_diagnostics <- function(package, output) {
 r_cmd_install <- function(package, path, ...) {
 
   # normalize path to package
-  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+  path <- renv_path_normalize(path, mustWork = TRUE)
 
-  # unpack source packages in zip archives
+  # unpack .zip source archives before install
+  # https://github.com/rstudio/renv/issues/1359
+  ftype <- renv_file_type(path)
+  atype <- renv_archive_type(path)
+  ptype <- renv_package_type(path)
+
   unpack <-
-    renv_archive_type(path) %in% "zip" &&
-    renv_package_type(path) %in% "source"
+    ftype == "file" &&
+    atype == "zip" &&
+    ptype == "source"
 
   if (unpack) {
-    path <- renv_package_unpack(package, path, force = TRUE)
-    defer(unlink(path, recursive = TRUE))
+    newpath <- renv_package_unpack(package, path, force = TRUE)
+    if (!identical(newpath, path)) {
+      path <- newpath
+      defer(unlink(path, recursive = TRUE))
+    }
+  }
+
+  # rename binary .zip files if necessary
+  rename <-
+    ftype == "file" &&
+    atype == "zip" &&
+    ptype == "binary"
+
+  if (rename) {
+    regexps <- .standard_regexps()
+    fmt <- "^%s(?:_%s)?\\.zip$"
+    pattern <- sprintf(fmt, regexps$valid_package_name, regexps$valid_package_version)
+    if (!grepl(pattern, basename(path), perl = TRUE)) {
+      dir <- renv_scope_tempfile(package)
+      ensure_directory(dir)
+      newpath <- file.path(dir, paste(package, "zip", sep = "."))
+      renv_file_copy(path, newpath)
+      path <- newpath
+    }
   }
 
   # resolve default library path
@@ -21233,7 +21352,7 @@ r_cmd_install <- function(package, path, ...) {
   # could be changed by, for example, site-specific profiles
   args <- c(
     "--vanilla",
-    "CMD", "INSTALL", "--preclean", "--no-multiarch",
+    "CMD", "INSTALL", "--preclean", "--no-multiarch", "--with-keep.source",
     r_cmd_install_option(package, "configure.args", TRUE),
     r_cmd_install_option(package, "configure.vars", TRUE),
     r_cmd_install_option(package, c("install.opts", "INSTALL_opts"), FALSE),
@@ -21276,7 +21395,7 @@ r_cmd_install <- function(package, path, ...) {
 
 r_cmd_build <- function(package, path, ...) {
 
-  path <- renv_path_normalize(path, winslash = "/", mustWork = TRUE)
+  path <- renv_path_normalize(path, mustWork = TRUE)
   args <- c("--vanilla", "CMD", "build", "--md5", ..., renv_shell_path(path))
 
   output <- r(args, stdout = TRUE, stderr = TRUE)
@@ -21356,10 +21475,10 @@ r_cmd_config <- function(...) {
 }
 
 
-# rebuild.R ==================================================================
+# rebuild.R ------------------------------------------------------------------
 
 
-#' Rebuild the Packages in your Project Library
+#' Rebuild the packages in your project library
 #'
 #' Rebuild and reinstall packages in your library. This can be useful as a
 #' diagnostic tool -- for example, if you find that one or more of your
@@ -21419,7 +21538,7 @@ rebuild <- function(packages  = NULL,
   # make sure records are named
   names(records) <- map_chr(records, `[[`, "Package")
   if (empty(records)) {
-    vwritef("* There are no packages currently installed -- nothing to rebuild.")
+    writef("* There are no packages currently installed -- nothing to rebuild.")
     return(invisible(records))
   }
 
@@ -21450,10 +21569,10 @@ rebuild <- function(packages  = NULL,
 }
 
 
-# record.R ===================================================================
+# record.R -------------------------------------------------------------------
 
 
-#' Update Package Records in a Lockfile
+#' Update package records in a lockfile
 #'
 #' Use `record()` to record a new entry within an existing renv lockfile.
 #'
@@ -21462,7 +21581,7 @@ rebuild <- function(packages  = NULL,
 #' package cannot be restored in a particular environment, and you know of a
 #' suitable alternative.
 #'
-#' @section Records:
+#' # Records
 #'
 #' Records can be provided either using the **remotes** short-hand syntax,
 #' or by using an \R list of entries to record within the lockfile. See
@@ -21513,7 +21632,7 @@ record <- function(records,
 
   n <- length(records)
   fmt <- "* Updated %s in %s."
-  vwritef(fmt, nplural("record", n), renv_path_pretty(lockfile))
+  writef(fmt, nplural("record", n), renv_path_pretty(lockfile))
 
   renv <- records[["renv"]]
   if (!is.null(renv) && !is.null(renv[["Version"]])) {
@@ -21531,7 +21650,7 @@ renv_record_normalize <- function(record) {
 
   # normalize source
   source <- record$Source %||% "unknown"
-  if (source %in% c("CRAN", "RSPM"))
+  if (source %in% c("CRAN", "PPM", "RSPM"))
     record$Source <- "Repository"
 
   # drop remotes from records with a repository source
@@ -21550,7 +21669,7 @@ renv_record_normalize <- function(record) {
 }
 
 
-# records.R ==================================================================
+# records.R ------------------------------------------------------------------
 
 
 renv_records_select <- function(records, actions, action) {
@@ -21636,7 +21755,7 @@ renv_record_validate <- function(package, record) {
     return(record)
 
   # if we're running tests, or in CI, then report
-  if (renv_tests_running() || !is.na(Sys.getenv("CI", unset = NA))) {
+  if (renv_tests_running() || renv_envvar_exists("CI")) {
     fmt <- "! Internal error: unexpected record for package '%s'"
     writef(fmt, package)
     print(record)
@@ -21842,7 +21961,7 @@ renv_records_resolve <- function(records, latest = FALSE) {
 }
 
 
-# recurse.R ==================================================================
+# recurse.R ------------------------------------------------------------------
 
 
 recurse <- function(object, callback, ...) {
@@ -21873,10 +21992,10 @@ renv_recurse_impl <- function(stack, object, callback, ...) {
 }
 
 
-# refresh.R ==================================================================
+# refresh.R ------------------------------------------------------------------
 
 
-#' Refresh the Local Cache of Available Packages
+#' Refresh the local cache of available packages
 #'
 #' Query the active R package repositories for available packages, and
 #' update the in-memory cache of those packages.
@@ -21925,7 +22044,7 @@ refresh <- function() {
 }
 
 
-# regexps.R ==================================================================
+# regexps.R ------------------------------------------------------------------
 
 
 renv_regexps_package_name <- function() {
@@ -21947,10 +22066,10 @@ renv_regexps_join <- function(regexps, capture = TRUE) {
 }
 
 
-# rehash.R ===================================================================
+# rehash.R -------------------------------------------------------------------
 
 
-#' Re-Hash Packages in the renv Cache
+#' Re-hash packages in the renv cache
 #'
 #' Re-hash packages in the renv cache, ensuring that any previously-cached
 #' packages are copied to a new cache location appropriate for this version of
@@ -21988,13 +22107,13 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
   # re-compute package hashes
   old <- renv_cache_list(cache = cache)
 
-  vprintf("* Re-computing package hashes ... ")
+  printf("* Re-computing package hashes ... ")
   new <- map_chr(old, renv_progress_callback(renv_cache_path, length(old)))
-  vwritef("Done!")
+  writef("Done!")
 
   changed <- which(old != new & file.exists(old) & !file.exists(new))
   if (empty(changed)) {
-    vwritef("* Your cache is already up-to-date -- nothing to do.")
+    writef("* Your cache is already up-to-date -- nothing to do.")
     return(TRUE)
   }
 
@@ -22007,8 +22126,7 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
     renv_pretty_print(
       sprintf(fmt, format(packages), format(oldhash), format(newhash)),
       "The following packages will be re-cached:",
-      sprintf("Packages will be %s to their new locations in the cache.", label),
-      wrap = FALSE
+      sprintf("Packages will be %s to their new locations in the cache.", label)
     )
 
     cancel_if(prompt && !proceed())
@@ -22020,13 +22138,13 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
   names(sources) <- targets
   names(targets) <- sources
 
-  vprintf("* Re-caching packages ... ")
+  printf("* Re-caching packages ... ")
   enumerate(targets, renv_progress_callback(action, length(targets)))
-  vwritef("Done!")
+  writef("Done!")
 
   n <- length(targets)
   fmt <- "Successfully re-cached %s."
-  vwritef(fmt, nplural("package", n))
+  writef(fmt, nplural("package", n))
 
   renv_cache_clean_empty()
 
@@ -22034,7 +22152,7 @@ renv_rehash_cache <- function(cache, prompt, action, label) {
 }
 
 
-# release.R ==================================================================
+# release.R ------------------------------------------------------------------
 
 
 renv_release_preflight <- function() {
@@ -22065,7 +22183,7 @@ renv_release_preflight_urlcheck <- function() {
 }
 
 
-# remotes.R ==================================================================
+# remotes.R ------------------------------------------------------------------
 
 
 #' Resolve a Remote
@@ -22834,7 +22952,7 @@ renv_remotes_resolve_git_sha_ref <- function(record) {
 
 renv_remotes_resolve_git_description <- function(record) {
 
-  path <- tempfile("renv-git-")
+  path <- renv_scope_tempfile("renv-git-")
   ensure_directory(path)
 
   # TODO: is there a cheaper way for us to accomplish this?
@@ -23030,10 +23148,10 @@ renv_remotes_resolve_path_impl <- function(path) {
 }
 
 
-# remove.R ===================================================================
+# remove.R -------------------------------------------------------------------
 
 
-#' Remove Packages
+#' Remove packages
 #'
 #' Remove (uninstall) \R packages.
 #'
@@ -23069,10 +23187,10 @@ remove <- function(packages,
   records <- Filter(function(record) !inherits(record, "error"), records)
 
   if (library == renv_paths_library(project = project)) {
-    vwritef("* Removing package(s) from project library ...")
+    writef("* Removing package(s) from project library ...")
   } else {
     fmt <- "* Removing package(s) from library '%s' ..."
-    vwritef(fmt, renv_path_aliased(library))
+    writef(fmt, renv_path_aliased(library))
   }
 
   if (length(packages) == 1) {
@@ -23086,7 +23204,7 @@ remove <- function(packages,
       count <- count + 1
   }
 
-  vwritef("* Done! Removed %s.", nplural("package", count))
+  writef("* Done! Removed %s.", nplural("package", count))
   invisible(records)
 }
 
@@ -23094,21 +23212,21 @@ renv_remove_impl <- function(package, library) {
 
   path <- file.path(library, package)
   if (!renv_file_exists(path)) {
-    vwritef("* Package '%s' is not installed -- nothing to do.", package)
+    writef("* Package '%s' is not installed -- nothing to do.", package)
     return(FALSE)
   }
 
   recursive <- renv_file_type(path) == "directory"
-  vprintf("Removing package '%s' ... ", package)
+  printf("Removing package '%s' ... ", package)
   unlink(path, recursive = recursive)
-  vwritef("Done!")
+  writef("Done!")
 
   TRUE
 
 }
 
 
-# renv-package.R =============================================================
+# renv-package.R -------------------------------------------------------------
 
 
 #' Project-local Environments for R
@@ -23123,7 +23241,7 @@ renv_remove_impl <- function(package, library) {
 "_PACKAGE"
 
 
-# renvignore.R ===============================================================
+# renvignore.R ---------------------------------------------------------------
 
 
 # given a path within a project, read all relevant ignore files
@@ -23343,10 +23461,10 @@ renv_renvignore_pattern_extra <- function(key, root) {
 }
 
 
-# repair.R ===================================================================
+# repair.R -------------------------------------------------------------------
 
 
-#' Repair a Project Library
+#' Repair a project library
 #'
 #' Repair a project library whose cache symlinks have become broken.
 #' renv will attempt to reinstall the requisite packages.
@@ -23377,7 +23495,7 @@ repair <- function(library  = NULL,
   packages <- basename(paths[broken])
   if (empty(packages)) {
     fmt <- "* The project library has no broken links -- nothing to do."
-    vwritef(fmt)
+    writef(fmt)
     return(invisible(packages))
   }
 
@@ -23406,7 +23524,7 @@ renv_repair_records <- function(packages, lockfile, project) {
 }
 
 
-# repos.R ====================================================================
+# repos.R --------------------------------------------------------------------
 
 
 renv_repos_encode <- function(x) {
@@ -23435,7 +23553,7 @@ renv_repos_normalize <- function(repos = getOption("repos")) {
   repos[repos == "@CRAN@"] <- cran
 
   # if repos is length 1 but has no names, then assume it's CRAN
-  nms <- names(repos) %??% rep.int("", length(repos))
+  nms <- names(repos) %||% rep.int("", length(repos))
   if (identical(nms, ""))
     nms <- names(repos) <- "CRAN"
 
@@ -23521,7 +23639,7 @@ renv_repos_info_impl <- function(url) {
 }
 
 
-# restart.R ==================================================================
+# restart.R ------------------------------------------------------------------
 
 
 renv_restart_request <- function(project, reason, ...) {
@@ -23547,7 +23665,7 @@ renv_restart_request_default <- function(project, reason, ...) {
   # otherwise, ask the user to restart
   if (interactive()) {
     fmt <- "* %s -- please restart the R session."
-    vwritef(fmt, sprintf(reason, ...), con = stderr())
+    writef(fmt, sprintf(reason, ...))
   }
 
 }
@@ -23586,7 +23704,7 @@ renv_restart_request_rstudio <- function(project, reason, ...) {
 }
 
 
-# restore.R ==================================================================
+# restore.R ------------------------------------------------------------------
 
 
 `_renv_restore_state` <- NULL
@@ -23719,7 +23837,7 @@ restore <- function(project  = NULL,
 
   if (!length(diff)) {
     name <- if (!missing(library)) "library" else "project"
-    vwritef("* The %s is already synchronized with the lockfile.", name)
+    writef("* The %s is already synchronized with the lockfile.", name)
     return(renv_restore_successful(diff, prompt, project))
   }
 
@@ -23882,11 +24000,11 @@ renv_restore_report_actions <- function(actions, current, lockfile) {
 renv_restore_remove <- function(project, package, lockfile) {
   records <- renv_lockfile_records(lockfile)
   record <- records[[package]]
-  vwritef("Removing %s [%s] ...", package, record$Version)
+  writef("Removing %s [%s] ...", package, record$Version)
   paths <- renv_paths_library(project = project, package)
   recursive <- renv_file_type(paths) == "directory"
   unlink(paths, recursive = recursive)
-  vwritef("\tOK [removed from library]")
+  writef("\tOK [removed from library]")
   TRUE
 }
 
@@ -23962,7 +24080,7 @@ renv_restore_successful <- function(records, prompt, project) {
 }
 
 
-# retrieve.R =================================================================
+# retrieve.R -----------------------------------------------------------------
 
 
 `_renv_repos_archive` <- new.env(parent = emptyenv())
@@ -23980,13 +24098,13 @@ retrieve <- function(packages) {
   # normalize repositories (ensure @CRAN@ is resolved)
   options(repos = renv_repos_normalize())
 
-  # transform repository URLs for RSPM
-  if (renv_rspm_enabled()) {
+  # transform repository URLs for PPM
+  if (renv_ppm_enabled()) {
     repos <- getOption("repos")
-    renv_scope_options(repos = renv_rspm_transform(repos))
+    renv_scope_options(repos = renv_ppm_transform(repos))
   }
 
-  # ensure HTTPUserAgent is set (required for RSPM binaries)
+  # ensure HTTPUserAgent is set (required for PPM binaries)
   agent <- renv_http_useragent()
   if (!grepl("renv", agent)) {
     renv <- sprintf("renv (%s)", renv_metadata_version())
@@ -23994,10 +24112,16 @@ retrieve <- function(packages) {
   }
   renv_scope_options(HTTPUserAgent = agent)
 
+  writef(header("Downloading packages"))
   # TODO: parallel?
   handler <- state$handler
   for (package in packages)
     handler(package, renv_retrieve_impl(package))
+
+  if (is.null(state$downloaded)) {
+    writef("[no downloads required]")
+  }
+  writef("")
 
   state <- renv_restore_state()
   data <- state$install$data()
@@ -24147,7 +24271,7 @@ renv_retrieve_impl <- function(package) {
     }
 
     # otherwise, success
-    path <- normalizePath(path, winslash = "/", mustWork = TRUE)
+    path <- renv_path_normalize(path, mustWork = TRUE)
     return(renv_retrieve_successful(record, path))
 
   }
@@ -24170,6 +24294,7 @@ renv_retrieve_impl <- function(package) {
 
   }
 
+  state$downloaded <- TRUE
   # time to retrieve -- delegate based on previously-determined source
   switch(source,
          bioconductor = renv_retrieve_bioconductor(record),
@@ -24198,9 +24323,9 @@ renv_retrieve_path <- function(record, type = "source", ext = NULL) {
   name <- renv_retrieve_name(record, type, ext)
   source <- renv_record_source(record)
 
-  # check for packages from an RSPM binary URL, and
+  # check for packages from an PPM binary URL, and
   # update the package type if known
-  if (renv_rspm_enabled()) {
+  if (renv_ppm_enabled()) {
     url <- attr(record, "url")
     if (is.character(url) && grepl("/__[^_]+__/", url))
       type <- "binary"
@@ -24323,7 +24448,7 @@ renv_retrieve_gitlab <- function(record) {
 }
 
 renv_retrieve_git <- function(record) {
-  path <- tempfile("renv-git-")
+  path <- renv_scope_tempfile("renv-git-")
   ensure_directory(path)
   renv_retrieve_git_impl(record, path)
   renv_retrieve_successful(record, path)
@@ -24369,7 +24494,7 @@ renv_retrieve_git_impl <- function(record, path) {
   if (renv_platform_windows())
     command <- paste(comspec(), "/C", command)
 
-  vwritef("Cloning '%s' ...", url)
+  writef("Cloning '%s' ...", url)
 
   before <- Sys.time()
 
@@ -24388,7 +24513,7 @@ renv_retrieve_git_impl <- function(record, path) {
 
   fmt <- "\tOK [cloned repository in %s]"
   elapsed <- difftime(after, before, units = "auto")
-  vwritef(fmt, renv_difftime_format(elapsed))
+  writef(fmt, renv_difftime_format(elapsed))
 
   TRUE
 
@@ -24403,7 +24528,7 @@ renv_retrieve_cellar_find <- function(record, project = NULL) {
   # have a RemoteUrl entry that we can use
   url <- record$RemoteUrl %||% ""
   if (file.exists(url)) {
-    path <- renv_path_normalize(url, winslash = "/", mustWork = TRUE)
+    path <- renv_path_normalize(url, mustWork = TRUE)
     type <- if (fileext(path) %in% c(".tgz", ".zip")) "binary" else "source"
     return(named(path, type))
   }
@@ -24440,7 +24565,7 @@ renv_retrieve_cellar_report <- function(record) {
     return(record)
 
   fmt <- "* Package %s [%s] will be installed from the cellar."
-  with(record, vwritef(fmt, Package, Version))
+  with(record, writef(fmt, Package, Version))
 
   record
 
@@ -24507,7 +24632,7 @@ renv_retrieve_explicit <- function(record) {
   }
 
   # treat as 'local' source but extract path
-  normalized <- renv_path_normalize(source, winslash = "/", mustWork = TRUE)
+  normalized <- renv_path_normalize(source, mustWork = TRUE)
   resolved$Source <- "Local"
   renv_retrieve_successful(resolved, normalized)
 
@@ -24541,7 +24666,7 @@ renv_retrieve_repos <- function(record) {
     methods$push(renv_retrieve_repos_binary_fallback)
 
     # if MRAN is enabled, check those binaries as well
-    if (config$mran.enabled())
+    if (renv_mran_enabled())
       methods$push(renv_retrieve_repos_mran)
 
   }
@@ -24623,8 +24748,7 @@ renv_retrieve_repos_error_report <- function(record, errors) {
 
   renv_pretty_print(
     values   = paste("-", messages),
-    preamble = preamble,
-    wrap     = FALSE
+    preamble = preamble
   )
 
   if (renv_verbose())
@@ -24966,7 +25090,11 @@ renv_retrieve_successful <- function(record, path, install = TRUE) {
   # record this package's requirements
   state <- renv_restore_state()
   requirements <- state$requirements
-  deps <- renv_dependencies_discover_description(path, subdir = subdir)
+  deps <- renv_dependencies_discover_description(
+    path,
+    subdir = subdir,
+    fields = if (!record$Package %in% state$packages) "strong"
+  )
   if (length(deps$Source))
     deps$Source <- record$Package
 
@@ -25135,8 +25263,7 @@ renv_retrieve_missing_record <- function(package) {
   entry <- renv_available_packages_entry(package, type = "source")
   version <- entry$Version %||% "<unknown>"
 
-  msg <- sprintf(fmt, package, version)
-  writeLines(msg)
+  writef(fmt, package, version)
 
   stopf("failed to find a compatible version of the '%s' package", package)
 
@@ -25201,8 +25328,7 @@ renv_retrieve_incompatible_report <- function(package, record, replacement, comp
     renv_pretty_print(
       values = values,
       preamble = preamble,
-      postamble = postamble,
-      wrap = FALSE
+      postamble = postamble
     )
   }
 
@@ -25221,7 +25347,7 @@ renv_retrieve_origin <- function(host) {
 }
 
 
-# robocopy.R =================================================================
+# robocopy.R -----------------------------------------------------------------
 
 
 renv_robocopy_exec <- function(source, target, flags = NULL) {
@@ -25254,7 +25380,7 @@ renv_robocopy_move <- function(source, target) {
 }
 
 
-# roxygen.R ==================================================================
+# roxygen.R ------------------------------------------------------------------
 
 
 #' @param project The project directory. If `NULL`, then the active project will
@@ -25347,246 +25473,7 @@ renv_roxygen_config_section <- function() {
 }
 
 
-# rspm.R =====================================================================
-
-
-renv_rspm_normalize <- function(url) {
-  sub("/__[^_]+__/[^/]+/", "/", url)
-}
-
-renv_rspm_transform <- function(repos = getOption("repos")) {
-  map_chr(repos, function(url) {
-    tryCatch(
-      renv_rspm_transform_impl(url),
-      error = function(e) url
-    )
-  })
-}
-
-renv_rspm_transform_impl <- function(url) {
-
-  # repository URL transformation is only necessary on Linux
-  os <- renv_rspm_os()
-  if (!identical(os, "__linux__"))
-    return(url)
-
-  # check for a known platform
-  platform <- renv_rspm_platform()
-  if (is.null(platform))
-    return(url)
-
-  # don't transform non-https URLs
-  if (!grepl("^https?://", url))
-    return(url)
-
-  # if this already appears to be a binary URL, then avoid
-  # transforming it
-  if (grepl("/__[^_]+__/", url))
-    return(url)
-
-  # only attempt to transform URLs that are formatted like
-  # RSPM urls -- for example:
-  #
-  #   https://rspm.company.org/cran/checkpoint/id
-  #
-  # in particular, there should be at least two trailing
-  # alphanumeric path components
-  pattern <- "/[^/]+/[^/]+/"
-  if (!grepl(pattern, url))
-    return(url)
-
-  # begin building list of URLs
-  urls <- character()
-
-  # ignore some known CRAN mirrors
-  # (note that getCRANmirrors can fail if R is not installed with
-  # any local knowledge of available CRAN repositories)
-  mirrors <- catch(getCRANmirrors(local.only = TRUE))
-  urls <- c(urls, mirrors$URL)
-
-  # also ignore some RStudio URLs
-  rstudio <- c(
-    "http://cran.rstudio.com",
-    "http://cran.rstudio.org",
-    "https://cran.rstudio.com",
-    "https://cran.rstudio.org"
-  )
-  urls <- c(urls, rstudio)
-
-  if (sub("/+$", "", url) %in% sub("/+$", "", urls))
-    return(url)
-
-  # try to query the status endpoint
-  # TODO: this could fail if the URL is a proxy back to RSPM
-  base <- dirname(dirname(url))
-  status <- catch(renv_rspm_status(base))
-  if (inherits(status, "error"))
-    return(url)
-
-  # iterate through distros and check for a match
-  for (distro in status$distros) {
-
-    ok <-
-      identical(distro$binaryURL, platform) &&
-      identical(distro$binaries, TRUE)
-
-    if (ok) {
-      parts <- c(dirname(url), "__linux__", platform, basename(url))
-      binurl <- paste(parts, collapse = "/")
-      return(binurl)
-    }
-
-  }
-
-  # no match; return url as-is
-  url
-
-}
-
-renv_rspm_status <- function(base) {
-  memoize(
-    key   = base,
-    value = catch(renv_rspm_status_impl(base))
-  )
-}
-
-renv_rspm_status_impl <- function(base) {
-
-  # use a shorter delay to avoid hanging a session
-  renv_scope_options(
-    renv.config.connect.timeout = 10L,
-    renv.config.connect.retry   = 1L
-  )
-
-  # attempt the download
-  endpoint <- file.path(base, "__api__/status")
-  destfile <- renv_scope_tempfile("renv-rspm-status-", fileext = ".json")
-  quietly(download(endpoint, destfile))
-
-  # read the downloaded JSON
-  renv_json_read(destfile)
-
-}
-
-renv_rspm_platform <- function(file = "/etc/os-release") {
-
-  platform <- Sys.getenv("RENV_RSPM_PLATFORM", unset = NA)
-  if (!is.na(platform))
-    return(platform)
-
-  if (renv_platform_windows())
-    return("windows")
-
-  if (renv_platform_macos())
-    return("macos")
-
-  renv_rspm_platform_impl(file)
-
-}
-
-renv_rspm_platform_impl <- function(file = "/etc/os-release") {
-
-  if (file.exists(file)) {
-
-    properties <- renv_properties_read(
-      path      = file,
-      delimiter = "=",
-      dequote   = TRUE
-    )
-
-    id <- properties$ID %||% ""
-
-    case(
-      identical(id, "ubuntu") ~ renv_rspm_platform_ubuntu(properties),
-      identical(id, "centos") ~ renv_rspm_platform_centos(properties),
-      identical(id, "rhel")   ~ renv_rspm_platform_rhel(properties),
-      grepl("\\bsuse\\b", id) ~ renv_rspm_platform_suse(properties)
-    )
-
-  }
-
-}
-
-renv_rspm_platform_ubuntu <- function(properties) {
-
-  codename <- properties$VERSION_CODENAME
-  if (is.null(codename))
-    return(NULL)
-
-  codename
-
-}
-
-renv_rspm_platform_centos <- function(properties) {
-
-  id <- properties$VERSION_ID
-  if (is.null(id))
-    return(NULL)
-
-  paste0("centos", substring(id, 1L, 1L))
-
-}
-
-renv_rspm_platform_rhel <- function(properties) {
-
-  id <- properties$VERSION_ID
-  if (is.null(id))
-    return(NULL)
-
-  paste0("centos", substring(id, 1L, 1L))
-
-}
-
-
-renv_rspm_platform_suse <- function(properties) {
-
-  id <- properties$VERSION_ID
-  if (is.null(id))
-    return(NULL)
-
-  parts <- strsplit(id, ".", fixed = TRUE)[[1L]]
-  paste0("opensuse", parts[[1L]])
-
-}
-
-renv_rspm_os <- function() {
-
-  os <- Sys.getenv("RENV_RSPM_OS", unset = NA)
-  if (!is.na(os))
-    return(os)
-
-  if (renv_platform_windows())
-    "__windows__"
-  else if (renv_platform_macos())
-    "__macos__"
-  else if (renv_platform_linux())
-    "__linux__"
-
-}
-
-
-renv_rspm_enabled <- function() {
-
-  # allow environment variable override
-  enabled <- Sys.getenv("RENV_RSPM_ENABLED", unset = NA)
-  if (!is.na(enabled))
-    return(truthy(enabled, default = TRUE))
-
-  # binaries not available for Linux on arm64
-  disabled <-
-    renv_platform_linux() &&
-    identical(renv_platform_machine(), "aarch64")
-
-  if (disabled)
-    return(FALSE)
-
-  # otherwise, use configuration option
-  config$rspm.enabled()
-
-}
-
-
-# rstudio.R ==================================================================
+# rstudio.R ------------------------------------------------------------------
 
 
 renv_rstudio_available <- function() {
@@ -25645,7 +25532,7 @@ renv_rstudio_fixup <- function() {
 }
 
 
-# rtools.R ===================================================================
+# rtools.R -------------------------------------------------------------------
 
 
 renv_rtools_list <- function() {
@@ -25693,18 +25580,19 @@ renv_rtools_read <- function(root) {
 
 renv_rtools_version <- function(root) {
 
-  # detect Rtools40
-  files <- c("mirrorlist.rtools", "rtools.mingw32", "rtools.mingw64")
-  for (file in files) {
-    path <- file.path(root, "etc/pacman.d", file)
-    if (file.exists(path))
-      return(numeric_version("4.0"))
-  }
+  name <- basename(root)
 
-  # detect Rtools42
-  mirrors <- file.path(root, "etc/pacman.d/mirrorlist.clang64")
-  if (file.exists(mirrors))
-    return(numeric_version("4.2"))
+  # check for 'rtools<xyz>' folder
+  # e.g. C:/rtools42
+  pattern <- "^rtools(\\d)(\\d)$"
+  if (grepl(pattern, name, perl = TRUE, ignore.case = TRUE))
+    return(gsub(pattern, "\\1.\\2", name, perl = TRUE, ignore.case = TRUE))
+
+  # check for versioned installation path
+  # e.g. C:/RBuildTools/4.2
+  version <- catch(numeric_version(name))
+  if (!inherits(version, "error"))
+    return(format(version))
 
   # detect older Rtools installations
   path <- file.path(root, "VERSION.txt")
@@ -25713,7 +25601,6 @@ renv_rtools_version <- function(root) {
 
   contents <- readLines(path, warn = FALSE)
   version <- gsub("[^[:digit:].]", "", contents)
-
   numeric_version(version)
 
 }
@@ -25724,7 +25611,8 @@ renv_rtools_compatible <- function(spec) {
     return(FALSE)
 
   ranges <- list(
-    "4.2" = c("4.2.0", "9.9.9"),
+    "4.3" = c("4.3.0", "9.9.9"),
+    "4.2" = c("4.2.0", "4.3.0"),
     "4.0" = c("4.0.0", "4.2.0"),
     "3.5" = c("3.3.0", "4.0.0"),
     "3.4" = c("3.3.0", "4.0.0"),
@@ -25755,7 +25643,7 @@ renv_rtools_registry <- function() {
 
   path <- status$InstallPath %||% ""
   if (file.exists(path))
-    return(normalizePath(path, winslash = "/"))
+    return(renv_path_normalize(path))
 
 }
 
@@ -25767,28 +25655,35 @@ renv_rtools_envvars <- function(root) {
     renv_rtools_envvars_default(root)
   else if (version < "4.2")
     renv_rtools_envvars_rtools40(root)
-  else
+  else if (version < "4.3")
     renv_rtools_envvars_rtools42(root)
+  else
+    renv_rtools_envvars_rtools43(root)
 
 }
 
 renv_rtools_envvars_default <- function(root) {
 
   # add Rtools utilities to path
-  bin <- normalizePath(
-    file.path(root, "bin"),
-    winslash = "\\",
-    mustWork = FALSE
-  )
-
+  bin <- normalizePath(file.path(root, "bin"), mustWork = FALSE)
   path <- paste(bin, Sys.getenv("PATH"), sep = .Platform$path.sep)
 
   # set BINPREF (note: trailing slash is required)
-  binpref <- paste(
-    normalizePath(root, winslash = "/", mustWork = FALSE),
-    "mingw_$(WIN)/bin/",
-    sep = "/"
-  )
+  # file.path drops trailing separators on Windows, so we use paste
+  binpref <- paste(renv_path_normalize(root), "mingw_$(WIN)/bin/", sep = "/")
+
+  list(PATH = path, BINPREF = binpref)
+
+}
+
+renv_rtools_envvars_rtools43 <- function(root) {
+
+  # add Rtools utilities to path
+  bin <- normalizePath(file.path(root, "usr/bin"), mustWork = FALSE)
+  path <- paste(bin, Sys.getenv("PATH"), sep = .Platform$path.sep)
+
+  # set BINPREF
+  binpref <- ""
 
   list(PATH = path, BINPREF = binpref)
 
@@ -25797,11 +25692,7 @@ renv_rtools_envvars_default <- function(root) {
 renv_rtools_envvars_rtools42 <- function(root) {
 
   # add Rtools utilities to path
-  bin <- normalizePath(
-    file.path(root, "usr/bin"),
-    winslash = "\\",
-    mustWork = FALSE
-  )
+  bin <- normalizePath(file.path(root, "usr/bin"), mustWork = FALSE)
 
   path <- paste(bin, Sys.getenv("PATH"), sep = .Platform$path.sep)
 
@@ -25815,15 +25706,10 @@ renv_rtools_envvars_rtools42 <- function(root) {
 renv_rtools_envvars_rtools40 <- function(root) {
 
   # add Rtools utilities to path
-  bin <- normalizePath(
-    file.path(root, "usr/bin"),
-    winslash = "\\",
-    mustWork = FALSE
-  )
-
+  bin <- normalizePath(file.path(root, "usr/bin"), mustWork = FALSE)
   path <- paste(bin, Sys.getenv("PATH"), sep = .Platform$path.sep)
 
-  # set BINPREF
+  # set BINPREF (note: trailing slash is required)
   binpref <- "/mingw$(WIN)/bin/"
 
   list(PATH = path, BINPREF = binpref)
@@ -25831,10 +25717,10 @@ renv_rtools_envvars_rtools40 <- function(root) {
 }
 
 
-# run.R ======================================================================
+# run.R ----------------------------------------------------------------------
 
 
-#' Run a Script
+#' Run a script
 #'
 #' Run an \R script, in the context of a project using renv. The script will
 #' be run within an \R sub-process.
@@ -25861,7 +25747,7 @@ run <- function(script, ..., job = NULL, name = NULL, project = NULL) {
   renv_scope_error_handler()
   renv_dots_check(...)
 
-  script <- renv_path_normalize(script, winslash = "/", mustWork = TRUE)
+  script <- renv_path_normalize(script, mustWork = TRUE)
 
   # find the project directory
   project <- project %||% renv_file_find(script, function(path) {
@@ -25923,13 +25809,12 @@ renv_run_job <- function(script, name, project) {
 }
 
 renv_run_impl <- function(script, name, project) {
-  owd <- setwd(project)
-  defer(setwd(owd))
+  renv_scope_wd(project)
   system2(R(), c("-s", "-f", renv_shell_path(script)))
 }
 
 
-# sandbox.R ==================================================================
+# sandbox.R ------------------------------------------------------------------
 
 
 renv_sandbox_init <- function() {
@@ -25989,7 +25874,7 @@ renv_sandbox_activate_impl <- function(project = NULL, path = NULL) {
   # get current library paths
   oldlibs <- .libPaths()
   syslibs <- c(renv_libpaths_site(), renv_libpaths_system())
-  syslibs <- renv_path_normalize(syslibs, winslash = "/", mustWork = FALSE)
+  syslibs <- renv_path_normalize(syslibs)
 
   # override .Library.site
   base <- .BaseNamespaceEnv
@@ -26070,10 +25955,9 @@ renv_sandbox_generate <- function(sandbox) {
   renv_scope_lock(lockfile)
 
   # make the library temporarily writable
-  lock <- getOption("renv.sandbox.locking_enabled") %||% all(
-    !renv_package_checking() &&
-    !renv_path_within(sandbox, tempdir())
-  )
+  lock <- getOption("renv.sandbox.locking_enabled") %||% {
+    !renv_package_checking() && !renv_path_within(sandbox, tempdir())
+  }
 
   if (lock) {
     dlog("sandbox", "Temporarily unlocking sandbox.")
@@ -26148,22 +26032,22 @@ renv_sandbox_path <- function(project = NULL) {
 }
 
 renv_sandbox_lock <- function(sandbox = NULL, project = NULL) {
-  sandbox <- sandbox %??% renv_sandbox_path(project = project)
+  sandbox <- sandbox %||% renv_sandbox_path(project = project)
   Sys.chmod(sandbox, mode = "0555")
 }
 
 renv_sandbox_locked <- function(sandbox = NULL, project = NULL) {
-  sandbox <- sandbox %??% renv_sandbox_path(project = project)
+  sandbox <- sandbox %||% renv_sandbox_path(project = project)
   mode <- suppressWarnings(file.mode(sandbox))
   mode == 365L  # as.integer(as.octmode("0555"))
 }
 
 renv_sandbox_unlock <- function(sandbox = NULL, project = NULL) {
-  sandbox <- sandbox %??% renv_sandbox_path(project = project)
+  sandbox <- sandbox %||% renv_sandbox_path(project = project)
   Sys.chmod(sandbox, mode = "0755")
 }
 
-#' The system library sandbox
+#' The default library sandbox
 #'
 #' @description
 #' An \R installation can have up to three types of library paths available
@@ -26177,38 +26061,38 @@ renv_sandbox_unlock <- function(sandbox = NULL, project = NULL) {
 #'   system are installed. This library path, if it exists, is visible to all
 #'   users on the system.
 #'
-#' - The _system library_, where \R packages distributed with \R itself are
+#' - The _default library_, where \R packages distributed with \R itself are
 #'   installed. This library path is visible to all users on the system.
 #'
 #' Normally, only so-called "base" and "recommended" packages should be installed
-#' in the system library (You can get a list of these packages with
+#' in the default library. (You can get a list of these packages with
 #' `installed.packages(priority = c("base", "recommended"))`). However, it is
-#' possible for users and administrators to install packages into the system
+#' possible for users and administrators to install packages into the default
 #' library, if the filesystem permissions permit them to do so. (This, for
 #' example, is the default behavior on macOS.)
 #'
-#' Because the site and system libraries are visible to all users, having those
+#' Because the site and default libraries are visible to all users, having those
 #' accessible in renv projects can potentially break isolation -- that is,
-#' if a package were updated in the system library, that update would be visible
+#' if a package were updated in the default library, that update would be visible
 #' to all \R projects on the system.
 #'
-#' To help defend against this, renv uses something it calls the "system library
-#' sandbox", or the "sandbox", to isolate renv projects from non-"base" packages
-#' that are installed into the system library. To accomplish this, when an renv
-#' project is loaded, renv will:
+#' To help defend against this, renv uses something called the "sandbox" to
+#' isolate renv projects from non-"base" packages that are installed into the
+#' default library. When an renv project is loaded, renv will:
 #'
 #' - Create a new, empty library path (called the "sandbox"),
 #'
-#' - Link only the "base" packages from the system library into the sandbox,
+#' - Link only the "base" and "recommended" packages from the default library
+#'   into the sandbox,
 #'
 #' - Mark the sandbox as read-only, so that users are unable to install packages
 #'   into this library,
 #'
-#' - Instruct the \R session to use the "sandbox" as the system library.
+#' - Instruct the \R session to use the "sandbox" as the default library.
 #'
 #' This process is mostly transparent to the user. However, because the sandbox
 #' is read-only, if you later need to remove the sandbox, you'll need to reset
-#' file permissions manually; for example, with `renv::sandbox$unlock()`
+#' file permissions manually; for example, with `renv::sandbox$unlock()`.
 #'
 #' If you'd prefer to keep the sandbox unlocked, you can also set:
 #'
@@ -26224,6 +26108,9 @@ renv_sandbox_unlock <- function(sandbox = NULL, project = NULL) {
 #' RENV_CONFIG_SANDBOX_ENABLED = FALSE
 #' ```
 #'
+#' The sandbox library path can also be configured using the `RENV_PATHS_SANDBOX`
+#' environment variable: see [paths] for more details.
+#'
 #' @format NULL
 #' @export
 sandbox <- list(
@@ -26234,9 +26121,9 @@ sandbox <- list(
 )
 
 
-# scaffold.R =================================================================
+# scaffold.R -----------------------------------------------------------------
 
-#' Generate Project Infrastructure
+#' Generate project infrastructure
 #'
 #' @description
 #' Create the renv project infrastructure. This will:
@@ -26307,29 +26194,26 @@ scaffold <- function(project  = NULL,
 
   # notify user
   fmt <- "* renv infrastructure has been generated for project %s."
-  vwritef(fmt, renv_path_pretty(project))
+  writef(fmt, renv_path_pretty(project))
 
   # return project invisibly
   invisible(project)
 }
 
 
-# scope.R ====================================================================
+# scope.R --------------------------------------------------------------------
 
 
 renv_scope_tempdir <- function(pattern = "renv-tempdir-",
                                tmpdir = tempdir(),
+                               umask = NULL,
                                envir = parent.frame())
 {
-  dir <- tempfile(pattern = pattern, tmpdir = tmpdir)
-  ensure_directory(dir)
-  owd <- setwd(dir)
+  dir <- renv_scope_tempfile(pattern = pattern, tmpdir = tmpdir, envir = envir)
+  ensure_directory(dir, umask = umask)
 
-  defer({
-    setwd(owd)
-    unlink(dir, recursive = TRUE)
-  }, envir = envir)
-
+  renv_scope_wd(dir, envir = envir)
+  dir
 }
 
 renv_scope_auth <- function(record, envir = parent.frame()) {
@@ -26367,11 +26251,9 @@ renv_scope_libpaths <- function(new = .libPaths(), envir = parent.frame()) {
 }
 
 renv_scope_options <- function(..., envir = parent.frame()) {
-
   new <- list(...)
   old <- options(new)
   defer(options(old), envir = envir)
-
 }
 
 renv_scope_locale <- function(category = "LC_ALL", locale = "", envir = parent.frame()) {
@@ -26382,7 +26264,7 @@ renv_scope_locale <- function(category = "LC_ALL", locale = "", envir = parent.f
 
 renv_scope_envvars <- function(..., list = NULL, envir = parent.frame()) {
 
-  dots <- list %??% list(...)
+  dots <- list %||% list(...)
   old <- as.list(Sys.getenv(names(dots), unset = NA))
   names(old) <- names(dots)
 
@@ -26396,20 +26278,6 @@ renv_scope_envvars <- function(..., list = NULL, envir = parent.frame()) {
     Sys.unsetenv(names(old[na]))
     if (length(old[!na]))
       do.call(Sys.setenv, old[!na])
-  }, envir = envir)
-
-}
-
-renv_scope_sink <- function(file = nullfile(), envir = parent.frame()) {
-
-  # redirect stdout to file, and redirect stderr back to stdout
-  # this ensures that both stdout, stderr are redirected to the same place
-  sink(file = file,     type = "output")
-  sink(file = stdout(), type = "message")
-
-  defer({
-    sink(type = "output")
-    sink(type = "message")
   }, envir = envir)
 
 }
@@ -26665,17 +26533,15 @@ renv_scope_trace <- function(what, tracer, envir = parent.frame()) {
 
 }
 
-renv_scope_var <- function(key, value, frame, envir = parent.frame()) {
 
-  if (exists(key, envir = frame, inherits = FALSE)) {
-    saved <- get(key, envir = frame, inherits = FALSE)
-    assign(key, value, envir = frame, inherits = FALSE)
-    defer(assign(key, saved, envir = frame, inherits = FALSE), envir = envir)
+renv_scope_binding <- function(envir, symbol, replacement, frame = parent.frame()) {
+  if (exists(symbol, envir, inherits = FALSE)) {
+    old <- renv_binding_replace(symbol, replacement, envir)
+    defer(renv_binding_replace(symbol, old, envir), envir = frame)
   } else {
-    assign(key, value, envir = frame, inherits = FALSE)
-    defer(rm(list = key, envir = frame, inherits = FALSE), envir = envir)
+    assign(symbol, replacement, envir = envir)
+    defer(rm(list = symbol, envir = envir, inherits = FALSE), envir = frame)
   }
-
 }
 
 renv_scope_tempfile <- function(pattern = "renv-tempfile-",
@@ -26683,11 +26549,9 @@ renv_scope_tempfile <- function(pattern = "renv-tempfile-",
                                 fileext = "",
                                 envir  = parent.frame())
 {
-  filepath <- tempfile(pattern, tmpdir, fileext)
-
-  defer(unlink(filepath, recursive = TRUE, force = TRUE), envir = envir)
-
-  invisible(filepath)
+  path <- renv_path_normalize(tempfile(pattern, tmpdir, fileext))
+  defer(unlink(path, recursive = TRUE, force = TRUE), envir = envir)
+  invisible(path)
 }
 
 renv_scope_umask <- function(umask, envir = parent.frame()) {
@@ -26696,8 +26560,20 @@ renv_scope_umask <- function(umask, envir = parent.frame()) {
   invisible(oldmask)
 }
 
+renv_scope_wd <- function(dir = getwd(), envir = parent.frame()) {
+  owd <- setwd(dir)
+  defer(setwd(owd), envir = envir)
+  invisible(owd)
+}
 
-# sdkroot.R ==================================================================
+renv_scope_sandbox <- function(envir = parent.frame()) {
+  sandbox <- renv_sandbox_activate()
+  defer(renv_sandbox_deactivate(), envir = envir)
+  invisible(sandbox)
+}
+
+
+# sdkroot.R ------------------------------------------------------------------
 
 
 renv_sdkroot_init <- function() {
@@ -26734,7 +26610,7 @@ renv_sdkroot_init <- function() {
 }
 
 
-# session.R ==================================================================
+# session.R ------------------------------------------------------------------
 
 
 renv_session_quiet <- function() {
@@ -26751,7 +26627,7 @@ renv_session_quiet <- function() {
 }
 
 
-# settings.R =================================================================
+# settings.R -----------------------------------------------------------------
 
 
 `_renv_settings` <- new.env(parent = emptyenv())
@@ -26907,7 +26783,7 @@ renv_settings_set <- function(project, name, value, persist = TRUE) {
   settings <- renv_settings_get(project)
 
   # update setting value
-  old <- settings[[name]] %??% renv_settings_default(name)
+  old <- settings[[name]] %||% renv_settings_default(name)
   new <- renv_settings_validate(name, value)
   settings[[name]] <- new
 
@@ -26984,11 +26860,11 @@ renv_settings_updated_cache <- function(project, old, new) {
 
   if (empty(pkgpaths)) {
     fmt <- "* The cache has been %s for this project."
-    vwritef(fmt, if (new) "enabled" else "disabled")
+    writef(fmt, if (new) "enabled" else "disabled")
     return(TRUE)
   }
 
-  vprintf("* Synchronizing project library with the cache ... ")
+  printf("* Synchronizing project library with the cache ... ")
 
   if (new) {
 
@@ -27022,10 +26898,10 @@ renv_settings_updated_cache <- function(project, old, new) {
 
   }
 
-  vwritef("Done!")
+  writef("Done!")
 
   fmt <- "* The cache has been %s for this project."
-  vwritef(fmt, if (new) "enabled" else "disabled")
+  writef(fmt, if (new) "enabled" else "disabled")
 
 }
 
@@ -27100,7 +26976,7 @@ renv_settings_impl <- function(name, default, scalar, validate, coerce, update) 
 #'
 #' A vector of library paths, to be used in addition to the project's own
 #' private library. This can be useful if you have a package available for use
-#' in some global library, but for some reason renv is not able to install
+#' in some system library, but for some reason renv is not able to install
 #' that package (e.g. sources or binaries for that package are not publicly
 #' available, or you have been unable to orchestrate the pre-requisites for
 #' installing some packages from source on your machine).
@@ -27113,11 +26989,10 @@ renv_settings_impl <- function(name, default, scalar, validate, coerce, update) 
 #'
 #' ## `package.dependency.fields`
 #'
-#' During dependency discovery, renv uses the fields of an installed
-#' package's `DESCRIPTION` file to determine that package's recursive
-#' dependencies. By default, the `Imports`, `Depends` and `LinkingTo` fields
-#' are used. If you'd prefer that renv also captures the `Suggests`
-#' dependencies for a package, you can set this to
+#' When explicitly installing a package with `install()`, what fields
+#' should be used to determine that packages dependencies? The default
+#' uses `Imports`, `Depends` and `LinkingTo` fields, but you also want
+#' to install `Suggests` dependencies for a package, you can set this to
 #' `c("Imports", "Depends", "LinkingTo", "Suggests")`.
 #'
 #' ## `r.version`
@@ -27302,7 +27177,7 @@ settings <- list(
 )
 
 
-# shell.R ====================================================================
+# shell.R --------------------------------------------------------------------
 
 
 renv_shell_quote <- function(x) {
@@ -27316,7 +27191,7 @@ renv_shell_path <- function(x) {
 }
 
 
-# shims.R ====================================================================
+# shims.R --------------------------------------------------------------------
 
 
 `_renv_shims` <- new.env(parent = emptyenv())
@@ -27397,64 +27272,7 @@ renv_shims_deactivate <- function() {
 }
 
 
-# skip.R =====================================================================
-
-
-skip_if_no_python <- function(python = NULL) {
-
-  python <- python %||% "python3"
-  key <- paste("tests", python, "installed", sep = ".")
-  installed <- global(key, {
-    python <- Sys.which(python)
-    nzchar(python)
-  })
-
-  if (installed)
-    return(TRUE)
-
-  testthat::skip("python is not installed")
-
-}
-
-skip_if_no_virtualenv <- function(python = NULL) {
-
-  skip_if_no_python(python)
-
-  key <- paste("tests", python, "virtualenv.installed", sep = ".")
-  installed <- global(key, {
-    version <- renv_python_version(python)
-    module <- if (numeric_version(version) >= "3.2") "venv" else "virtualenv"
-    renv_python_module_available(python, module)
-  })
-
-  if (!installed)
-    testthat::skip("virtualenv module not installed")
-
-  TRUE
-
-}
-
-skip_if_no_miniconda <- function(python) {
-
-  skip_if_no_python(python)
-  testthat::skip_if_not_installed("reticulate", "1.13.0.9002")
-
-  # gymnastics for CRAN checks before next release of reticulate
-  if (requireNamespace("reticulate", quietly = TRUE)) {
-    reticulate <- asNamespace("reticulate")
-    if (is.function(reticulate$miniconda_path)) {
-      path <- reticulate$miniconda_path()
-      if (!file.exists(path))
-        testthat::skip("miniconda is not installed")
-    }
-  }
-
-  TRUE
-
-}
-
-
-# snapshot-auto.R ============================================================
+# snapshot-auto.R ------------------------------------------------------------
 
 
 `_renv_library_info` <- NULL
@@ -27470,31 +27288,41 @@ renv_snapshot_auto <- function(project) {
   defer(`_renv_snapshot_running` <<- FALSE)
 
   # passed pre-flight checks; snapshot the library
-  # validation messages can be noisy; turn off for auto snapshot
-  status <- catch(renv_snapshot_auto_impl(project))
-  if (inherits(status, "error"))
-    return(FALSE)
+  updated <- tryCatch(
+    renv_snapshot_auto_impl(project),
+    error = function(err) FALSE
+  )
 
-  lockfile <- renv_lockfile_path(project = project)
-  vwritef("* Automatic snapshot has updated '%s'.", renv_path_aliased(lockfile))
-  TRUE
+  if (updated) {
+    lockfile <- renv_path_aliased(renv_lockfile_path(project))
+    writef("* Automatic snapshot has updated '%s'.", lockfile)
+  }
+
+  invisible(updated)
 
 }
 
 renv_snapshot_auto_impl <- function(project) {
 
-  # be quiet during auto snapshot
+  # validation messages can be noisy; turn off for auto snapshot
   renv_scope_options(
     renv.config.snapshot.validate = FALSE,
     renv.verbose = FALSE
   )
 
+  lockfile <- renv_paths_lockfile(project)
+  old <- file.info(lockfile)$mtime
+
   # perform snapshot without prompting
   snapshot(project = project, prompt = FALSE)
 
+  new <- file.info(lockfile)$mtime
+
+  old != new
+
 }
 
-renv_snapshot_auto_enabled <- function(project) {
+renv_snapshot_auto_enabled <- function(project = renv_project_get()) {
 
   # don't auto-snapshot if disabled by user
   enabled <- config$auto.snapshot()
@@ -27502,7 +27330,7 @@ renv_snapshot_auto_enabled <- function(project) {
     return(FALSE)
 
   # only automatically snapshot the current project
-  if (renv_project_loaded(project))
+  if (!renv_project_loaded(project))
     return(FALSE)
 
   # don't auto-snapshot if the project hasn't been initialized
@@ -27522,7 +27350,7 @@ renv_snapshot_auto_enabled <- function(project) {
 
 }
 
-renv_snapshot_auto_update <- function(project) {
+renv_snapshot_auto_update <- function(project = renv_project_get() ) {
 
   # check for enabled
   if (!renv_snapshot_auto_enabled(project = project))
@@ -27560,12 +27388,12 @@ renv_snapshot_task <- function() {
   # check for active renv project
   project <- renv_project_get()
   if (is.null(project))
-    return()
+    return(invisible(FALSE))
 
   # see if library state has updated
   updated <- renv_snapshot_auto_update(project = project)
   if (!updated)
-    return()
+    return(invisible(FALSE))
 
   # library has updated; perform auto snapshot
   renv_snapshot_auto(project = project)
@@ -27586,7 +27414,7 @@ renv_snapshot_auto_suppress_next <- function() {
 # nocov end
 
 
-# snapshot.R =================================================================
+# snapshot.R -----------------------------------------------------------------
 
 
 # controls whether hashes are computed when computing a snapshot
@@ -27604,6 +27432,9 @@ renv_snapshot_auto_suppress_next <- function() {
 #' in which case it will record the current state of dependencies in the
 #' current library paths. This makes it possible to [restore] the current packages,
 #' providing lightweight portability and reproducibility without isolation.
+#'
+#' If you want to automatically snapshot after each change, you can
+#' set `config$config$auto.snapshot(TRUE)`, see `?config` for more details.
 #'
 #' # Snapshot types
 #'
@@ -27685,6 +27516,8 @@ renv_snapshot_auto_suppress_next <- function() {
 #'   lockfile as well.
 #'
 #' @param exclude A vector of packages to be explicitly excluded from the lockfile.
+#'   Note that transitive package dependencies will always be included, to avoid
+#'   potentially creating an incomplete / non-functional lockfile.
 #'
 #' @param update Boolean; if the lockfile already exists, then attempt to update
 #'   that lockfile without removing any prior package records.
@@ -27769,7 +27602,7 @@ snapshot <- function(project  = NULL,
     # check if there are any changes in the lockfile
     diff <- renv_lockfile_diff(old, alt)
     if (empty(diff)) {
-      vwritef("* The lockfile is already up to date.")
+      writef("* The lockfile is already up to date.")
       return(renv_snapshot_successful(alt, prompt, project))
     }
 
@@ -27796,12 +27629,12 @@ snapshot <- function(project  = NULL,
     renv_snapshot_report_actions(actions, old, new)
 
   # request user confirmation
-  cancel_if(length(actions) && prompt && !proceed())
+  cancel_if(length(actions) && file.exists(lockfile) && prompt && !proceed())
 
   # write it out
   ensure_parent_directory(lockfile)
   renv_lockfile_write(new, file = lockfile)
-  vwritef("* Lockfile written to '%s'.", renv_path_aliased(lockfile))
+  writef("* Lockfile written to '%s'.", renv_path_aliased(lockfile))
 
   # ensure the lockfile is .Rbuildignore-d
   renv_infrastructure_write_rbuildignore(project)
@@ -27905,7 +27738,7 @@ renv_snapshot_validate_report <- function(valid, prompt, force) {
 
   # in interactive sessions, if 'prompt' is set, then ask the user
   # if they would like to proceed
-  if (interactive() && prompt) {
+  if (interactive() && !is_testing() && prompt) {
     cancel_if(!proceed())
     return(TRUE)
   }
@@ -27937,9 +27770,7 @@ renv_snapshot_validate_bioconductor <- function(project, lockfile, libpaths) {
       "Consider installing %s before snapshot.",
       ""
     )
-
-    if (!renv_tests_running())
-      writeLines(sprintf(text, package))
+    writef(text, package)
 
     ok <- FALSE
   }
@@ -27972,9 +27803,9 @@ renv_snapshot_validate_bioconductor <- function(project, lockfile, libpaths) {
     if (identical(latest, "<NA>"))
       return(TRUE)
 
-    current <- unclass(package_version(current))[[1]]
-    latest <- unclass(package_version(latest))[[1]]
-    current[[1]] != latest[[1]] || current[[2]] != latest[[2]]
+    current <- renv_version_maj_min(current)
+    latest <- renv_version_maj_min(latest)
+    current != latest
 
   }, bioc$Version, bioc$Latest)
 
@@ -27983,18 +27814,14 @@ renv_snapshot_validate_bioconductor <- function(project, lockfile, libpaths) {
 
     fmt <- "%s [installed %s != latest %s]"
     msg <- sprintf(fmt, format(bad$Package), format(bad$Version), bad$Latest)
-
-    if (!renv_tests_running()) {
-      renv_pretty_print(
-        msg,
-        "The following Bioconductor packages appear to be from a separate Bioconductor release:",
-        c(
-          "renv may be unable to restore these packages.",
-          paste("Bioconductor version:", version)
-        ),
-        wrap = FALSE
+    renv_pretty_print(
+      msg,
+      "The following Bioconductor packages appear to be from a separate Bioconductor release:",
+      c(
+        "renv may be unable to restore these packages.",
+        paste("Bioconductor version:", version)
       )
-    }
+    )
 
     ok <- FALSE
   }
@@ -28045,14 +27872,11 @@ renv_snapshot_validate_dependencies_available <- function(project, lockfile, lib
 
   })
 
-  if (!renv_tests_running()) {
-    renv_pretty_print(
-      sprintf("%s  [required by %s]", format(missing), usedby),
-      "The following required packages are not installed:",
-      "Consider reinstalling these packages before snapshotting the lockfile.",
-      wrap = FALSE
-    )
-  }
+  renv_pretty_print(
+    sprintf("%s  [required by %s]", format(missing), usedby),
+    "The following required packages are not installed:",
+    "Consider reinstalling these packages before snapshotting the lockfile."
+  )
 
   FALSE
 
@@ -28112,17 +27936,12 @@ renv_snapshot_validate_dependencies_compatible <- function(project, lockfile, li
 
   fmt <- "%s requires %s, but version %s is installed"
   txt <- sprintf(fmt, format(package), format(requires), format(request))
+  renv_pretty_print(
+    txt,
+    "The following package(s) have unsatisfied dependencies:",
+    "Consider updating the required dependencies as appropriate."
+  )
 
-  if (!renv_tests_running()) {
-    renv_pretty_print(
-      txt,
-      "The following package(s) have unsatisfied dependencies:",
-      "Consider updating the required dependencies as appropriate.",
-      wrap = FALSE
-    )
-  }
-
-  renv_condition_signal("renv.snapshot.unsatisfied_dependencies")
   FALSE
 
 }
@@ -28198,7 +28017,6 @@ renv_snapshot_library <- function(library = NULL,
 
     messages <- map_chr(broken, conditionMessage)
     text <- sprintf("'%s': %s", names(broken), messages)
-
     renv_pretty_print(
       text,
       "renv was unable to snapshot the following packages:",
@@ -28271,8 +28089,7 @@ renv_snapshot_library_diagnose_missing_description <- function(library, pkgs) {
     c(
       "These may be left over from a prior, failed installation attempt.",
       "Consider removing or reinstalling these packages."
-    ),
-    wrap = FALSE
+    )
   )
 
   pkgs[!missing]
@@ -28324,12 +28141,16 @@ renv_snapshot_description_impl <- function(dcf, path = NULL) {
   git <- grep("^git", names(dcf), value = TRUE)
   remotes <- grep("^Remote", names(dcf), value = TRUE)
 
-  # https://github.com/rstudio/renv/issues/736
-  remotes <- grep("[.]\\d+$", remotes, perl = TRUE, invert = TRUE, value = TRUE)
+  is_repo <- is.null(dcf[["RemoteType"]]) ||
+    identical(dcf[["RemoteType"]], "standard")
 
   # only keep relevant fields
   extra <- c("Repository", "OS_type")
-  all <- c(required, extra, remotes, git, "Requirements", "Hash")
+  all <- c(
+    required, extra,
+    if (!is_repo) c(remotes, git),
+    "Requirements", "Hash"
+  )
   keep <- renv_vector_intersect(all, names(dcf))
 
   # return as list
@@ -28413,32 +28234,38 @@ renv_snapshot_description_source_hack <- function(package) {
 # nocov start
 renv_snapshot_report_actions <- function(actions, old, new) {
 
-  if (!renv_verbose() || empty(actions))
+  if (!renv_verbose())
     return(invisible())
 
-  lhs <- renv_lockfile_records(old)
-  rhs <- renv_lockfile_records(new)
-  renv_pretty_print_records_pair(
-    lhs[names(lhs) %in% names(actions)],
-    rhs[names(rhs) %in% names(actions)],
-    "The following package(s) will be updated in the lockfile:"
-  )
+  if (length(actions)) {
+    lhs <- renv_lockfile_records(old)
+    rhs <- renv_lockfile_records(new)
+    renv_pretty_print_records_pair(
+      lhs[names(lhs) %in% names(actions)],
+      rhs[names(rhs) %in% names(actions)],
+      "The following package(s) will be updated in the lockfile:"
+    )
+  }
 
   oldr <- old$R$Version
   newr <- new$R$Version
   rdiff <- renv_version_compare(oldr %||% "0", newr %||% "0")
 
   if (rdiff != 0L) {
-    n <- max(nchar(names(actions)))
+    n <- max(nchar(names(actions)), 0)
     fmt <- paste("-", format("R", width = n), " ", "[%s -> %s]")
     msg <- sprintf(fmt, oldr %||% "*", newr %||% "*")
-    writeLines(c("The version of R recorded in the lockfile will be updated:", msg, ""))
+    writef(
+      c("The version of R recorded in the lockfile will be updated:", msg, "")
+    )
   }
 
 }
 # nocov end
 
-renv_snapshot_dependencies <- function(project, type) {
+renv_snapshot_dependencies <- function(project, type = NULL, dev = FALSE) {
+
+  type <- type %||% settings$snapshot.type(project = project)
 
   message <- "snapshot aborted"
   errors <- config$dependency.errors()
@@ -28467,7 +28294,8 @@ renv_snapshot_dependencies <- function(project, type) {
       root     = project,
       progress = FALSE,
       field    = "Package",
-      errors   = errors
+      errors   = errors,
+      dev      = dev
     ),
 
     renv.dependencies.error = renv_dependencies_error_handler(message, errors)
@@ -28478,72 +28306,36 @@ renv_snapshot_dependencies <- function(project, type) {
 
 renv_snapshot_filter <- function(project, records, type, packages, exclude) {
 
-  start <- Sys.time()
-
   type <- type %||% settings$snapshot.type(project = project)
 
   aliases <- list(packrat = "implicit", simple = "all")
   type <- aliases[[type]] %||% type
 
   result <- switch(type,
-    all      = renv_snapshot_filter_all(project, records),
-    custom   = renv_snapshot_filter_custom(project, records),
-    explicit = renv_snapshot_filter_explicit(project, records),
-    implicit = renv_snapshot_filter_implicit(project, records),
-    packages = renv_snapshot_filter_packages(project, records, packages),
+    all      = renv_snapshot_filter_all(project, records, exclude),
+    custom   = renv_snapshot_filter_custom(project, records, exclude),
+    explicit = renv_snapshot_filter_explicit(project, records, exclude),
+    implicit = renv_snapshot_filter_implicit(project, records, exclude),
+    packages = renv_snapshot_filter_packages(project, records, packages, exclude),
     stopf("unknown snapshot type '%s'", type)
   )
-
-  if (length(exclude))
-    result <- exclude(result, exclude)
-
-  if (type %in% c("all", "explicit"))
-    return(result)
-
-  end <- Sys.time()
-
-  # report if dependency discovery took a long time
-  limit <- getOption("renv.snapshot.filter.timelimit", default = 10L)
-  diff <- difftime(end, start, units = "secs")
-
-  if (diff > limit) {
-
-    lines <- c(
-      "NOTE: Dependency discovery took %s %s during snapshot.",
-      "Consider using .renvignore to ignore files -- see `?dependencies` for more information."
-    )
-
-    time <- difftime(end, start, units = "auto")
-    elapsed <- format(unclass(signif(time, digits = 2L)))
-    units <- switch(
-      attr(time, "units"),
-      secs  = "seconds",
-      mins  = "minutes",
-      hours = "hours",
-      days  = "days",
-      weeks = "weeks"
-    )
-
-    vwritef(lines, elapsed, units)
-
-  }
 
   result
 
 }
 
-renv_snapshot_filter_all <- function(project, records) {
-  renv_snapshot_filter_impl(project, records, names(records), "all")
+renv_snapshot_filter_all <- function(project, records, exclude) {
+  renv_snapshot_filter_impl(project, records, names(records), "all", exclude)
 }
 
-renv_snapshot_filter_impl <- function(project, records, packages, type) {
+renv_snapshot_filter_impl <- function(project, records, packages, type, exclude) {
 
   # make sure we include renv
   packages <- unique(c(packages, "renv"))
 
   # warn if some required packages are missing
   ignored <- c(renv_project_ignored_packages(project), renv_packages_base())
-  missing <- setdiff(packages, c(names(records), ignored))
+  missing <- setdiff(packages, c(names(records), ignored, exclude))
   if (!`_renv_status_running`)
     renv_snapshot_filter_report_missing(missing, type)
 
@@ -28574,48 +28366,84 @@ renv_snapshot_filter_report_missing <- function(missing, type) {
   if (empty(missing))
     return(TRUE)
 
-  if (renv_tests_running())
-    renv_condition_signal("renv.snapshot.missing_packages", missing)
-
   preamble <- "The following required packages are not installed:"
 
   postamble <- c(
     "Packages must first be installed before renv can snapshot them.",
-    "Consider installing these packages using `renv::install()`.",
     if (type %in% "explicit")
       "If these packages are no longer required, consider removing them from your DESCRIPTION file."
     else
       "Use `renv::dependencies()` to see where this package is used in your project."
   )
 
-  if (!renv_tests_running()) {
-    renv_pretty_print(
-      values = csort(unique(missing)),
-      preamble = preamble,
-      postamble = postamble
-    )
+  renv_pretty_print(
+    values = sort(unique(missing)),
+    preamble = preamble,
+    postamble = postamble
+  )
+
+  # only prompt the user to install if a restart is available
+  restart <- findRestart("renv_recompute_records")
+
+  choices <- c(
+    snapshot = "Snapshot, just using the currently installed packages.",
+    install = if (isRestart(restart))
+      "Install the packages, then snapshot.",
+    cancel = "Cancel, and resolve the situation on your own."
+  )
+
+  choice <- menu(choices, title = "What do you want to do?")
+
+  if (choice == "snapshot") {
+    # do nothing
+  } else if (choice == "install") {
+    install(missing, prompt = FALSE)
+    invokeRestart(restart)
+  } else {
+    cancel()
   }
 
-  cancel_if(interactive() && !proceed())
   TRUE
-
 }
 
-renv_snapshot_filter_implicit <- function(project, records) {
+renv_snapshot_filter_implicit <- function(project, records, exclude) {
+
+  # compute snapshot dependencies
+  start <- Sys.time()
   packages <- renv_snapshot_dependencies(project, "implicit")
-  renv_snapshot_filter_impl(project, records, packages, "implicit")
+  end <- Sys.time()
+
+  # report if dependency discovery took a long time
+  limit <- getOption("renv.snapshot.filter.timelimit", default = 10L)
+  diff <- difftime(end, start, units = "secs")
+
+  if (diff > limit) {
+
+    time <- difftime(end, start, units = "auto")
+    lines <- c(
+      "NOTE: Dependency discovery took %s during snapshot.",
+      "Consider using .renvignore to ignore files or switching to explicit snapshots",
+      "See `?dependencies` for more information."
+    )
+    writef(lines, renv_difftime_format(time))
+
+  }
+
+  renv_snapshot_filter_impl(project, records, packages, "implicit", exclude)
+
 }
 
-renv_snapshot_filter_explicit <- function(project, records) {
+renv_snapshot_filter_explicit <- function(project, records, exclude) {
   packages <- renv_snapshot_dependencies(project, "explicit")
-  renv_snapshot_filter_impl(project, records, packages, "explicit")
+  renv_snapshot_filter_impl(project, records, packages, "explicit", exclude)
 }
 
-renv_snapshot_filter_packages <- function(project, records, packages) {
+renv_snapshot_filter_packages <- function(project, records, packages, exclude) {
 
+  # TODO: do we want to respect other ignores here?
   # include transitive dependencies
   paths <- renv_package_dependencies(packages, project = project)
-  all <- as.character(names(paths))
+  all <- setdiff(as.character(names(paths)), exclude)
   kept <- keep(records, all)
 
   # add in bioconductor infrastructure packages
@@ -28655,7 +28483,7 @@ renv_snapshot_filter_custom_resolve <- function() {
 
 }
 
-renv_snapshot_filter_custom <- function(project, records) {
+renv_snapshot_filter_custom <- function(project, records, exclude) {
 
   # get user-defined snapshot filter
   filter <- renv_snapshot_filter_custom_resolve()
@@ -28668,6 +28496,9 @@ renv_snapshot_filter_custom <- function(project, records) {
   # sanity check the result
   if (!is.character(packages))
     stop("custom snapshot filter did not return a character vector")
+
+  # remove excluded packages
+  packages <- setdiff(packages, exclude)
 
   # return matching records
   keep(records, packages)
@@ -28698,8 +28529,7 @@ renv_snapshot_fixup_renv <- function(records) {
 
   # no valid record available; construct a synthetic one
   version <- renv_metadata_version()
-  components <- unclass(numeric_version(version))[[1]]
-  remote <- if (length(components) == 4L)
+  remote <- if (renv_metadata_is_dev())
     paste("rstudio/renv", version, sep = "@")
   else
     paste("renv", version, sep = "@")
@@ -28746,7 +28576,7 @@ renv_snapshot_successful <- function(records, prompt, project) {
 }
 
 
-# stack.R ====================================================================
+# stack.R --------------------------------------------------------------------
 
 
 stack <- function(mode = "list") {
@@ -28805,7 +28635,7 @@ stack <- function(mode = "list") {
 }
 
 
-# status.R ===================================================================
+# status.R -------------------------------------------------------------------
 
 
 `_renv_status_running` <- FALSE
@@ -28867,7 +28697,7 @@ renv_status_impl <- function(project, libpaths, lockpath, sources, cache) {
 
   # check to see if we've initialized this project
   if (!renv_project_initialized(project)) {
-    vwritef("* This project has not yet been initialized.")
+    writef("* This project has not yet been initialized.")
     return(default)
   }
 
@@ -28883,61 +28713,45 @@ renv_status_impl <- function(project, libpaths, lockpath, sources, cache) {
   if (!ok)
     return(default)
 
-  # get lockfile state
-  lockfile <- renv_lockfile_read(lockpath)
-
-  # get library state
-  library <- local({
-    renv_scope_options(renv.verbose = FALSE)
-    snapshot(project  = project,
-             library  = libpaths,
-             lockfile = NULL,
-             type     = "all",
-             force    = TRUE)
-  })
-
-  # get dependencies
-  dependencies <- renv_snapshot_dependencies(
-    project = project,
-    type    = settings$snapshot.type(project = project)
-  )
-
-  # include transitive dependencies
-  packages <- sort(unique(c(dependencies, "renv")))
+  # get all dependencies, including transitive
+  dependencies <- renv_snapshot_dependencies(project)
+  packages <- sort(union(dependencies, "renv"))
   paths <- renv_package_dependencies(packages, project = project)
   packages <- as.character(names(paths))
 
+  # get lockfile records
+  lockfile <- renv_lockfile_records(renv_lockfile_read(lockpath))
+
+  # get library records
+  library <- renv_snapshot_libpaths(libpaths = libpaths, project = project)
+
   # remove ignored packages
-  ignored <- c(renv_project_ignored_packages(project), renv_packages_base())
-  library$Packages <- exclude(library$Packages, ignored)
-  packages <- setdiff(packages, ignored)
-
-  # ignore renv when testing
-  if (renv_tests_running()) {
-    packages <- setdiff(packages, "renv")
-    lockfile$Packages[["renv"]] <- NULL
-    library$Packages[["renv"]] <- NULL
-  }
-
-  synchronized <- all(
-
-    renv_status_check_synchronized(
-      project      = project,
-      lockfile     = lockfile,
-      library      = library,
-      packages     = packages
-    ),
-
-    if (sources)
-      renv_status_check_unknown_sources(project, lockfile)
-
+  ignored <- c(
+    renv_project_ignored_packages(project),
+    renv_packages_base(),
+    if (renv_tests_running()) "renv"
   )
+  packages <- setdiff(packages, ignored)
+  lockfile <- exclude(lockfile, ignored)
+  library <- exclude(library, ignored)
+
+  synchronized <- renv_status_check_synchronized(
+    project      = project,
+    lockfile     = lockfile,
+    library      = library,
+    packages     = packages
+  )
+
+  if (sources) {
+    synchronized <- synchronized &&
+      renv_status_check_unknown_sources(project, lockfile)
+  }
 
   if (cache)
     renv_status_check_cache(project)
 
   if (synchronized)
-    vwritef("* The project is already synchronized with the lockfile.")
+    writef("* The project is already synchronized with the lockfile.")
 
   list(
     library      = library,
@@ -28952,12 +28766,11 @@ renv_status_check_missing_lockfile <- function(project, lockpath) {
   if (file.exists(lockpath))
     return(TRUE)
 
-  text <- if (identical(lockpath, renv_lockfile_path(project)))
-    "* This project has not yet been snapshotted -- 'renv.lock' does not exist."
+  if (identical(lockpath, renv_lockfile_path(project)))
+    writef("* This project has not yet been snapshotted -- 'renv.lock' does not exist.")
   else
-    sprintf("* Lockfile %s does not exist.", renv_path_pretty(lockpath))
+    writef("* Lockfile %s does not exist.", renv_path_pretty(lockpath))
 
-  vwritef(text)
   FALSE
 
 }
@@ -28968,19 +28781,17 @@ renv_status_check_missing_library <- function(project, libpaths) {
   if (file.exists(projlib))
     return(TRUE)
 
-  text <- if (identical(projlib, renv_paths_library(project = project)))
-    "* This project's private library is empty or does not exist."
+  if (identical(projlib, renv_paths_library(project = project)))
+    writef("* This project's private library is empty or does not exist.")
   else
-    sprintf("* Library %s is empty or does not exist.", renv_path_pretty(projlib))
+    writef("* Library %s is empty or does not exist.", renv_path_pretty(projlib))
 
-  vwritef(text)
   FALSE
 
 }
 
 renv_status_check_unknown_sources <- function(project, lockfile) {
-  records <- renv_lockfile_records(lockfile)
-  renv_check_unknown_source(records, project)
+  renv_check_unknown_source(lockfile, project)
 }
 
 renv_status_check_synchronized <- function(project,
@@ -28988,31 +28799,17 @@ renv_status_check_synchronized <- function(project,
                                            library,
                                            packages)
 {
-  # flag set to FALSE if any of the below checks report out-of-sync
-  ok <- TRUE
-
-  # extract record components
-  lockfile <- renv_lockfile_records(lockfile)
-  library  <- renv_lockfile_records(library)
-
-  # projects will implicitly depend on BiocManager if any Bioconductor
-  # packages are in use
-  sources <- extract_chr(library, "Source")
+  # projects will implicitly depend on BiocManager & BiocVersion if any
+  # Bioconductor packages are in use
+  sources <- extract_chr(keep(library, packages), "Source")
   if ("Bioconductor" %in% sources)
-    packages <- unique(c(packages, "BiocManager"))
+    packages <- union(packages, "BiocManager")
 
-  # NOTE: If we have some packages which are required by the project,
-  # but are presently not installed, then the 'packages' vector
-  # (which tries to enumerate all transitive dependencies) may be
-  # incomplete. In this scenario, we need to avoid certain reports which
-  # might be misleading to the user.
-  missing <- setdiff(packages, c(names(library)))
+  # missing dependencies -------------------------------------------------------
+  # Must return early because `packages` will be incomplete making later
+  # reports confusing
+  missing <- setdiff(packages, names(library))
   if (length(missing)) {
-
-    if (renv_tests_running()) {
-      condition <- "renv.status.used_but_not_installed"
-      renv_condition_signal(condition, missing)
-    }
 
     lockmsg <- "The following packages are recorded in the lockfile, but not installed:"
     usedmsg <- "The following packages are used in this project, but not installed:"
@@ -29042,7 +28839,7 @@ renv_status_check_synchronized <- function(project,
     }
 
     renv_pretty_print(
-      missing,
+      sort(missing),
       preamble  = usedmsg,
       postamble = postamble
     )
@@ -29051,22 +28848,15 @@ renv_status_check_synchronized <- function(project,
 
   }
 
+  # flag set to FALSE if any of the below checks report out-of-sync
+  ok <- TRUE
 
-  # - Recorded in the lockfile.
-  # - Not installed in the library.
-  # - Used in the project.
-  #
-  # Use `renv::restore()` to install these packages.
+  # not installed/recorded/used ------------------------------------------------
   records <- lockfile %>%
     exclude(names(library)) %>%
     keep(packages)
 
   if (length(records)) {
-
-    if (renv_tests_running()) {
-      condition <- "renv.status.recorded_but_not_installed"
-      renv_condition_signal(condition, records)
-    }
 
     renv_pretty_print_records(
       records,
@@ -29078,23 +28868,12 @@ renv_status_check_synchronized <- function(project,
 
   }
 
-  # Case 3.
-  #
-  # - Installed in the library.
-  # - Not recorded in the lockfile.
-  # - Used in the project.
-  #
-  # Use `renv::snapshot()` to add these packages to the lockfile.
+  # installed/not recorded/used ------------------------------------------------
   records <- library %>%
     exclude(names(lockfile)) %>%
     keep(packages)
 
   if (length(records)) {
-
-    if (renv_tests_running()) {
-      condition <- "renv.status.installed_but_not_recorded"
-      renv_condition_signal(condition, records)
-    }
 
     renv_pretty_print_records(
       records,
@@ -29106,20 +28885,9 @@ renv_status_check_synchronized <- function(project,
 
   }
 
-  # Case 5 and 6.
-  #
-  # - Recorded in the lockfile
-  # - Installed (or not?) in the library.
-  # - Not used in the project
-  #
-  # Use renv::snapshot() to remove from the lockfile.
+  # */recorded/not used --------------------------------------------------------
   records <- lockfile %>% exclude(packages)
   if (length(records)) {
-
-    if (renv_tests_running()) {
-      condition <- "renv.status.recorded_but_not_used"
-      renv_condition_signal(condition, records)
-    }
 
     renv_pretty_print_records(
       records,
@@ -29133,15 +28901,10 @@ renv_status_check_synchronized <- function(project,
 
   }
 
-  # Case 7 and 8.
-  #
-  # - Not recorded in the lockfile.
-  # - Installed (or not?) in the library.
-  # - Not used in the project.
-  #
+  # */not recorded/not used ----------------------------------------------------
   # No action; it's okay if some auxiliary packages are installed.
 
-  # Report about other changes.
+  # other changes, i.e. different version/source -------------------------------
   actions <- renv_lockfile_diff_packages(lockfile, library)
   rest <- c("upgrade", "downgrade", "crossgrade")
   if (any(rest %in% actions)) {
@@ -29151,22 +28914,15 @@ renv_status_check_synchronized <- function(project,
     rlock <- renv_lockfile_records(lockfile)[names(matches)]
     rlibs <- renv_lockfile_records(library)[names(matches)]
 
-    data <- data.frame(
-      "  Package"          = names(matches),
-      "  Lockfile Version" = extract_chr(rlock, "Version"),
-      "  Library Version"  = extract_chr(rlibs, "Version"),
-      row.names            = NULL,
-      stringsAsFactors     = FALSE,
-      check.names          = FALSE
+    renv_pretty_print_records_pair(
+      rlock,
+      rlibs,
+      preamble = "The following package(s) are out of sync [lockfile -> library]:",
+      postamble = c(
+        "Use `renv::snapshot()` to save the state of your library to the lockfile.",
+        "Use `renv::restore()` to restore your library from the lockfile."
+      )
     )
-
-    writeLines("The following package(s) are out of sync:")
-    writeLines("")
-    print(data, row.names = FALSE)
-    writeLines("")
-    writeLines("Use `renv::snapshot()` to save the state of your library to the lockfile.")
-    writeLines("Use `renv::restore()` to restore your library from the lockfile.")
-    writeLines("")
 
     ok <- FALSE
 
@@ -29182,12 +28938,9 @@ renv_status_check_cache <- function(project) {
 
 }
 
-renv_status_signal_unsynchronized <- function() {
-  renv_condition_signal("status.unsynchronized", list())
-}
 
 
-# system.R ===================================================================
+# system.R -------------------------------------------------------------------
 
 
 renv_system_exec <- function(command,
@@ -29256,7 +29009,7 @@ renv_system_exec <- function(command,
       output
 
     # write to stderr
-    writeLines(c(header, "", body), con = stderr())
+    writef(c(header, "", body))
 
   }
 
@@ -29267,7 +29020,7 @@ renv_system_exec <- function(command,
 
 
 
-# tar.R ======================================================================
+# tar.R ----------------------------------------------------------------------
 
 
 renv_tar_exe <- function() {
@@ -29316,13 +29069,13 @@ renv_tar_decompress <- function(tar, archive, files = NULL, exdir = ".", ...) {
 }
 
 
-# task.R =====================================================================
+# task.R ---------------------------------------------------------------------
 
 
 renv_task_create <- function(callback, name = NULL) {
 
   # create name for task callback
-  name <- name %??% as.character(substitute(callback))
+  name <- name %||% as.character(substitute(callback))
   name <- paste("renv", name, sep = ":::")
 
   # remove an already-existing task of the same name
@@ -29346,8 +29099,7 @@ renv_task_callback <- function(callback, name) {
     status <- tryCatch(callback(), error = identity)
     if (inherits(status, "error")) {
       fmt <- "renv background task '%s' failed; it will be stopped"
-      msg <- sprintf(fmt, name)
-      warning(msg, call. = FALSE)
+      warningf(fmt, name)
       return(FALSE)
     }
 
@@ -29366,7 +29118,7 @@ renv_task_unload <- function() {
 }
 
 
-# template.R =================================================================
+# template.R -----------------------------------------------------------------
 
 
 renv_template_create <- function(template) {
@@ -29385,15 +29137,19 @@ renv_template_replace <- function(text, replacements, format = "${%s}") {
 }
 
 
-# tests.R ====================================================================
+# tests.R --------------------------------------------------------------------
+
+
+`_renv_tests_root` <- NULL
 
 renv_tests_running <- function() {
   getOption("renv.tests.running", default = FALSE)
 }
 
-renv_test_code <- function(code, data = list(), fileext = ".R") {
+renv_test_code <- function(code, data = list(), fileext = ".R", envir = parent.frame()) {
   code <- do.call(substitute, list(substitute(code), data))
-  file <- tempfile("renv-code-", fileext = fileext)
+  file <- renv_scope_tempfile("renv-code-", fileext = fileext, envir = envir)
+
   writeLines(deparse(code), con = file)
   file
 }
@@ -29403,7 +29159,8 @@ renv_test_retrieve <- function(record) {
   renv_scope_error_handler()
 
   # avoid using cache
-  renv_scope_envvars(RENV_PATHS_CACHE = tempfile())
+  cache_path <- renv_scope_tempfile()
+  renv_scope_envvars(RENV_PATHS_CACHE = cache_path)
 
   # construct records
   package <- record$Package
@@ -29446,30 +29203,26 @@ renv_tests_diagnostics <- function() {
   # print library paths
   renv_pretty_print(
     paste("-", .libPaths()),
-    "The following R libraries are set:",
-    wrap = FALSE
+    "The following R libraries are set:"
   )
 
   # print repositories
   repos <- getOption("repos")
   renv_pretty_print(
     paste(names(repos), repos, sep = ": "),
-    "The following repositories are set:",
-    wrap = FALSE
+    "The following repositories are set:"
   )
 
   # print renv root
   renv_pretty_print(
     paste("-", paths$root()),
-    "The following renv root directory is being used:",
-    wrap = FALSE
+    "The following renv root directory is being used:"
   )
 
   # print cache root
   renv_pretty_print(
     paste("-", paths$cache()),
     "The following renv cache directory is being used:",
-    wrap = FALSE
   )
 
   writeLines("The following packages are available in the test repositories:")
@@ -29488,8 +29241,7 @@ renv_tests_diagnostics <- function() {
 
   renv_pretty_print(
     paste("-", splat),
-    "The following PATH is set:",
-    wrap = FALSE
+    "The following PATH is set:"
   )
 
   envvars <- c(
@@ -29507,30 +29259,33 @@ renv_tests_diagnostics <- function() {
 
   renv_pretty_print(
     paste(keys, vals, sep = " : "),
-    "The following environment variables of interest are set:",
-    wrap = FALSE
+    "The following environment variables of interest are set:"
   )
 
 }
 
-# Cache absolute path to tests/testthat
 renv_tests_root <- function() {
-  global("tests.root", normalizePath(testthat::test_path(".")))
+  `_renv_tests_root` <<- `_renv_tests_root` %||% {
+    renv_path_normalize(testthat::test_path("."))
+  }
 }
 
 renv_tests_path <- function(path = NULL) {
-  if (is.null(path)) {
-    renv_tests_root()
-  } else {
-    file.path(renv_tests_root(), path)
-  }
+
+  # special case for NULL path
+  if (is.null(path))
+    return(renv_tests_root())
+
+  # otherwise, form path from root
+  file.path(renv_tests_root(), path)
+
 }
 
 renv_tests_supported <- function() {
 
   # supported when running locally + on CI
   for (envvar in c("NOT_CRAN", "CI"))
-    if (!is.na(Sys.getenv(envvar, unset = NA)))
+    if (renv_envvar_exists(envvar))
       return(TRUE)
 
   # disabled on older macOS releases (credentials fails to load)
@@ -29547,7 +29302,7 @@ renv_tests_supported <- function() {
 }
 
 
-# testthat-helpers.R =========================================================
+# testthat-helpers.R ---------------------------------------------------------
 
 
 expect_same_elements <- function(lhs, rhs) {
@@ -29568,69 +29323,25 @@ expect_same_elements <- function(lhs, rhs) {
 
 }
 
-expect_signal <- function(expr, class) {
 
-  conditions <- stack()
-  withCallingHandlers(expr, condition = function(c) conditions$push(c))
+# truthy.R -------------------------------------------------------------------
 
-  ok <- FALSE
-  for (c in conditions$data()) {
-    if (inherits(c, class)) {
-      ok <- TRUE
-      break
-    }
-  }
-
-  message <- sprintf("did not signal condition of class '%s'", class)
-  testthat::expect(ok, message)
-
-}
-
-skip_if_local <- function() {
-  ci <- Sys.getenv("CI", unset = NA)
-  testthat::skip_if(is.na(ci), "Running tests locally")
-}
-
-skip_on_windows <- function() {
-  testthat::skip_on_os("windows")
-}
-
-
-# truthy.R ===================================================================
-
-
-renv_truthy_impl <- function(value, values, default) {
-
-  if (is.call(value)) {
-    value <- catch(renv_dependencies_eval(value))
-    if (inherits(value, "error"))
-      return(default)
-  }
-
-  case(
-    is.null(value)      ~ default,
-    is.symbol(value)    ~ as.character(value) %in% values,
-    is.na(value)        ~ default,
-    is.logical(value)   ~ value,
-    is.character(value) ~ value %in% values,
-    is.numeric(value)   ~ value != 0,
-    ~ tryCatch(as.logical(value), error = function(e) default)
-  )
-
-}
 
 truthy <- function(value, default) {
-  values <- c("TRUE", "True", "true", "T", "1")
-  renv_truthy_impl(value, values, default)
+  if (length(value) == 0)
+    default
+  else if (is.character(value))
+    value %in% c("TRUE", "True", "true", "T", "1")
+  else if (is.symbol(value))
+    as.character(value) %in% c("TRUE", "True", "true", "T", "1")
+  else if (is.na(value))
+    default
+  else
+    as.logical(value)
 }
 
-falsy <- function(value, default) {
-  values <- c("FALSE", "False", "false", "F", "0")
-  renv_truthy_impl(value, values, default)
-}
 
-
-# type.R =====================================================================
+# type.R ---------------------------------------------------------------------
 
 
 renv_type_check <- function(value, type) {
@@ -29661,7 +29372,7 @@ renv_type_unexpected <- function(value) {
 }
 
 
-# unload.R ===================================================================
+# unload.R -------------------------------------------------------------------
 
 
 unload <- function(project = NULL, quiet = FALSE) {
@@ -29711,7 +29422,7 @@ renv_unload_libpaths <- function(project) {
 }
 
 
-# update.R ===================================================================
+# update.R -------------------------------------------------------------------
 
 
 `_renv_update_errors` <- new.env(parent = emptyenv())
@@ -29787,7 +29498,7 @@ renv_update_find_git_impl <- function(record) {
 renv_update_find_github <- function(records) {
 
   # check for GITHUB_PAT
-  if (is.na(Sys.getenv("GITHUB_PAT", unset = NA))) {
+  if (!renv_envvar_exists("GITHUB_PAT")) {
 
     msg <- paste(
       "GITHUB_PAT is unset. Updates may fail due to GitHub's API rate limit.",
@@ -29853,6 +29564,49 @@ renv_update_find_github_impl <- function(record) {
 
 }
 
+
+renv_update_find_remote <- function(records, type) {
+
+  update <- switch(type,
+    "gitlab" = renv_remotes_resolve_gitlab,
+    "bitbucket" = renv_remotes_resolve_bitbucket,
+    stopf("Unsupported type %s", type)
+  )
+
+  names(records) <- map_chr(records, `[[`, "Package")
+  results <- renv_parallel_exec(records, function(record) {
+    catch(renv_update_find_remote_impl(record, update))
+  })
+
+  failed <- map_lgl(results, inherits, "error")
+  if (any(failed))
+    renv_update_errors_set(type, results[failed])
+
+  results[!failed]
+
+}
+
+renv_update_find_remote_impl <- function(record, update) {
+
+  remote <- list(
+    host = record$RemoteHost,
+    user = record$RemoteUsername,
+    repo = record$RemoteRepo,
+    ref = record$RemoteRef
+  )
+  current <- update(remote)
+
+  # check that the version has actually updated
+  updated <-
+    current$RemoteSha != record$RemoteSha &&
+    numeric_version(current$Version) >= numeric_version(record$Version)
+
+  if (updated)
+    return(current)
+
+}
+
+
 renv_update_find <- function(records) {
 
   sources <- extract_chr(records, "Source")
@@ -29864,7 +29618,9 @@ renv_update_find <- function(records) {
       source == "Bioconductor" ~ renv_update_find_repos(records),
       source == "Repository"   ~ renv_update_find_repos(records),
       source == "GitHub"       ~ renv_update_find_github(records),
-      source == "Git"          ~ renv_update_find_git(records)
+      source == "Git"          ~ renv_update_find_git(records),
+      source == "GitLab"       ~ renv_update_find_remote(records, "gitlab"),
+      source == "Bitbucket"    ~ renv_update_find_remote(records, "bitbucket")
     )
   })
 
@@ -29885,11 +29641,13 @@ renv_update_find <- function(records) {
 
 
 
-#' Update Packages
+#' Update packages
 #'
 #' @description
 #' Update packages which are currently out-of-date. Currently supports CRAN,
-#' Bioconductor, other CRAN-like repositories, GitHub and Git.
+#' Bioconductor, other CRAN-like repositories, GitHub, GitLab, Git, and
+#' BitBucket.
+#'
 #' Updates will only be checked from the same source -- for example,
 #' if a package was installed from GitHub, but a newer version is
 #' available on CRAN, that updated version will not be seen.
@@ -29951,7 +29709,7 @@ update <- function(packages = NULL,
   }
 
   # get package records
-  renv_scope_var("_renv_snapshot_hash", FALSE, frame = renv_envir_self())
+  renv_scope_binding(renv_envir_self(), "_renv_snapshot_hash", FALSE)
   records <- renv_snapshot_libpaths(libpaths = libpaths, project = project)
   packages <- packages %||% names(records)
 
@@ -29966,8 +29724,7 @@ update <- function(packages = NULL,
       renv_pretty_print(
         missing,
         "The following package(s) are not currently installed:",
-        "The latest available versions of these packages will be installed instead.",
-        wrap = FALSE
+        "The latest available versions of these packages will be installed instead."
       )
     }
 
@@ -30012,7 +29769,7 @@ update <- function(packages = NULL,
     }
   }
 
-  vprintf("* Checking for updated packages ... ")
+  printf("* Checking for updated packages ... ")
 
   # remove records that appear to be from an R package repository,
   # but are not actually available in the current repositories
@@ -30030,12 +29787,12 @@ update <- function(packages = NULL,
   })
 
   updates <- renv_update_find(selected)
-  vwritef("Done!")
+  writef("Done!")
 
   renv_update_errors_emit()
 
   if (empty(updates)) {
-    vwritef("* All packages appear to be up-to-date.")
+    writef("* All packages appear to be up-to-date.")
     return(invisible(TRUE))
   }
 
@@ -30052,7 +29809,7 @@ update <- function(packages = NULL,
       length(diff) != 1 ~ "* %i packages have updates available."
     )
 
-    vwritef(fmt, length(diff))
+    writef(fmt, length(diff))
     renv_updates_report(diff, old, new)
     return(invisible(renv_updates_create(diff, old, new)))
 
@@ -30096,7 +29853,9 @@ renv_update_errors_emit <- function() {
 
   # then emit errors for each class
   renv_update_errors_emit_repos()
-  renv_update_errors_emit_github()
+  renv_update_errors_emit_remote("github", "GitHub")
+  renv_update_errors_emit_remote("gitlab", "GitLab")
+  renv_update_errors_emit_remote("bitbucket", "BitBucket")
 
 }
 
@@ -30114,8 +29873,7 @@ renv_update_errors_emit_impl <- function(key, preamble, postamble) {
   renv_pretty_print(
     values = messages,
     preamble = preamble,
-    postamble = postamble,
-    wrap = FALSE
+    postamble = postamble
   )
 
 }
@@ -30130,19 +29888,19 @@ renv_update_errors_emit_repos <- function() {
 
 }
 
-renv_update_errors_emit_github <- function() {
+renv_update_errors_emit_remote <- function(key, label) {
 
   renv_update_errors_emit_impl(
-    key       = "github",
-    preamble  = "One or more errors occurred while finding updates for the following GitHub packages:",
-    postamble = "Ensure that these packages were installed from an accessible GitHub remote."
+    key       = key,
+    preamble  = sprintf("One or more errors occurred while finding updates for the following %s packages:", label),
+    postamble = sprintf("Ensure that these packages were installed from an accessible %s remote.", label)
   )
 
 }
 
 
 
-# updates.R ==================================================================
+# updates.R ------------------------------------------------------------------
 
 
 renv_updates_create <- function(diff, old, new) {
@@ -30164,7 +29922,7 @@ renv_updates_report <- function(diff, old, new) {
 }
 
 
-# upgrade.R ==================================================================
+# upgrade.R ------------------------------------------------------------------
 
 
 #' Upgrade renv
@@ -30181,8 +29939,7 @@ renv_updates_report <- function(diff, old, new) {
 #'   When `NULL` (the default), the latest version of renv will be installed as
 #'   available from CRAN (or whatever active package repositories are active)
 #'   Alternatively, you can install the latest development version with
-#'   `"main"`, or a specific version from GitHub with (e.g.) `"0.17.3"` or
-#'   `"0.17.3-29"`.
+#'  `"main"`, or a specific commit with a SHA, e.g. `"5049cef8a"`.
 #'
 #' @param prompt Boolean; prompt upgrade before proceeding?
 #'
@@ -30229,7 +29986,7 @@ renv_upgrade_impl <- function(project, version, reload, prompt) {
   # check for some form of change
   if (renv_records_equal(old, new)) {
     fmt <- "* renv [%s] is already installed and active for this project."
-    vwritef(fmt, new$Version)
+    writef(fmt, new$Version)
     return(TRUE)
   }
 
@@ -30351,10 +30108,10 @@ renv_upgrade_reload <- function() {
 }
 
 
-# use-python.R ===============================================================
+# use-python.R ---------------------------------------------------------------
 
 
-#' Use Python
+#' Use python
 #'
 #' Associate a version of Python with your project.
 #'
@@ -30405,8 +30162,8 @@ renv_upgrade_reload <- function() {
 #'   a project-local environment will be created instead, using a name
 #'   generated from the associated version of Python.
 #'
-#'
-#' @section Finding Python:
+#' @details
+#' # Finding Python
 #'
 #' In interactive sessions, when `python = NULL`, renv will prompt for an
 #' appropriate version of Python. renv will search a pre-defined set of
@@ -30427,7 +30184,7 @@ renv_upgrade_reload <- function() {
 #' supplied for non-interactive usages of `use_python()`.
 #'
 #'
-#' @section Warning:
+#' # Warning
 #'
 #' We strongly recommend using Python virtual environments, for a few reasons:
 #'
@@ -30633,10 +30390,10 @@ renv_use_python_fini <- function(info,
   if (!renv_tests_running()) {
     if (is.null(info$type)) {
       fmt <- "* Activated Python %s (%s)."
-      vwritef(fmt, version, renv_path_aliased(info$python))
+      writef(fmt, version, renv_path_aliased(info$python))
     } else {
       fmt <- "* Activated Python %s [%s; %s]"
-      vwritef(fmt, version, info$type, renv_path_aliased(name))
+      writef(fmt, version, info$type, renv_path_aliased(name))
     }
   }
 
@@ -30719,13 +30476,13 @@ renv_use_python_virtualenv_impl <- function(project,
       return(exe)
   }
 
-  vprintf("* Creating virtual environment '%s' ... ", basename(name))
+  printf("* Creating virtual environment '%s' ... ", basename(name))
   vpython <- renv_python_virtualenv_create(python, path)
-  vwritef("Done!")
+  writef("Done!")
 
-  vprintf("* Updating Python packages ... ")
+  printf("* Updating Python packages ... ")
   renv_python_virtualenv_update(vpython)
-  vwritef("Done!")
+  writef("Done!")
 
   renv_python_virtualenv_validate(path, version)
 
@@ -30779,14 +30536,16 @@ renv_python_deactivate <- function(project) {
 
   lockfile$Python <- NULL
   renv_lockfile_write(lockfile, file = file)
-  vwritef("* Deactived Python -- the lockfile has been updated.")
+  writef("* Deactived Python -- the lockfile has been updated.")
   TRUE
 
 }
 
 
-# use.R ======================================================================
+# use.R ----------------------------------------------------------------------
 
+
+`_renv_use_libpath` <- NULL
 
 #' @rdname embed
 #'
@@ -30885,7 +30644,7 @@ use <- function(...,
 }
 
 renv_use_libpath <- function() {
-  global("use.library", tempfile("renv-library-"))
+  `_renv_use_libpath` <<- `_renv_use_libpath` %||% tempfile("renv-use-libpath-")
 }
 
 renv_use_sandbox <- function(sandbox) {
@@ -30907,7 +30666,7 @@ renv_use_sandbox <- function(sandbox) {
 }
 
 
-# utils-connections.R ========================================================
+# utils-connections.R --------------------------------------------------------
 
 
 textfile <- function(description, open = "wt") {
@@ -30915,7 +30674,7 @@ textfile <- function(description, open = "wt") {
 }
 
 
-# utils-format.R =============================================================
+# utils-format.R -------------------------------------------------------------
 
 
 sprintf <- function(fmt, ...) {
@@ -30935,68 +30694,22 @@ warningf <- function(fmt = "", ..., call. = FALSE, immediate. = FALSE) {
   warning(sprintf(fmt, ...), call. = call., immediate. = immediate.)
 }
 
-messagef <- function(fmt = "", ..., appendLF = TRUE) {
-  message(sprintf(fmt, ...), appendLF = appendLF)
-}
-
-vmessagef <- function(fmt = "", ..., appendLF = TRUE) {
-  if (renv_verbose())
-    message(sprintf(fmt, ...), appendLF = appendLF)
-}
-
-
-
 printf <- function(fmt = "", ..., file = stdout(), sep = "") {
   if (!is.null(fmt) && renv_verbose())
     cat(sprintf(fmt, ...), file = file, sep = sep)
 }
-
-eprintf <- function(fmt = "", ..., file = stderr(), sep = "") {
-  if (!is.null(fmt) && renv_verbose())
-    cat(sprintf(fmt, ...), file = file, sep = sep)
-}
-
-vprintf <- function(fmt = "", ..., file = stdout(), sep = "") {
-  if (!is.null(fmt) && renv_verbose())
-    cat(sprintf(fmt, ...), file = file, sep = sep)
-}
-
-veprintf <- function(fmt = "", ..., file = stderr(), sep = "") {
-  if (!is.null(fmt) && renv_verbose())
-    cat(sprintf(fmt, ...), file = file, sep = sep)
-}
-
-
 
 writef <- function(fmt = "", ..., con = stdout()) {
   if (!is.null(fmt) && renv_verbose())
     writeLines(sprintf(fmt, ...), con = con)
 }
 
-ewritef <- function(fmt = "", ..., con = stderr()) {
-  if (!is.null(fmt) && renv_verbose())
-    writeLines(sprintf(fmt, ...), con = con)
-}
-
-vwritef <- function(fmt = "", ..., con = stdout()) {
-  if (!is.null(fmt) && renv_verbose())
-    writeLines(sprintf(fmt, ...), con = con)
-}
-
-vewritef <- function(fmt = "", ..., con = stderr()) {
-  if (!is.null(fmt) && renv_verbose())
-    writeLines(sprintf(fmt, ...), con = con)
-}
-
-infof <- function(fmt = "", ..., con = stdout()) {
-  if (!is.null(fmt) && renv_verbose()) {
-    fmt <- paste(if (l10n_info()$`UTF-8`) "\u2139" else "i", fmt)
-    writeLines(sprintf(fmt, ...), con = con)
-  }
+info_bullet <- function() {
+  if (l10n_info()$`UTF-8`) "\u2139" else "i"
 }
 
 
-# utils-map.R ================================================================
+# utils-map.R ----------------------------------------------------------------
 
 
 bapply <- function(x, f, ..., index = "Index") {
@@ -31099,7 +30812,7 @@ extract_lgl <- function(x, ...) {
 }
 
 
-# utils.R ====================================================================
+# utils.R --------------------------------------------------------------------
 
 
 `%>%` <- function(...) {
@@ -31123,10 +30836,6 @@ extract_lgl <- function(x, ...) {
 
 }
 
-`%""%` <- function(x, y) {
-  if (length(x) && nzchar(x)) x else y
-}
-
 `%NA%` <- function(x, y) {
   if (length(x) && is.na(x)) y else x
 }
@@ -31134,7 +30843,6 @@ extract_lgl <- function(x, ...) {
 `%&&%` <- function(x, y) {
   if (length(x)) y
 }
-
 
 lines <- function(...) {
   paste(..., sep = "\n")
@@ -31267,6 +30975,45 @@ proceed <- function(default = TRUE) {
   ask("Do you want to proceed?", default = default)
 }
 
+menu <- function(choices, title, default = 1L) {
+  testing <- getOption("renv.menu.choice", integer())
+  if (length(testing)) {
+    selected <- testing[[1]]
+    options(renv.menu.choice = testing[-1])
+  } else if (is_testing()) {
+    selected <- default
+  } else {
+    selected <- NULL
+  }
+
+  if (!is.null(selected)) {
+    writef(c(
+      title,
+      "",
+      paste0(seq_along(choices), ": ", choices),
+      "",
+      paste0("Selection: ", selected),
+      ""
+    ))
+    return(names(choices)[selected])
+  }
+
+  if (!interactive()) {
+    writef(c("Not interactive. Will:", choices[[default]]))
+    return(default)
+  }
+
+  idx <- tryCatch(
+    utils::menu(choices, paste(title, collapse = "\n"), graphics = FALSE),
+    interrupt = function(cnd) 0L
+  )
+  if (idx == 0L) {
+    "cancel"
+  } else {
+    names(choices)[idx]
+  }
+}
+
 # nocov end
 
 inject <- function(contents,
@@ -31320,10 +31067,6 @@ trunc <- function(text, n = 78) {
   text
 }
 
-startswith <- function(string, prefix) {
-  substring(string, 1, nchar(prefix)) == prefix
-}
-
 endswith <- function(string, suffix) {
   substring(string, nchar(string) - nchar(suffix) + 1) == suffix
 }
@@ -31346,7 +31089,7 @@ git <- function() {
 }
 
 visited <- function(name, envir) {
-  value <- envir[[name]] %??% FALSE
+  value <- envir[[name]] %||% FALSE
   envir[[name]] <- TRUE
   value
 }
@@ -31381,6 +31124,8 @@ quietly <- function(expr, sink = TRUE) {
 
 }
 
+# NOTE: This function can be used in preference to `as.*()` if you'd like
+# to preserve attributes on the incoming object 'x'.
 convert <- function(x, type) {
   storage.mode(x) <- type
   x
@@ -31399,15 +31144,15 @@ remap <- function(x, map) {
 
 header <- function(label,
                    prefix = "#",
-                   suffix = "=",
-                   n = 38L)
+                   suffix = "-",
+                   n = min(getOption("width"), 78))
 {
   n <- n - nchar(label) - nchar(prefix) - 2L
   if (n <= 0)
     return(paste(prefix, label))
 
   tail <- paste(rep.int(suffix, n), collapse = "")
-  paste(prefix, label, tail)
+  paste0(prefix, " ", label, " ", tail)
 
 }
 
@@ -31609,8 +31354,12 @@ take <- function(data, index = NULL) {
 
 cancel <- function() {
   renv_snapshot_auto_suppress_next()
-  message("* Operation canceled.")
-  invokeRestart("abort")
+  if (is_testing()) {
+    stop("Operation canceled", call. = FALSE)
+  } else {
+    message("* Operation canceled.")
+    invokeRestart("abort")
+  }
 }
 
 cancel_if <- function(cnd) {
@@ -31644,11 +31393,13 @@ untar <- function(tarfile,
 }
 
 rep_named <- function(names, x) {
-  stats::setNames(rep_len(x, length(names)), names)
+  values <- rep_len(x, length(names))
+  names(values) <- names
+  values
 }
 
 
-# vector.R ===================================================================
+# vector.R -------------------------------------------------------------------
 
 
 renv_vector_diff <- function(x, y) {
@@ -31673,14 +31424,13 @@ renv_vector_merge <- function(x, y) {
 }
 
 
-# vendor.R ===================================================================
+# vendor.R -------------------------------------------------------------------
 
 
-#' Vendor renv in an R Package
+#' Vendor renv in an R package
 #'
-#' Vendor a copy of renv in an \R package.
-#'
-#' Calling `renv::vendor()` will:
+#' @description
+#' Calling `renv:::vendor()` will:
 #'
 #' - Compile a vendored copy of renv to `inst/vendor/renv.R`,
 #' - Generate an renv auto-loader at `R/renv.R`.
@@ -31698,13 +31448,10 @@ renv_vector_merge <- function(x, y) {
 #' need to rely on renv internal functions, we strongly recommend testing
 #' your usages of these functions to avoid potential breakage.
 #'
-#' @param version The version of renv to vendor. If `NULL` (the default),
-#'   the current version of renv will be used. Ignored if `sources`
-#'   is non-`NULL`.
-#'
-#' @param repository The Git repository from which renv should be retrieved.
-#'   renv will use `git clone <repository> --branch <version>` to download
-#'   the required renv sources. Ignored if `sources` is non-`NULL`.
+#' @param version The version of renv to vendor. A Git tag targets a CRAN
+#'   version and "main" references the latest development version of renv. Use
+#'   a Git branch name or commit SHA to target other versions. Ignored when
+#'   `sources` is non-`NULL`.
 #'
 #' @param sources The path to local renv sources to be vendored.
 #'
@@ -31713,7 +31460,6 @@ renv_vector_merge <- function(x, y) {
 #' @keywords internal
 #'
 vendor <- function(version    = NULL,
-                   repository = "https://github.com/rstudio/renv",
                    sources    = NULL,
                    project    = getwd())
 {
@@ -31727,7 +31473,12 @@ vendor <- function(version    = NULL,
   }
 
   # get renv sources
-  sources <- sources %||% renv_vendor_sources(version, repository)
+  if (is.null(sources)) {
+    if (is.null(version)) {
+      stop("Specify an renv version or a path to renv sources")
+    }
+    sources <- renv_vendor_sources(version)
+  }
 
   # re-compute renv version from sources
   version <- renv_description_read(path = sources, field = "Version")
@@ -31754,8 +31505,7 @@ vendor <- function(version    = NULL,
     #
   ")
 
-  blurb <- sprintf(template, renv_path_pretty(embed), renv_path_pretty(loader))
-  writeLines(blurb)
+  writef(template, renv_path_pretty(embed), renv_path_pretty(loader))
 
   invisible(TRUE)
 
@@ -31830,26 +31580,18 @@ renv_vendor_imports <- function() {
 
 }
 
-renv_vendor_sources <- function(version, repository) {
+renv_vendor_sources <- function(version) {
 
-  # move to temporary directory
-  owd <- setwd(tempdir())
-  defer(setwd(owd))
+  tarball <- renv_bootstrap_download_github(version)
+  if (!is.character(tarball) || !file.exists(tarball)) {
+    stop("Download failed")
+  }
+  defer(unlink(tarball))
 
-  # resolve version
-  version <- version %||% renv_package_version("renv")
+  untarred <- tempfile("renv-vendor-")
+  untar(tarball, exdir = untarred)
 
-  printf("# Cloning renv %s from %s ... ", version, repository)
-  args <- c("clone", "--branch", version, "--depth", "1", repository)
-  renv_system_exec(git(), args, action = "cloning renv")
-  writef("Done!")
-  path <- normalizePath("renv", winslash = "/", mustWork = TRUE)
-
-  # make sure we clean up when we're done
-  defer(unlink(path, recursive = TRUE), envir = parent.frame())
-
-  path
-
+  dir(untarred, full.names = TRUE)[[1]]
 }
 
 renv_vendor_header <- function(version) {
@@ -31866,7 +31608,7 @@ renv_vendor_header <- function(version) {
 }
 
 
-# verbose.R ==================================================================
+# verbose.R ------------------------------------------------------------------
 
 
 renv_verbose <- function() {
@@ -31892,7 +31634,7 @@ is_testing <- function() {
 }
 
 
-# version.R ==================================================================
+# version.R ------------------------------------------------------------------
 
 
 renv_version_compare <- function(lhs, rhs, n = NULL) {
@@ -31964,23 +31706,33 @@ renv_version_match <- function(versions, request) {
 
 }
 
-renv_version_components <- function(version, n) {
+renv_version_parts <- function(version, n) {
 
   # split version into parts
-  parts <- unclass(numeric_version(version))[[1L]]
+  parts <- unclass(as.numeric_version(version))[[1L]]
 
   # extend parts to size of n
   diff <- max(n) - length(parts)
   if (diff > 0)
     parts <- c(parts, rep.int(0L, diff))
 
-  # retrieve components
-  parts[n]
+  # retrieve possibly-extended parts
+  parts[1:n]
 
 }
 
+renv_version_maj_min <- function(version) {
+  parts <- renv_version_parts(version, 2L)
+  paste(parts, collapse = ".")
+}
 
-# virtualization.R ===========================================================
+renv_version_length <- function(version) {
+  nv <- as.numeric_version(version)
+  length(unclass(nv)[[1L]])
+}
+
+
+# virtualization.R -----------------------------------------------------------
 
 
 `_renv_virtualization_type` <- NULL
@@ -32019,7 +31771,7 @@ renv_virtualization_type_impl <- function() {
 }
 
 
-# warnings.R =================================================================
+# warnings.R -----------------------------------------------------------------
 
 
 renv_warnings_unknown_sources <- function(records) {
@@ -32052,7 +31804,7 @@ renv_warnings_unknown_sources <- function(records) {
 }
 
 
-# xcode.R ====================================================================
+# xcode.R --------------------------------------------------------------------
 
 
 renv_xcode_available <- function() {
@@ -32113,7 +31865,7 @@ Set options(renv.xcode.check = FALSE) to disable this warning.
 }
 
 
-# yaml.R =====================================================================
+# yaml.R ---------------------------------------------------------------------
 
 
 renv_yaml_load <- function(text) {
@@ -32132,7 +31884,7 @@ renv_yaml_load <- function(text) {
 }
 
 
-# zzz.R ======================================================================
+# zzz.R ----------------------------------------------------------------------
 
 
 `__self__` <- NULL
@@ -32232,7 +31984,7 @@ renv_zzz_run <- function() {
   # check if we're running as part of R CMD build
   # if so, build our local repository with a copy of ourselves
   building <-
-    !is.na(Sys.getenv("R_CMD", unset = NA)) &&
+    renv_envvar_exists("R_CMD") &&
     grepl("Rbuild", basename(dirname(getwd())))
 
   if (building) {
@@ -32287,8 +32039,7 @@ renv_zzz_repos <- function() {
   # move to build directory
   tdir <- tempfile("renv-build-")
   ensure_directory(tdir)
-  owd <- setwd(tdir)
-  defer(setwd(owd))
+  renv_scope_wd(tdir)
 
   # build renv again
   r_cmd_build("renv", path = pkgdir)


### PR DESCRIPTION
Loads binary packages at install time, which traps some environment compatibility problems. The package is removed from the packrat library and never reaches the packrat cache.

Fixes #712

The following Dockerfile examples show failures occurring at restore-time; the "runtime" script.R is never executed.

This first example shows how an install-time package load can identify missing system dependencies.

<details>
<summary>Dockerfile.packrat identifying missing (jags) system dependencies

```dockerfile
FROM rstudio/r-base:4.3-jammy AS base

RUN apt-get update && apt-get -y install pkg-config

ARG REPOSITORY=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
RUN echo "options(repos = c(CRAN = '${REPOSITORY}'))" >> /opt/R/4.3.0/lib/R/etc/Rprofile.site

RUN R -s -e "install.packages('remotes')"

FROM base as setup

ARG PACKRAT_REF="aron-renv-binary-package-validation"
RUN R -s -e "remotes::install_github('rstudio/packrat', '${PACKRAT_REF}')"

FROM setup AS installation

RUN mkdir /content \
    && echo "library(rjags)" > /content/script.R \
    && echo "options(download.file.method = 'curl', download.file.extra = paste('-s -L -f -A ', shQuote(getOption('HTTPUserAgent'))))" > /content/.Rprofile

WORKDIR /content

ENV RENV_INSTALL_TEST_LOAD=True

RUN R -s -e "packrat::init(enter = FALSE, infer.dependencies = FALSE)"
# install by R of rjags into the packrat library..
RUN R -s -e "install.packages('rjags')"
RUN R -s -e "packrat::snapshot()"
RUN rm -rf packrat/lib* packrat/src
# installation by packrat of rjags into the packrat library.
RUN R -s -e "packrat::restore()"
RUN R -s -f "script.R"
```
</details>

```bash
docker build --progress=plain --no-cache-filter=setup -f Dockerfile.packrat .
```

```
 > [installation 7/8] RUN R -s -e "packrat::restore()":
#15 8.501 Loading required package: coda
#15 8.501 Error: package or namespace load failed for ‘rjags’:
#15 8.501  .onLoad failed in loadNamespace() for 'rjags', details:
#15 8.501   call: dyn.load(file, DLLpath = DLLpath, ...)
#15 8.501   error: unable to load shared object '/content/packrat/lib/x86_64-pc-linux-gnu/4.3.0/rjags/libs/rjags.so':
#15 8.501   libjags.so.4: cannot open shared object file: No such file or directory
#15 8.501 Execution halted
#15 8.530 FAILED
#15 8.532 Error: error testing if 'rjags' can be loaded [error code 1]
#15 8.533 Execution halted
```

This second example shows how an install-time package load can identify incompatible base system libraries.

<details>
<summary>Dockerfile.packrat-crosswired showing incompatible base libraries

```dockerfile
FROM rstudio/r-base:4.3-bionic AS base

RUN apt-get update && apt-get -y install pkg-config

ARG REPOSITORY=https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
RUN echo "options(repos = c(CRAN = '${REPOSITORY}'))" >> /opt/R/4.3.0/lib/R/etc/Rprofile.site

RUN R -s -e "install.packages('remotes')"

FROM base as setup

ARG PACKRAT_REF="aron-renv-binary-package-validation"
RUN R -s -e "remotes::install_github('rstudio/packrat', '${PACKRAT_REF}')"

FROM setup AS installation

RUN mkdir /content \
    && echo "library(fastmap)" > /content/script.R \
    && echo "options(download.file.method = 'curl', download.file.extra = paste('-s -L -f -A ', shQuote(getOption('HTTPUserAgent'))))" > /content/.Rprofile

WORKDIR /content

ENV RENV_INSTALL_TEST_LOAD=True

RUN R -s -e "packrat::init(enter = FALSE, infer.dependencies = FALSE)"
# install by R of fastmap into the packrat library..
RUN R -s -e "install.packages('fastmap')"
RUN R -s -e "packrat::snapshot()"
RUN rm -rf packrat/lib* packrat/src
# installation by packrat of fastmap into the packrat library using a BAD repository
ARG JAMMY_REPOSITORY=https://packagemanager.rstudio.com/cran/__linux__/jammy/latest
RUN R -s -e "packrat::set_lockfile_metadata(repos = c(CRAN = '${JAMMY_REPOSITORY}'))"
RUN R -s -e "packrat::restore()"
RUN R -s -f "script.R"
```
</details>

```bash
docker build --progress=plain --no-cache-filter=setup -f Dockerfile.packrat-crosswired .
```

```
 > [installation 8/9] RUN R -s -e "packrat::restore()":
#17 2.259 /opt/R/4.3.0/lib/R/bin/R --vanilla -s -f '/tmp/Rtmpq1ZfQc/renv-install-75dce439a'
#17 2.259 ================================================================================
#17 2.259
#17 2.259 Error: package or namespace load failed for ‘fastmap’ in dyn.load(file, DLLpath = DLLpath, ...):
#17 2.259  unable to load shared object '/content/packrat/lib/x86_64-pc-linux-gnu/4.3.0/fastmap/libs/fastmap.so':
#17 2.259   /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /content/packrat/lib/x86_64-pc-linux-gnu/4.3.0/fastmap/libs/fastmap.so)
#17 2.259 Execution halted
#17 2.303 FAILED
#17 2.305 Error: error testing if 'fastmap' can be loaded [error code 1]
#17 2.305 Execution halted
```
