### PR TITLE
installPkg: do no work when using cached package and annotate safely

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
 # packrat (development version)
 
-# packrat 0.9.2
+- Improve package installation in a multi-process environment. Do less work
+  when a target package is in the cache and write package `DESCRIPTION`
+  updates to temporary files before persisting. (#720)
 
-# Packrat 0.9.2 (UNRELEASED)
+# Packrat 0.9.2
 
 - Update vendored `renv` package to include functions for normalizing and
   transforming Posit Package Manager URLs. (#711)
@@ -11,9 +13,6 @@
 - Update vendored `renv` package to include a fix for load-testing certain
   binary packages. (#716)
 - Update package documentation according to r-lib/roxygen2#1491. (#721)
-- Improve package installation in a multi-process environment. Do less work
-  when a target package is in the cache and write package `DESCRIPTION`
-  updates to temporary files before persisting. (#720)
 
 # Packrat 0.9.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
 - Update vendored `renv` package to include a fix for load-testing certain
   binary packages. (#716)
 - Update package documentation according to r-lib/roxygen2#1491. (#721)
+- Improve package installation in a multi-process environment. Do less work
+  when a target package is in the cache and write package `DESCRIPTION`
+  updates to temporary files before persisting. (#720)
 
 # Packrat 0.9.1
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -395,14 +395,6 @@ annotatePkgDesc <- function(pkgRecord, project, lib = libDir(project)) {
   write_dcf(content, descFile)
 }
 
-# Annotate a set of packages by name.
-annotatePkgs <- function(pkgNames, project, lib = libDir(project)) {
-  records <- searchPackages(lockInfo(project), pkgNames)
-  lapply(records, function(record) {
-    annotatePkgDesc(record, project, lib)
-  })
-}
-
 # Takes a vector of package names, and returns a logical vector that indicates
 # whether the package was not installed by packrat.
 installedByPackrat <- function(pkgNames, lib.loc, default = NA) {

--- a/R/restore.R
+++ b/R/restore.R
@@ -574,7 +574,6 @@ installPkg <- function(pkgRecord,
     annotatePkgDesc(pkgRecord, project, lib),
     error = function(e) {
       unlink(pkgInstallPath, recursive = TRUE)
-      return(e)
     }
   )
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -394,7 +394,9 @@ annotatePkgDesc <- function(pkgRecord, project, lib = libDir(project)) {
   # Write it out using a temporary file so DESCRIPTION is never partial.
   tmpf <- tempfile(tmpdir = dirname(descFile))
   write_dcf(content, tmpf)
-  file.rename(tmpf, descFile)
+  if (!file.rename(tmpf, descFile)) {
+    stop("Unable to rename annotated package DESCRIPTION")
+  }
 }
 
 # Takes a vector of package names, and returns a logical vector that indicates

--- a/R/restore.R
+++ b/R/restore.R
@@ -427,7 +427,6 @@ installPkg <- function(pkgRecord,
                        repos,
                        lib = libDir(project))
 {
-  pkgSrc <- NULL
   type <- "built source"
   needsInstall <- TRUE
 
@@ -525,14 +524,11 @@ installPkg <- function(pkgRecord,
     })
   }
 
-  if (is.null(pkgSrc)) {
+  if (needsInstall) {
     # When installing from github/bitbucket/gitlab or an older version, use the cached source
     # tarball or zip created in snapshotSources
     pkgSrc <- file.path(srcDir(project), pkgRecord$name,
                         pkgSrcFilename(pkgRecord))
-  }
-
-  if (needsInstall) {
 
     if (!file.exists(pkgSrc)) {
       # If the source file is missing, try to download it. (Could happen in the

--- a/R/restore.R
+++ b/R/restore.R
@@ -588,23 +588,20 @@ installPkg <- function(pkgRecord,
 
   # copy package into cache if enabled
   if (isUsingCache(project)) {
-    pkgPath <- file.path(lib, pkgRecord$name)
-
     # copy into global cache if this is a trusted package
     if (isTrustedPackage(pkgRecord$name)) {
-      descPath <- file.path(pkgPath, "DESCRIPTION")
+      descPath <- file.path(pkgInstallPath, "DESCRIPTION")
       if (!file.exists(descPath)) {
         warning("cannot cache package: no DESCRIPTION file at path '", descPath, "'")
       } else {
         hash <- hash(descPath)
         moveInstalledPackageToCache(
-          packagePath = pkgPath,
+          packagePath = pkgInstallPath,
           hash = hash,
           cacheDir = cacheLibDir()
         )
       }
     } else {
-      pkgPath <- file.path(lib, pkgRecord$name)
       tarballName <- pkgSrcFilename(pkgRecord)
       tarballPath <- file.path(srcDir(project), pkgRecord$name, tarballName)
       if (!file.exists(tarballPath)) {
@@ -612,7 +609,7 @@ installPkg <- function(pkgRecord,
       } else {
         hash <- hashTarball(tarballPath)
         moveInstalledPackageToCache(
-          packagePath = pkgPath,
+          packagePath = pkgInstallPath,
           hash = hash,
           cacheDir = untrustedCacheLibDir()
         )

--- a/R/restore.R
+++ b/R/restore.R
@@ -570,7 +570,13 @@ installPkg <- function(pkgRecord,
   }
 
   # Annotate DESCRIPTION file so we know we installed it
-  annotatePkgDesc(pkgRecord, project, lib)
+  withCallingHandlers(
+    annotatePkgDesc(pkgRecord, project, lib),
+    error = function(e) {
+      unlink(pkgInstallPath, recursive = TRUE)
+      return(e)
+    }
+  )
 
   # copy package into cache if enabled
   if (isUsingCache(project)) {

--- a/R/restore.R
+++ b/R/restore.R
@@ -391,8 +391,10 @@ annotatePkgDesc <- function(pkgRecord, project, lib = libDir(project)) {
     content[name] <- records[name]
   }
 
-  # Write it out
-  write_dcf(content, descFile)
+  # Write it out using a temporary file so DESCRIPTION is never partial.
+  tmpf <- tempfile(tmpdir = dirname(descFile))
+  write_dcf(content, tmpf)
+  file.rename(tmpf, descFile)
 }
 
 # Takes a vector of package names, and returns a logical vector that indicates

--- a/R/restore.R
+++ b/R/restore.R
@@ -465,22 +465,6 @@ installPkg <- function(pkgRecord,
     return(cacheCopyStatus$type)
   }
 
-  # The package was not in a cache and needs to be installed.
-  # Remove a prior installation / file from library (if necessary).
-  # We move the old directory out of the way temporarily, and then
-  # delete if if all went well, or restore it if installation failed
-  # for some reason.
-  if (file.exists(pkgInstallPath)) {
-    pkgRenamePath <- tempfile(tmpdir = lib)
-    file.rename(pkgInstallPath, pkgRenamePath)
-    on.exit({
-      if (file.exists(pkgInstallPath))
-        unlink(pkgRenamePath, recursive = !is.symlink(pkgRenamePath))
-      else
-        file.rename(pkgRenamePath, pkgInstallPath)
-    }, add = TRUE)
-  }
-
   type <- "built source"
   needsInstall <- TRUE
 

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -7,9 +7,21 @@
 
 library(testthat)
 
+# Confirm that the package name still exists in the DESCRIPTION along with
+# the install-time annotation.
+#
+# Other fields are not included in this check.
+expect_annotated_description <- function(lib, name) {
+  desc <- file.path(lib, name, "DESCRIPTION")
+  result <- as.data.frame(readDcf(desc), stringsAsFactors = FALSE)
+
+  expect_equal(result$Package, name)
+  expect_equal(result$InstallAgent, paste('packrat', packageVersion('packrat')))
+}
+
 withTestContext({
 
-  test_that("init creates project structure and installs dependencies", {
+  test_that("init creates project structure and installs dependencies with annotated DESCRIPTION", {
     skip_on_cran()
     projRoot <- cloneTestProject("sated")
     init(enter = FALSE, projRoot, options = list(local.repos = "packages"))
@@ -17,11 +29,17 @@ withTestContext({
     expect_true(file.exists(lockFilePath(projRoot)))
     expect_true(file.exists(srcDir(projRoot)))
     expect_true(file.exists(libDir(projRoot)))
+
+    expect_true(file.exists(file.path(lib, "packrat")))
     expect_true(file.exists(file.path(lib, "breakfast")))
     expect_true(file.exists(file.path(lib, "bread")))
     expect_true(file.exists(file.path(lib, "oatmeal")))
-    expect_true(file.exists(file.path(lib, "packrat")))
     expect_true(file.exists(file.path(lib, "toast")))
+
+    expect_annotated_description(lib, "breakfast")
+    expect_annotated_description(lib, "bread")
+    expect_annotated_description(lib, "oatmeal")
+    expect_annotated_description(lib, "toast")
   })
 
   test_that("init does not install dependencies when infer.dependencies is false", {
@@ -33,10 +51,11 @@ withTestContext({
     expect_true(file.exists(lockFilePath(projRoot)))
     expect_true(file.exists(srcDir(projRoot)))
     expect_true(file.exists(libDir(projRoot)))
+
+    expect_true(file.exists(file.path(lib, "packrat")))
     expect_false(file.exists(file.path(lib, "breakfast")))
     expect_false(file.exists(file.path(lib, "bread")))
     expect_false(file.exists(file.path(lib, "oatmeal")))
-    expect_true(file.exists(file.path(lib, "packrat")))
     expect_false(file.exists(file.path(lib, "toast")))
   })
 

--- a/tests/testthat/test-restore.R
+++ b/tests/testthat/test-restore.R
@@ -90,7 +90,7 @@ test_that("annotatePkgDesc annotates a package description", {
   )
 
   annotatePkgDesc(pkgRecord, project)
-  result <- as.data.frame(readDcf(desc))
+  result <- as.data.frame(readDcf(desc), stringsAsFactors = FALSE)
   expect_equal(result$Package, "fake")
   expect_equal(result$Version, "1.2.3")
   expect_equal(result$InstallAgent, paste('packrat', packageVersion('packrat')))

--- a/tests/testthat/test-restore.R
+++ b/tests/testthat/test-restore.R
@@ -67,3 +67,32 @@ test_that("appendRemoteInfoToDescription modifies DESCRIPTION file", {
   expect_identical(tail(desc, 6), expected_desc_tail)
   getwd()
 })
+
+test_that("annotatePkgDesc annotates a package description", {
+  project <- tempfile()
+  dir.create(project)
+  lib <- libDir(project)
+  package <- file.path(lib, "fake")
+  dir.create(package, recursive = TRUE)
+  desc <- file.path(package, "DESCRIPTION")
+  write_dcf(
+    list(
+      Package = "fake",
+      Version = "1.2.3",
+      InstallAgent = "testthat"
+    ),
+    desc
+  )
+  pkgRecord <- list(
+    name = "fake",
+    source = "CRAN",
+    version = "1.2.3"
+  )
+
+  annotatePkgDesc(pkgRecord, project)
+  result <- as.data.frame(readDcf(desc))
+  expect_equal(result$Package, "fake")
+  expect_equal(result$Version, "1.2.3")
+  expect_equal(result$InstallAgent, paste('packrat', packageVersion('packrat')))
+  expect_equal(result$InstallSource, "CRAN")
+})


### PR DESCRIPTION
First, the `installPkg()` function no longer does additional work when the package was discovered in the cache. This avoids the most common situation where multiple processes performing package installation can race to the `annotatePkgDesc()` and `moveInstalledPackageToCache()` calls.

Second, `annotatePkgDesc()` writes its update to a temporary file before renaming to the target `DESCRIPTION`. This avoids a (now more rare) situation where a second process might see an incompletely written `DESCRIPTION` file.

As a side-effect, only the originally installing actor will annotate the `DESCRIPTION`. Previously, an update occurred even when the package was used from the cache, which overwrote an existing annotation.

Update: After thinking about this problem a bit more, realized that the root cause to #720 is because `annotatePkgDesc()` was previously writing into the package cache. After calling `restoreWithCopyFromCache()`, the library contains a symlink into the cache. Calling `annotatePkgDesc()` reads through the symlink and modifies the in-cache `DESCRIPTION`. This is why we saw multiple actors reading/writing the same file.

Fixes #720