### PR TITLE
Prioritize `RemoteSubdir` over `GithubSubdir` for GitHub remotes

### DIFF
--- a/R/restore.R
+++ b/R/restore.R
@@ -1152,12 +1152,15 @@ appendRemoteInfoToDescription <- function(src, dest, remote_info) {
     basedir <- scratchDir
   }
 
-  # Determine the true package root
-  if (remote_info$RemoteType == "github") {
-    remote_subdir <- remote_info$GithubSubdir
-  } else {
+  # Determine the true package root. RemoteSubDir is the more modern way of
+  # recording this info, but in some cases GithubSubDir may be used instead (or
+  # in addition). If package isn't in a subdirectory, then both should be NULL.
+  if (!is.null(remote_info$RemoteSubdir)) {
     remote_subdir <- remote_info$RemoteSubdir
+  } else {
+    remote_subdir <- remote_info$GithubSubdir
   }
+
   if (length(remote_subdir) > 0) {
     basedir <- file.path(basedir, remote_subdir)
   }

--- a/tests/testthat/test-restore.R
+++ b/tests/testthat/test-restore.R
@@ -103,3 +103,50 @@ test_that("annotatePkgDesc annotates a package description", {
   expect_equal(result$InstallAgent, paste('packrat', packageVersion('packrat')))
   expect_equal(result$InstallSource, "CRAN")
 })
+
+test_that("appendRemoteInfoToDescription uses RemoteSubdir", {
+  parent_dir <- withr::local_tempdir()
+  dest_dir <- withr::local_tempdir()
+  # create package dir with subdirectory
+  src_dir <- file.path(parent_dir, "bread", "toast")
+  dir.create(src_dir, recursive = TRUE)
+
+  writeLines(
+    readLines(test_path("packages/toast/DESCRIPTION")),
+    file.path(src_dir, "DESCRIPTION")
+  )
+
+  parent_tarball <- paste0(parent_dir, ".tar.gz")
+  dest_tarball <- paste0(dest_dir, ".tar.gz")
+
+  in_dir(
+    parent_dir,
+    tar(
+      tarfile = parent_tarball,
+      files = "bread",
+      compression = "gzip",
+      tar = tar_binary()
+    )
+  )
+
+  remote_info <- data.frame(
+    RemoteType = "github",
+    RemoteHost = "github.com",
+    RemoteRepo = "bread",
+    RemoteUsername = "breakfaster",
+    RemoteRef = "HEAD",
+    RemoteSha = "abc123",
+    RemoteSubdir = "toast",
+    stringsAsFactors = FALSE
+  )
+
+  appendRemoteInfoToDescription(
+    src = parent_tarball,
+    dest = dest_tarball,
+    remote_info = remote_info
+  )
+
+  untar(dest_tarball, exdir = dest_dir, tar = tar_binary())
+  desc <- readLines(file.path(dest_dir, "toast", "DESCRIPTION"))
+  expect_true("RemoteSubdir: toast" %in% desc)
+})


### PR DESCRIPTION
Currently we only look in the `GithubSubdir` field for subdirectory information for GitHub remotes. `RemoteSubdir` is the more modern place to record the subdirectory. This PR looks in `RemoteSubdir` first, and falls back to `GithubSubdir` if that's `NULL`.

Fixes #740