### PR TITLE
builds(lintr): narrow lintr rules

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,14 +1,12 @@
 linters: linters_with_defaults(
-    # some tests have _VERY_ long expectations.
     indentation_linter = NULL,
+    # some tests have _VERY_ long expectations.
     line_length_linter(270),
     object_length_linter(80),
     object_name_linter = NULL,
     object_usage_linter = NULL,
-    brace_linter = NULL,
     commented_code_linter = NULL,
     quotes_linter = NULL,
-    seq_linter = NULL,
     return_linter = NULL
   )
 exclusions: list(

--- a/R/status.R
+++ b/R/status.R
@@ -139,7 +139,7 @@ status <- function(project = NULL, lib.loc = libDir(project), quiet = FALSE) {
   external.packages <- opts$external.packages()
   statusTbl <- data.frame(
     stringsAsFactors = FALSE,
-    row.names = 1:length(allPkgNames),
+    row.names = seq_along(allPkgNames),
     package = allPkgNames,
     packrat.version = packrat.version,
     packrat.source = packrat.source,

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -131,7 +131,7 @@ test_that("Git and user-specified variables can be masked while other variables 
   on.exit(options(user_mask_option), add = TRUE, after = FALSE)
 
   # We're expecting everything but the last item to be masked.
-  masked_names <- names(new_envvars)[1:length(new_envvars) - 1]
+  masked_names <- names(new_envvars)[seq_len(length(new_envvars) - 1)]
   unmasked_name <- names(new_envvars)[length(new_envvars)]
 
   subprocess_output <- R('-e "Sys.getenv()"', return_output = TRUE)


### PR DESCRIPTION
remove some of our lintr overrides.

similar to https://github.com/rstudio/rsconnect/pull/1351; likely in reach because `air` made the code have a much more regular shape.