### PR TITLE
fix and add integration tests for installing from bitbucket/gitlab/github 

### DIFF
--- a/tests/testthat/projects/falsy-bitbucket/deps.R
+++ b/tests/testthat/projects/falsy-bitbucket/deps.R
@@ -1,1 +1,0 @@
-library(falsy)

--- a/tests/testthat/projects/falsy-github/deps.R
+++ b/tests/testthat/projects/falsy-github/deps.R
@@ -1,0 +1,1 @@
+library(falsy)

--- a/tests/testthat/projects/falsy-github/packrat/packrat.lock
+++ b/tests/testthat/projects/falsy-github/packrat/packrat.lock
@@ -1,0 +1,18 @@
+PackratFormat: 1.4
+PackratVersion: 0.5.0.11
+RVersion: 3.5.1
+Repos: CRAN=https://cran.rstudio.com/
+
+Package: falsy
+Source: github
+Version: 1.0.1
+Hash: cd9f70fd26fa58a4b3070370b16b8660
+GithubRepo: falsy
+GithubUsername: cran
+GithubRef: master
+GithubSha1: 26a36cf957a18569e311ef75b6f61f822de945ef
+RemoteHost: api.github.com
+RemoteRepo: falsy
+RemoteUsername: cran
+RemoteRef: master
+RemoteSha: 26a36cf957a18569e311ef75b6f61f822de945ef

--- a/tests/testthat/projects/skeleton-bitbucket/deps.R
+++ b/tests/testthat/projects/skeleton-bitbucket/deps.R
@@ -1,0 +1,1 @@
+library(skeleton)

--- a/tests/testthat/projects/skeleton-bitbucket/packrat/packrat.lock
+++ b/tests/testthat/projects/skeleton-bitbucket/packrat/packrat.lock
@@ -3,12 +3,12 @@ PackratVersion: 0.5.0.11
 RVersion: 3.5.1
 Repos: CRAN=https://cran.rstudio.com/
 
-Package: falsy
+Package: skeleton
 Source: bitbucket
 Version: 1.0.1
 Hash: 97013d7da058d0be0595621449505494
-RemoteRepo: falsy
-RemoteUsername: rstudio_official
+RemoteRepo: skeleton
+RemoteUsername: kevinushey
 RemoteRef: master
