### PR TITLE
Handle empty repository field in lockfile

### DIFF
--- a/R/packrat.R
+++ b/R/packrat.R
@@ -430,8 +430,11 @@ restore <- function(
 
   # Configure repos globally to avoid explicitly passing the repos list to all
   # downstream function calls.
-  repos <- lockInfo(project, 'repos')
-  externalRepos <- getOption('repos')
+  repos <- lockInfo(project, "repos")
+  if (is.null(repos)) {
+    stop("Packrat lockfile is missing repository URLs")
+  }
+  externalRepos <- getOption("repos")
   options(repos = repos)
   on.exit(
     {

--- a/tests/testthat/lockfiles/lockfile-norepos.txt
+++ b/tests/testthat/lockfiles/lockfile-norepos.txt
@@ -1,0 +1,10 @@
+PackratFormat: 1.3
+PackratVersion: 0.2.0.108
+RVersion: 3.2.0
+Repos:
+
+
+Package: packrat
+Source: source
+Version: 0.2.0.108
+SourcePath: /Users/kevin/git/packrat

--- a/tests/testthat/test-lockfile.R
+++ b/tests/testthat/test-lockfile.R
@@ -36,3 +36,8 @@ test_that("Repository is properly split by readLockFile", {
     )
   )
 })
+
+test_that("readLockFile can handle empty repos", {
+  lf <- readLockFile("lockfiles/lockfile-norepos.txt")
+  expect_null(lf$repos)
+})

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -93,6 +93,10 @@ withTestContext({
     skip_on_cran()
     projRoot <- cloneTestProject("carbs")
     lib <- libDir(projRoot)
+
+    # ensure that "Repos: ..." stays all on one line
+    local_mocked_bindings(write_dcf = function(...) write.dcf(width = Inf, ...))
+
     init(enter = FALSE, projRoot)
 
     # remove repos

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -89,6 +89,24 @@ withTestContext({
     expect_true(file.exists(file.path(lib, "bread")))
   })
 
+  test_that("restore errors if repos are missing", {
+    skip_on_cran()
+    projRoot <- cloneTestProject("carbs")
+    lib <- libDir(projRoot)
+    init(enter = FALSE, projRoot)
+
+    # remove repos
+    lockFile <- file.path(projRoot, "packrat", "packrat.lock")
+    lockContent <- readLines(lockFile)
+    lockContent <- gsub("^Repos: .*$", "Repos: ", lockContent)
+    writeLines(lockContent, lockFile)
+
+    expect_error(
+      restore(projRoot, prompt = FALSE, restart = FALSE),
+      "Packrat lockfile is missing repository URLs"
+    )
+  })
+
   test_that("snapshot captures new dependencies", {
     skip_on_cran()
     skip_on_travis()


### PR DESCRIPTION
Updates `readLockFile` so that it will succeed if repos are missing. The `repos` field gets set to `NULL`, and `restore()` will error when trying to restore packages with no repository set. Closes #741 

I air formatted the files I touched so the diff looks a little big, but the actual changes are in b38a363 and 6e30f12. 00b7411ce66914fee82906df238025611328fd7b is just formatting.