### PR TITLE
Update `renv` to latest dev version

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: linters_with_defaults(
     # some tests have _VERY_ long expectations.
+    indentation_linter = NULL,
     line_length_linter(270),
     object_length_linter(80),
     object_name_linter = NULL,
@@ -7,7 +8,7 @@ linters: linters_with_defaults(
     brace_linter = NULL,
     commented_code_linter = NULL,
     cyclocomp_linter = NULL,
-    single_quotes_linter = NULL,
+    quotes_linter = NULL,
     seq_linter = NULL
   )
 exclusions: list(

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
   transforming Posit Package Manager URLs. (#711)
 - Perform a test-load when installing from binary packages. Includes an `renv`
   update. (#712)
+- Update vendored `renv` package to include a fix for load-testing certain
+  binary packages. (#716)
 
 # Packrat 0.9.1
 

--- a/R/renv.R
+++ b/R/renv.R
@@ -1,7 +1,7 @@
 
 #
-# renv 1.0.0 [rstudio/renv#7aa299d]: A dependency management toolkit for R.
-# Generated using `renv:::vendor()` at 2023-07-11 09:18:12.856442.
+# renv 1.0.0.9000 [rstudio/renv#42c22c0]: A dependency management toolkit for R.
+# Generated using `renv:::vendor()` at 2023-08-09 15:44:32.090958.
 #
 
 
@@ -70,7 +70,7 @@ renv$initialize <- function() {
   # initialize metadata
   renv$the$metadata <- list(
     embedded = TRUE,
-    version = structure("1.0.0", sha = "7aa299d0315eb014d38520047e22080c87596ebc")
+    version = structure("1.0.0.9000", sha = "42c22c01d3bc02968b52d2049dcef17e49b5b29a")
   )
 
   # run our load / attach hooks so internal state is initialized


### PR DESCRIPTION
This PR updates `renv` to the latest dev version, https://github.com/rstudio/renv/commit/42c22c01d3bc02968b52d2049dcef17e49b5b29a. This includes the commit that should fix #716.