-RemoteSha: 26a36cf957a18569e311ef75b6f61f822de945ef
+RemoteSha: 958296dbbbf7f1d82f7f5dd1b121c7558604809f
 RemoteHost: api.bitbucket.org/2.0

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -366,6 +366,7 @@ withTestContext({
     # verify the package was installed and can be loaded
     expect_true(file.exists(file.path(lib, "falsy")))
     expect_true(requireNamespace("falsy", lib.loc = lib))
+    on.exit(unloadNamespace("falsy"), add = TRUE)
 
     # validate the installed package has properly annotated DESCRIPTION
     descpath <- file.path(lib, "falsy/DESCRIPTION")
@@ -391,6 +392,7 @@ withTestContext({
     # verify the package was installed and can be loaded
     expect_true(file.exists(file.path(lib, "skeleton")))
     expect_true(requireNamespace("skeleton", lib.loc = lib))
+    on.exit(unloadNamespace("skeleton"), add = TRUE)
 
     # validate the installed package has properly annotated DESCRIPTION
     descpath <- file.path(lib, "skeleton/DESCRIPTION")
@@ -418,6 +420,7 @@ withTestContext({
     # verify the package was installed and can be loaded
     expect_true(file.exists(file.path(lib, "falsy")))
     expect_true(requireNamespace("falsy", lib.loc = lib))
+    on.exit(unloadNamespace("falsy"), add = TRUE)
 
     # validate the installed package has properly annotated DESCRIPTION
     descpath <- file.path(lib, "falsy/DESCRIPTION")

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -354,14 +354,21 @@ withTestContext({
 
   test_that("Packages restored from GitLab have RemoteType+RemoteHost in their DESCRIPTION", {
     skip_on_cran()
+    skip_if_offline()
     skip_on_os("windows") # Windows tar.exe fails to extract the archive received here.
     projRoot <- cloneTestProject("falsy-gitlab")
 
     # ignore R version warnings
     suppressWarnings(restore(projRoot))
 
+    lib <- libDir(projRoot)
+
+    # verify the package was installed and can be loaded
+    expect_true(file.exists(file.path(lib, "falsy")))
+    expect_true(requireNamespace("falsy", lib.loc = lib))
+
     # validate the installed package has properly annotated DESCRIPTION
-    descpath <- file.path(libDir(projRoot), "falsy/DESCRIPTION")
+    descpath <- file.path(lib, "falsy/DESCRIPTION")
     desc <- as.data.frame(readDcf(descpath))
     expect_true(desc$RemoteType == "gitlab")
     expect_true(desc$RemoteHost == "gitlab.com")
@@ -397,6 +404,32 @@ withTestContext({
 
     # confirm remote subdir is not in the record (unused by this lockfile)
     expect_false("remote_subdir" %in% names(record))
+  })
+
+  test_that("Packages restored from GitHub have GithubRepo+GithubSHA1 in their DESCRIPTION", {
+    skip_on_cran()
+    skip_if_offline()
+    projRoot <- cloneTestProject("falsy-github")
+
+    suppressWarnings(restore(projRoot))
+
+    lib <- libDir(projRoot)
+
+    # verify the package was installed and can be loaded
+    expect_true(file.exists(file.path(lib, "falsy")))
+    expect_true(requireNamespace("falsy", lib.loc = lib))
+
+    # validate the installed package has properly annotated DESCRIPTION
+    descpath <- file.path(lib, "falsy/DESCRIPTION")
+    desc <- as.data.frame(readDcf(descpath))
+    expect_equal(desc$RemoteType, "github")
+    expect_equal(desc$GithubRepo, "falsy")
+    expect_equal(desc$GithubUsername, "cran")
+    expect_equal(desc$GithubSHA1, "26a36cf957a18569e311ef75b6f61f822de945ef")
+
+    # confirm that packrat interprets this package as coming from github
+    record <- inferPackageRecord(desc)
+    expect_equal(record$source, "github")
   })
 
   test_that("packrat and remotes annotated descriptions are comparable", {

--- a/tests/testthat/test-packrat.R
+++ b/tests/testthat/test-packrat.R
@@ -373,13 +373,20 @@ withTestContext({
 
   test_that("Packages restored from BitBucket have RemoteType+RemoteHost in their DESCRIPTION", {
     skip_on_cran()
-    projRoot <- cloneTestProject("falsy-bitbucket")
+    skip_if_offline()
+    projRoot <- cloneTestProject("skeleton-bitbucket")
 
     # ignore R version warnings
     suppressWarnings(restore(projRoot))
 
+    lib <- libDir(projRoot)
+
+    # verify the package was installed and can be loaded
+    expect_true(file.exists(file.path(lib, "skeleton")))
+    expect_true(requireNamespace("skeleton", lib.loc = lib))
+
     # validate the installed package has properly annotated DESCRIPTION
-    descpath <- file.path(libDir(projRoot), "falsy/DESCRIPTION")
+    descpath <- file.path(lib, "skeleton/DESCRIPTION")
     desc <- as.data.frame(readDcf(descpath))
     expect_true(desc$RemoteType == "bitbucket")
     expect_true(desc$RemoteHost == "api.bitbucket.org/2.0")


### PR DESCRIPTION
Closes #754

Fixes the existing bitbucket test which attempted to install falsy from a bitbucket repo that no longer exists. Replaces with the skeleton package that renv also [tests against](https://github.com/rstudio/renv/blob/b7a73826b20f5bbded7f785f0b47b112e4b7b6d6/tests/testthat/test-retrieve.R#L50-L65). 

Adds a test for installing from github, and for all tests adds some additional logic to ensure that the package is actually installed and loadable.