### PR TITLE
Update vendored `renv` to include Linux distro detection bugfixes

### DIFF
--- a/R/renv.R
+++ b/R/renv.R
@@ -1,7 +1,7 @@
 
 #
-# renv 1.0.1 [rstudio/renv#5dc2fc9]: A dependency management toolkit for R.
-# Generated using `renv:::vendor()` at 2023-08-11 10:13:20.914354.
+# renv 1.0.3.9000 [rstudio/renv#1f5bafc]: A dependency management toolkit for R.
+# Generated using `renv:::vendor()` at 2023-10-18 14:18:45.514687.
 #
 
 
@@ -70,7 +70,7 @@ renv$initialize <- function() {
   # initialize metadata
   renv$the$metadata <- list(
     embedded = TRUE,
-    version = structure("1.0.1", sha = "5dc2fc934867a1b34ec9d1c594dc57d3c9698650")
+    version = structure("1.0.3.9000", sha = "1f5bafc05a09ce6b30b83b835ffcd70547fe4fae")
   )
 
   # run our load / attach hooks so internal state is initialized


### PR DESCRIPTION
Bumped the vendored version of `renv` to the latest dev version. This version includes expansions and bugfixes in Linux distro detection for Posit Package Manager binary URL rewriting. The commit used is [here](https://github.com/rstudio/renv/commit/1f5bafc05a09ce6b30b83b835ffcd70547fe4fae).

This is the set of changes between the latest `renv` release and this dev commit: [Comparing changes](https://github.com/rstudio/renv/compare/e49d9be9528e0ff73b673f97382731c140013474...1f5bafc05a09ce6b30b83b835ffcd70547fe4fae). There are few functional changes other than these fixes.

This is the set of changes between the last vendored `renv` release and the new commit: [Comparing changes](https://github.com/rstudio/renv/compare/5dc2fc934867a1b34ec9d1c594dc57d3c9698650...1f5bafc05a09ce6b30b83b835ffcd70547fe4fae).

Relevant functional changes to do with PPM URL transformations:
- Fix detection of `rhel9`, `opensuse154`, `opensuse155`.
- Add detection of SLES15 SP4 as `opensuse154` and SP5 as `opensuse155`.
- Add detection of AlmaLinux 8 and 9 and Rocky Linux 8 and 9 as `centos8` and `rhel9` respectively.
- Add detection of Amazon Linux 2 as `centos7`.

Less relevant:
- Technically could detect `opensuse153`, which is supported by Connect, but that distro isn't supported by Package Manager.
- Adds detection of Debian versions.