### PR TITLE
rename downloaded files when they do not mirror convention

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
   Paths used by CRAN-like, Nexus, and older Artifactory repositories are
   supported. (#583)
 - Attempt URL downloads fewer times before giving up.
+- Rename files downloaded from a package repository when the name is not
+  `name_1.2.3.tar.gz`, as can happen with r-universe. (#731)
 
 # Packrat 0.9.2
 

--- a/R/restore.R
+++ b/R/restore.R
@@ -186,11 +186,16 @@ getSourceForPkgRecord <- function(pkgRecord,
              "(", pkgRecord$version, ")")
         }
 
-      # If the file wasn't saved to the destination directory (which can happen
-      # if the repo is local--see documentation in download.packages), copy it
-      # there now
-      if (!identical(fileLoc[1, 2], file.path(pkgSrcDir, pkgSrcFile))) {
-        file.copy(fileLoc[1, 2], pkgSrcDir)
+      downloadedFile <- fileLoc[1, 2]
+      if (identical(dirname(downloadedFile), pkgSrcDir)) {
+        # The target file is in the destination directory.
+        if (!identical(basename(downloadedFile), pkgSrcFile)) {
+          # When the file has a different name, rename it. This can happen if the repository download redirects to a URL with a different path.
+          file.rename(downloadedFile, file.path(pkgSrcDir, pkgSrcFile))
+        }
+      } else {
+        # When target file is in some different directory, copy it. This can happen if the repo is local (see download.packages documentation).
+        file.copy(downloadedFile, file.path(pkgSrcDir, pkgSrcFile))
       }
       type <- paste(type, "current")
     } else {


### PR DESCRIPTION
fixes #731